### PR TITLE
Reuse existing Settings session instead of creating new ones

### DIFF
--- a/Sources/homeclaw/App/HomeClawApp.swift
+++ b/Sources/homeclaw/App/HomeClawApp.swift
@@ -82,10 +82,14 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
     }
 
     @objc func openSettings() {
+        // Reuse an existing Settings session instead of creating a new one each time
+        let existingSession = UIApplication.shared.openSessions.first {
+            $0.configuration.name == "Settings"
+        }
         Self.settingsRequested = true
         let activity = NSUserActivity(activityType: "com.shahine.homeclaw.settings")
         UIApplication.shared.requestSceneSessionActivation(
-            nil, userActivity: activity, options: nil)
+            existingSession, userActivity: activity, options: nil)
     }
 
     @objc func quitApp() {


### PR DESCRIPTION
## Summary
Modified the `openSettings()` method to reuse an existing Settings scene session instead of creating a new one each time the settings are opened.

## Key Changes
- Added logic to search for an existing Settings session by configuration name before requesting scene session activation
- Pass the existing session (if found) to `requestSceneSessionActivation()` instead of `nil`
- This prevents duplicate Settings windows from being created on repeated access

## Implementation Details
The change leverages `UIApplication.shared.openSessions` to find a session with configuration name "Settings". If an existing session is found, it's reused; otherwise, passing `nil` will allow the system to create a new session as needed. This improves the user experience by maintaining a single Settings window across multiple open requests.

https://claude.ai/code/session_014hP5ENneToa8uXSd7G2xDT