### PR TITLE
feat: add scene import, room assignment, and scene delete commands

### DIFF
--- a/Sources/HomeClawHelper/HelperSocketServer.swift
+++ b/Sources/HomeClawHelper/HelperSocketServer.swift
@@ -118,14 +118,18 @@ final class HelperSocketServer: @unchecked Sendable {
         setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &bufSize, socklen_t(MemoryLayout<Int32>.size))
 
         // Read request (up to 64KB)
-        var buffer = [UInt8](repeating: 0, count: 65536)
-        let bytesRead = recv(fd, &buffer, buffer.count, 0)
-        guard bytesRead > 0 else {
-            close(fd)
-            return
-        }
-
-        let requestData = Data(buffer[..<bytesRead])
+        var requestData = Data()
+                var buffer = [UInt8](repeating: 0, count: 65536)
+                while true {
+                    let bytesRead = recv(fd, &buffer, buffer.count, 0)
+                    if bytesRead <= 0 { break }
+                    requestData.append(contentsOf: buffer[..<bytesRead])
+                    if requestData.last == UInt8(ascii: "\n") { break }
+                }
+                guard !requestData.isEmpty else {
+                    close(fd)
+                    return
+                }
 
         // Find newline-delimited request
         let lineData: Data
@@ -295,6 +299,49 @@ final class HelperSocketServer: @unchecked Sendable {
                     }
                 }
                 result = HelperConfig.shared.toDict()
+
+            case "delete_scene":
+                guard let name = args["name"] as? String else {
+                    return encodeResponse(success: false, error: "Missing 'name' argument")
+                }
+                result = try await hk.deleteScene(
+                    name: name,
+                    homeName: args["home"] as? String
+                )
+
+            case "assign_rooms":
+                guard let homeName = args["home"] as? String,
+                      let assignments = args["assignments"] as? [[String: Any]]
+                else {
+                    return encodeResponse(
+                        success: false,
+                        error: "Missing required args: home, assignments"
+                    )
+                }
+                let dryRun = (args["dry_run"] as? Bool) ?? false
+                result = try await hk.assignRooms(
+                    homeName: homeName,
+                    assignments: assignments,
+                    dryRun: dryRun
+                )
+
+            case "import_scene":
+                guard let name = args["name"] as? String,
+                      let homeName = args["home"] as? String,
+                      let actions = args["actions"] as? [[String: Any]]
+                else {
+                    return encodeResponse(
+                        success: false,
+                        error: "Missing required args: name, home, actions"
+                    )
+                }
+                let dryRun = (args["dry_run"] as? Bool) ?? false
+                result = try await hk.importScene(
+                    name: name,
+                    homeName: homeName,
+                    actions: actions,
+                    dryRun: dryRun
+                )
 
             default:
                 return encodeResponse(success: false, error: "Unknown command: \(command)")

--- a/Sources/HomeClawHelper/HomeKitManager.swift
+++ b/Sources/HomeClawHelper/HomeKitManager.swift
@@ -223,6 +223,374 @@ final class HomeKitManager: NSObject, Observable {
         throw ControlError.accessoryNotFound("Scene not found: \(id)")
     }
 
+    // MARK: - Room Assignment
+
+    /// Assign accessories to rooms based on exported mappings.
+    /// Matches accessories by name (case-insensitive) since UUIDs change after re-pairing.
+    func assignRooms(
+        homeName: String,
+        assignments: [[String: Any]],
+        dryRun: Bool = false
+    ) async throws -> [String: Any] {
+        await waitForReady()
+
+        guard let home = homes.first(where: {
+            $0.name.localizedCaseInsensitiveCompare(homeName) == .orderedSame
+        }) else {
+            throw ControlError.accessoryNotFound("Home not found: \(homeName)")
+        }
+
+        // Build room lookup (create rooms that don't exist)
+        var roomLookup: [String: HMRoom] = [:]
+        for room in home.rooms {
+            roomLookup[room.name.lowercased()] = room
+        }
+
+        var assigned = 0
+        var alreadyCorrect = 0
+        var skipped = 0
+        var notFound = 0
+        var warnings: [[String: String]] = []
+        var errors: [[String: String]] = []
+        var roomsCreated: [String] = []
+        var planned: [[String: String]] = []
+
+        for assignment in assignments {
+            guard let accName = assignment["accessory_name"] as? String,
+                  let targetRoom = assignment["room"] as? String
+            else {
+                warnings.append(["type": "invalid", "detail": "Missing name or room in assignment"])
+                skipped += 1
+                continue
+            }
+
+            // Find the accessory by name
+            guard let accessory = home.accessories.first(where: {
+                $0.name.localizedCaseInsensitiveCompare(accName) == .orderedSame
+            }) else {
+                warnings.append([
+                    "type": "accessory_not_found",
+                    "accessory": accName,
+                    "room": targetRoom,
+                    "detail": "Accessory '\(accName)' not found in '\(homeName)'",
+                ])
+                notFound += 1
+                continue
+            }
+
+            // Check if already in the correct room
+            if let currentRoom = accessory.room,
+               currentRoom.name.localizedCaseInsensitiveCompare(targetRoom) == .orderedSame {
+                alreadyCorrect += 1
+                continue
+            }
+
+            if dryRun {
+                let currentRoomName = accessory.room?.name ?? "Default Room"
+                planned.append([
+                    "accessory": accName,
+                    "from": currentRoomName,
+                    "to": targetRoom,
+                ])
+                assigned += 1
+                continue
+            }
+
+            // Find or create the target room
+            var room = roomLookup[targetRoom.lowercased()]
+            if room == nil {
+                do {
+                    room = try await withCheckedThrowingContinuation { cont in
+                        home.addRoom(withName: targetRoom) { room, error in
+                            if let error { cont.resume(throwing: error) }
+                            else if let room { cont.resume(returning: room) }
+                            else { cont.resume(throwing: ControlError.accessoryNotFound("Failed to create room '\(targetRoom)'")) }
+                        }
+                    }
+                    roomLookup[targetRoom.lowercased()] = room
+                    roomsCreated.append(targetRoom)
+                    HelperLogger.homekit.info("Created room: \(targetRoom) in \(home.name)")
+                } catch {
+                    errors.append([
+                        "accessory": accName,
+                        "room": targetRoom,
+                        "error": "Failed to create room: \(error.localizedDescription)",
+                    ])
+                    skipped += 1
+                    continue
+                }
+            }
+
+            // Assign the accessory to the room
+            guard let targetRoomObj = room else {
+                skipped += 1
+                continue
+            }
+
+            do {
+                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                    home.assignAccessory(accessory, to: targetRoomObj) { error in
+                        if let error { cont.resume(throwing: error) }
+                        else { cont.resume() }
+                    }
+                }
+                assigned += 1
+                HelperLogger.homekit.info("Assigned '\(accName)' to '\(targetRoom)' in \(home.name)")
+            } catch {
+                errors.append([
+                    "accessory": accName,
+                    "room": targetRoom,
+                    "error": error.localizedDescription,
+                ])
+                skipped += 1
+            }
+        }
+
+        var result: [String: Any] = [
+            "dry_run": dryRun,
+            "home": homeName,
+            "assigned": assigned,
+            "already_correct": alreadyCorrect,
+            "skipped": skipped,
+            "not_found": notFound,
+            "rooms_created": roomsCreated,
+            "warnings": warnings,
+            "errors": errors,
+        ]
+        if dryRun {
+            result["planned"] = planned
+        }
+        return result
+    }
+
+    // MARK: - Scene Import
+
+    /// Find an accessory by name and room (case-insensitive).
+    private func findAccessory(name: String, room: String, in home: HMHome) -> HMAccessory? {
+        return home.accessories.first { accessory in
+            let nameMatch = accessory.name.localizedCaseInsensitiveCompare(name) == .orderedSame
+            let roomMatch = accessory.room?.name.localizedCaseInsensitiveCompare(room) == .orderedSame
+            return nameMatch && roomMatch
+        }
+    }
+
+    /// Find a characteristic on an accessory by its manufacturer description.
+    private func findCharacteristic(on accessory: HMAccessory, property: String) -> HMCharacteristic? {
+        for service in accessory.services {
+            for characteristic in service.characteristics {
+                if let desc = characteristic.metadata?.manufacturerDescription,
+                   desc.localizedCaseInsensitiveCompare(property) == .orderedSame {
+                    return characteristic
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Parse a human-readable value string back to a HomeKit-compatible NSNumber.
+    private func parseActionValue(_ valueStr: String, property: String) -> (NSCopying & NSObjectProtocol)? {
+        let prop = property.lowercased()
+
+        if prop.contains("power") {
+            if valueStr == "ON" { return NSNumber(value: true) }
+            if valueStr == "OFF" { return NSNumber(value: false) }
+        }
+
+        if prop.contains("lock") {
+            if valueStr.contains("Secured") || valueStr.contains("Locked") { return NSNumber(value: 1) }
+            if valueStr.contains("Unsecured") || valueStr.contains("Unlocked") { return NSNumber(value: 0) }
+        }
+
+        if valueStr.hasSuffix("%") {
+            let numStr = String(valueStr.dropLast())
+            if let intVal = Int(numStr) { return NSNumber(value: intVal) }
+            if let dblVal = Double(numStr) { return NSNumber(value: dblVal) }
+        }
+
+        if valueStr.hasSuffix("°") {
+            let numStr = String(valueStr.dropLast())
+            if let dblVal = Double(numStr) { return NSNumber(value: dblVal) }
+        }
+
+        if valueStr.contains("mireds") {
+                    let parts = valueStr.split(separator: " ")
+                    if let first = parts.first {
+                        if let intVal = Int(first) { return NSNumber(value: intVal) }
+                        if let dblVal = Double(first) { return NSNumber(value: Int(dblVal)) }
+                    }
+                }
+
+        if let intVal = Int(valueStr) { return NSNumber(value: intVal) }
+        if let dblVal = Double(valueStr) { return NSNumber(value: dblVal) }
+
+        HelperLogger.homekit.warning("Could not parse value '\(valueStr)' for property '\(property)'")
+        return nil
+    }
+
+    /// Delete a scene by name.
+    func deleteScene(name: String, homeName: String? = nil) async throws -> [String: Any] {
+        await waitForReady()
+        let targetHomes = filteredHomes(homeID: nil)
+
+        for home in targetHomes {
+            if let homeName, home.name.localizedCaseInsensitiveCompare(homeName) != .orderedSame {
+                continue
+            }
+            if let actionSet = home.actionSets.first(where: {
+                $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame
+            }) {
+                let summary = AccessoryModel.sceneSummary(actionSet)
+                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                                    home.removeActionSet(actionSet) { error in
+                                        if let error { cont.resume(throwing: error) }
+                                        else { cont.resume() }
+                                    }
+                                }
+                HelperLogger.homekit.info("Deleted scene: \(name) from \(home.name)")
+                return [
+                    "deleted": true,
+                    "scene": summary,
+                    "home": home.name,
+                ] as [String: Any]
+            }
+        }
+
+        throw ControlError.accessoryNotFound("Scene not found: \(name)")
+    }
+
+    /// Import a scene from exported action data. Matches accessories by name + room.
+    func importScene(
+        name: String,
+        homeName: String,
+        actions: [[String: Any]],
+        dryRun: Bool = false
+    ) async throws -> [String: Any] {
+        await waitForReady()
+
+        guard let home = homes.first(where: {
+            $0.name.localizedCaseInsensitiveCompare(homeName) == .orderedSame
+        }) else {
+            throw ControlError.accessoryNotFound("Home not found: \(homeName)")
+        }
+
+        var resolvedActions: [(HMCharacteristic, NSCopying & NSObjectProtocol, [String: Any])] = []
+        var warnings: [[String: String]] = []
+
+        for actionData in actions {
+            guard let accName = actionData["accessory_name"] as? String,
+                  let room = actionData["room"] as? String,
+                  let property = actionData["property"] as? String,
+                  let valueStr = actionData["value"] as? String
+            else {
+                warnings.append(["type": "invalid_action", "detail": "Missing fields in action: \(actionData)"])
+                continue
+            }
+
+            guard let accessory = findAccessory(name: accName, room: room, in: home) else {
+                warnings.append([
+                    "type": "accessory_not_found",
+                    "accessory": accName,
+                    "room": room,
+                    "detail": "Could not find '\(accName)' in room '\(room)'",
+                ])
+                continue
+            }
+
+            guard let characteristic = findCharacteristic(on: accessory, property: property) else {
+                warnings.append([
+                    "type": "characteristic_not_found",
+                    "accessory": accName,
+                    "property": property,
+                    "detail": "No '\(property)' characteristic on '\(accName)'",
+                ])
+                continue
+            }
+
+            guard let targetValue = parseActionValue(valueStr, property: property) else {
+                warnings.append([
+                    "type": "value_parse_error",
+                    "accessory": accName,
+                    "property": property,
+                    "value": valueStr,
+                    "detail": "Could not parse '\(valueStr)' for '\(property)'",
+                ])
+                continue
+            }
+
+            resolvedActions.append((characteristic, targetValue, actionData))
+        }
+
+        if dryRun {
+            let planned = resolvedActions.map { (_, _, data) in data }
+            return [
+                "dry_run": true,
+                "scene_name": name,
+                "home": homeName,
+                "actions_planned": planned.count,
+                "actions_skipped": warnings.count,
+                "planned": planned,
+                "warnings": warnings,
+            ] as [String: Any]
+        }
+
+        if home.actionSets.contains(where: {
+            $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame
+        }) {
+            throw ControlError.accessoryNotFound(
+                "Scene '\(name)' already exists in '\(homeName)'. Delete it first with delete-scene."
+            )
+        }
+
+        let actionSet: HMActionSet = try await withCheckedThrowingContinuation { cont in
+                    home.addActionSet(withName: name) { actionSet, error in
+                        if let error { cont.resume(throwing: error) }
+                        else if let actionSet { cont.resume(returning: actionSet) }
+                        else { cont.resume(throwing: ControlError.accessoryNotFound("Failed to create action set")) }
+                    }
+                }
+        HelperLogger.homekit.info("Created scene: \(name) in \(home.name)")
+
+        var added = 0
+        var actionErrors: [[String: String]] = []
+
+        for (characteristic, targetValue, actionData) in resolvedActions {
+            do {
+                let action = HMCharacteristicWriteAction(
+                    characteristic: characteristic,
+                    targetValue: targetValue
+                )
+                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                                    actionSet.addAction(action) { error in
+                                        if let error { cont.resume(throwing: error) }
+                                        else { cont.resume() }
+                                    }
+                                }
+                added += 1
+            } catch {
+                let accName = actionData["accessory_name"] as? String ?? "?"
+                let prop = actionData["property"] as? String ?? "?"
+                actionErrors.append([
+                    "accessory": accName,
+                    "property": prop,
+                    "error": error.localizedDescription,
+                ])
+                HelperLogger.homekit.error("Failed to add action \(accName)/\(prop): \(error.localizedDescription)")
+            }
+        }
+
+        return [
+            "dry_run": false,
+            "scene_name": name,
+            "home": homeName,
+            "actions_added": added,
+            "actions_skipped": warnings.count,
+            "action_errors": actionErrors.count,
+            "warnings": warnings,
+            "errors": actionErrors,
+            "scene": AccessoryModel.sceneSummary(actionSet),
+        ] as [String: Any]
+    }
+
     // MARK: - Search
 
     func searchAccessories(query: String, category: String? = nil, homeID: String? = nil) async -> [[String: Any]] {

--- a/Sources/homeclaw-cli/Commands/AssignRoomsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AssignRoomsCommand.swift
@@ -1,0 +1,95 @@
+import ArgumentParser
+import Foundation
+
+struct AssignRoomsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "assign-rooms",
+        abstract: "Assign accessories to rooms from an accessory_rooms.json export"
+    )
+
+    @Option(name: .long, help: "Path to accessory_rooms.json")
+    var file: String
+
+    @Option(name: .long, help: "Home name (required if multiple homes)")
+    var home: String?
+
+    @Flag(name: .long, help: "Preview what would happen without making changes")
+    var dryRun = false
+
+    @Flag(name: .long, help: "Output raw JSON response")
+    var json = false
+
+    func run() throws {
+        let url = URL(fileURLWithPath: (file as NSString).expandingTildeInPath)
+        let data = try Data(contentsOf: url)
+        guard let export = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let homes = export["homes"] as? [String: Any]
+        else {
+            throw ValidationError("Invalid accessory_rooms.json format")
+        }
+
+        for (homeName, accessoriesAny) in homes {
+            if let homeFilter = home,
+               homeName.caseInsensitiveCompare(homeFilter) != .orderedSame {
+                continue
+            }
+            guard let accessories = accessoriesAny as? [[String: Any]] else { continue }
+
+            let assignments: [[String: Any]] = accessories.compactMap { acc in
+                guard let name = acc["name"] as? String,
+                      let room = acc["room"] as? String
+                else { return nil }
+                return [
+                    "accessory_name": name,
+                    "room": room,
+                    "manufacturer": acc["manufacturer"] as Any,
+                    "model": acc["model"] as Any,
+                ]
+            }
+
+            if assignments.isEmpty {
+                print("⚠  \(homeName): no assignments to make")
+                continue
+            }
+
+            let prefix = dryRun ? "[DRY RUN] " : ""
+            print("\(prefix)Assigning \(assignments.count) accessories to rooms in '\(homeName)'...")
+
+            let args: [String: Any] = [
+                "home": homeName,
+                "assignments": assignments,
+                "dry_run": dryRun,
+            ]
+
+            let response = try SocketClient.sendAny(command: "assign_rooms", args: args)
+
+            if json {
+                printJSON(response.data?.value)
+            } else if response.success, let data = response.data?.value as? [String: Any] {
+                let assigned = data["assigned"] as? Int ?? 0
+                let skipped = data["skipped"] as? Int ?? 0
+                let already = data["already_correct"] as? Int ?? 0
+                let notFound = data["not_found"] as? Int ?? 0
+
+                if dryRun {
+                    print("  ✓ Would assign \(assigned), already correct \(already), not found \(notFound)")
+                } else {
+                    print("  ✓ Assigned \(assigned), already correct \(already), skipped \(skipped), not found \(notFound)")
+                }
+
+                if let warnings = data["warnings"] as? [[String: String]] {
+                    for w in warnings {
+                        print("  ⚠  \(w["detail"] ?? "unknown")")
+                    }
+                }
+                if let errors = data["errors"] as? [[String: String]] {
+                    for e in errors {
+                        print("  ✗  \(e["accessory"] ?? "?"): \(e["error"] ?? "unknown")")
+                    }
+                }
+            } else {
+                print("  ✗  \(response.error ?? "Unknown error")")
+            }
+        }
+    }
+}

--- a/Sources/homeclaw-cli/Commands/ImportSceneCommand.swift
+++ b/Sources/homeclaw-cli/Commands/ImportSceneCommand.swift
@@ -1,0 +1,161 @@
+import ArgumentParser
+import Foundation
+
+struct ImportSceneCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "import-scene",
+        abstract: "Import a scene from a scenes_export.json file"
+    )
+
+    @Option(name: .long, help: "Path to scenes_export.json")
+    var file: String
+
+    @Option(name: .long, help: "Scene name to import (imports all if omitted)")
+    var scene: String?
+
+    @Option(name: .long, help: "Home name (required if multiple homes)")
+    var home: String?
+
+    @Flag(name: .long, help: "Preview what would happen without making changes")
+    var dryRun = false
+
+    @Flag(name: .long, help: "Output raw JSON response")
+    var json = false
+
+    func run() throws {
+        let url = URL(fileURLWithPath: (file as NSString).expandingTildeInPath)
+        let data = try Data(contentsOf: url)
+        guard let export = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let homes = export["homes"] as? [String: Any]
+        else {
+            throw ValidationError("Invalid scenes_export.json format")
+        }
+
+        var scenesToImport: [(homeName: String, scene: [String: Any])] = []
+
+        for (homeName, scenesAny) in homes {
+            if let homeFilter = home,
+               homeName.caseInsensitiveCompare(homeFilter) != .orderedSame {
+                continue
+            }
+            guard let scenes = scenesAny as? [[String: Any]] else { continue }
+            for sceneData in scenes {
+                guard let sceneName = sceneData["name"] as? String else { continue }
+                if let sceneFilter = scene,
+                   sceneName.caseInsensitiveCompare(sceneFilter) != .orderedSame {
+                    continue
+                }
+                scenesToImport.append((homeName: homeName, scene: sceneData))
+            }
+        }
+
+        guard !scenesToImport.isEmpty else {
+            if let sceneName = scene {
+                print("Scene '\(sceneName)' not found in export file.")
+            } else {
+                print("No scenes found in export file.")
+            }
+            throw ExitCode.failure
+        }
+
+        for (homeName, sceneData) in scenesToImport {
+            guard let sceneName = sceneData["name"] as? String,
+                  let actions = sceneData["actions"] as? [[String: Any]]
+            else { continue }
+
+            let validActions = actions.filter { action in
+                guard let _ = action["accessory_name"] as? String,
+                      let _ = action["room"] as? String,
+                      let _ = action["property"] as? String,
+                      let val = action["value"] as? String
+                else { return false }
+                return val != "None"
+            }
+
+            if validActions.isEmpty {
+                print("⚠  \(sceneName): no valid actions to import, skipping")
+                continue
+            }
+
+            let prefix = dryRun ? "[DRY RUN] " : ""
+            print("\(prefix)Importing '\(sceneName)' into '\(homeName)' (\(validActions.count) actions)...")
+
+            let actionDicts: [[String: Any]] = validActions.map { action in
+                [
+                    "accessory_name": action["accessory_name"] as Any,
+                    "room": action["room"] as Any,
+                    "property": action["property"] as Any,
+                    "value": action["value"] as Any,
+                ]
+            }
+
+            let args: [String: Any] = [
+                "name": sceneName,
+                "home": homeName,
+                "actions": actionDicts,
+                "dry_run": dryRun,
+            ]
+
+            let response = try SocketClient.sendAny(command: "import_scene", args: args)
+
+            if json {
+                printJSON(response.data?.value)
+            } else if response.success, let data = response.data?.value as? [String: Any] {
+                let planned = data["actions_planned"] as? Int
+                    ?? data["actions_added"] as? Int ?? 0
+                let skipped = data["actions_skipped"] as? Int ?? 0
+                let errors = data["action_errors"] as? Int ?? 0
+
+                if dryRun {
+                    print("  ✓ Would create \(planned) action(s), skip \(skipped)")
+                } else {
+                    print("  ✓ Created \(planned) action(s), skipped \(skipped), errors \(errors)")
+                }
+
+                if let warnings = data["warnings"] as? [[String: String]] {
+                    for w in warnings {
+                        print("  ⚠  \(w["detail"] ?? "unknown")")
+                    }
+                }
+                if let errs = data["errors"] as? [[String: String]] {
+                    for e in errs {
+                        print("  ✗  \(e["accessory"] ?? "?"): \(e["error"] ?? "unknown")")
+                    }
+                }
+            } else {
+                print("  ✗  \(response.error ?? "Unknown error")")
+            }
+        }
+    }
+}
+
+struct DeleteSceneCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete-scene",
+        abstract: "Delete a scene by name"
+    )
+
+    @Argument(help: "Scene name to delete")
+    var name: String
+
+    @Option(name: .long, help: "Home name (if multiple homes)")
+    var home: String?
+
+    @Flag(name: .long, help: "Output raw JSON response")
+    var json = false
+
+    func run() throws {
+        var args: [String: String] = ["name": name]
+        if let home { args["home"] = home }
+
+        let response = try SocketClient.send(command: "delete_scene", args: args)
+
+        if json {
+            printJSON(response.data?.value)
+        } else if response.success {
+            print("✓ Deleted scene '\(name)'")
+        } else {
+            print("✗ \(response.error ?? "Unknown error")")
+        }
+    }
+}

--- a/Sources/homeclaw-cli/HomeKitCLI.swift
+++ b/Sources/homeclaw-cli/HomeKitCLI.swift
@@ -15,6 +15,9 @@ struct HomeKitCLI: ParsableCommand {
             Status.self,
             Config.self,
             DeviceMapCmd.self,
+            ImportSceneCommand.self,
+            DeleteSceneCommand.self,
+            AssignRoomsCommand.self,
         ],
         defaultSubcommand: Status.self
     )


### PR DESCRIPTION
## Summary

Adds three new CLI commands for HomeKit backup/restore workflows — particularly useful when re-pairing a Hue Bridge or replacing accessories, where all scene definitions and room assignments are lost.

These commands pair with [homekit_export.py](https://github.com/LittleOrangeC/homekit_export) which extracts scene definitions and room mappings from the local HomeKit SQLite databases.

## New Commands

### `import-scene`
Import scenes from a JSON export file. Matches accessories by **name + room** instead of UUID, so it works after re-pairing when internal identifiers change.

```bash
# Preview what would happen
homeclaw-cli import-scene --file scenes_export.json --home "My Home" --dry-run

# Import a single scene
homeclaw-cli import-scene --file scenes_export.json --scene "Reading" --home "My Home"

# Import all scenes for a home
homeclaw-cli import-scene --file scenes_export.json --home "My Home"
```

### `delete-scene`
Delete a scene by name. Required before re-importing, since HomeKit doesn't support modifying action sets in place.

```bash
homeclaw-cli delete-scene "Reading" --home "My Home"
```

### `assign-rooms`
Assign accessories to rooms from a JSON export file. Creates rooms that don't exist yet. Matches accessories by name (case-insensitive).

```bash
# Preview assignments
homeclaw-cli assign-rooms --file accessory_rooms.json --home "My Home" --dry-run

# Apply assignments
homeclaw-cli assign-rooms --file accessory_rooms.json --home "My Home"
```

## Typical Workflow

```bash
# BACKUP (before re-pairing)
python3 homekit_export.py --backup-all

# RESTORE (after re-pairing)
# 1. Assign accessories back to their rooms
homeclaw-cli assign-rooms --file accessory_rooms.json --home "My Home"

# 2. Delete stale scenes (they survive re-pair but with broken actions)
# 3. Re-import scenes from backup
homeclaw-cli import-scene --file scenes_export.json --home "My Home"
```

## Implementation Details

### HomeKitManager.swift
- `importScene()` — Creates `HMActionSet` with `HMCharacteristicWriteAction` entries, matching accessories by name + room
- `deleteScene()` — Removes an `HMActionSet` by name
- `assignRooms()` — Moves accessories to correct rooms using `HMHome.assignAccessory(_:to:)`, creating rooms as needed
- `parseActionValue()` — Converts human-readable value strings (ON/OFF, 85%, 45.5°, 400 mireds, Locked/Unlocked) back to `NSNumber` for HomeKit
- `findAccessory(name:room:in:)` — Case-insensitive accessory lookup by name + room
- `findCharacteristic(on:property:)` — Finds characteristics by manufacturer description

All HomeKit APIs use `withCheckedThrowingContinuation` wrappers around the completion-handler-based `HMHome` methods.

### HelperSocketServer.swift
- Added `import_scene`, `delete_scene`, and `assign_rooms` command handlers
- Fixed `recv()` to loop until newline delimiter — the previous single-read approach failed on payloads larger than one TCP segment (~12KB+ for 100+ accessory assignments)

### CLI
- `ImportSceneCommand` — Reads `scenes_export.json`, filters by home/scene name, sends to helper
- `DeleteSceneCommand` — Deletes a scene by name
- `AssignRoomsCommand` — Reads `accessory_rooms.json`, sends assignments to helper
- All commands support `--dry-run` and `--json` flags

## Testing

Tested on macOS Tahoe 26.3 with:
- 2 homes, 114 accessories (70+ Hue lights via Hue Bridge Pro v3)
- 60+ scenes with ~900 total actions
- Full delete → re-import cycle verified with correct action values
- Room assignment of 56 accessories after Hue Bridge re-pair
- Dry-run mode verified for all three commands

## JSON Export Format

The commands expect JSON files produced by [homekit_export.py](https://github.com/LittleOrangeC/homekit_export):

**scenes_export.json:**
```json
{
  "homes": {
    "My Home": [
      {
        "name": "Reading",
        "actions": [
          {
            "accessory_name": "Dining Puzzle",
            "room": "Dining Room",
            "property": "Brightness",
            "value": "85%"
          }
        ]
      }
    ]
  }
}
```

**accessory_rooms.json:**
```json
{
  "homes": {
    "My Home": [
      {
        "name": "Kitchen 1",
        "room": "Kitchen",
        "manufacturer": "Signify Netherlands B.V.",
        "model": "LCA009"
      }
    ]
  }
}
```
