### PR TITLE
fix: defer HMHomeManager creation to prevent TCC crash on macOS 26.4

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>131</string>
+	<string>133</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/homeclaw/App/HomeClawApp.swift
+++ b/Sources/homeclaw/App/HomeClawApp.swift
@@ -150,7 +150,6 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
         // HomeKitManager.shared.start() is called from HeadlessSceneDelegate
         // after the first scene connects. Creating HMHomeManager before a
         // window exists causes a TCC privacy violation crash on macOS 26.4+.
-        _ = HomeKitManager.shared
 
         // Start socket server for CLI and MCP clients
         SocketServer.shared.start()

--- a/Sources/homeclaw/App/HomeClawApp.swift
+++ b/Sources/homeclaw/App/HomeClawApp.swift
@@ -147,11 +147,10 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
         }
         #endif
 
-        // Initialize HomeKit directly (no IPC needed)
-        Task { @MainActor in
-            _ = HomeKitManager.shared
-            AppLogger.homekit.info("HomeKit manager initialized, waiting for homes...")
-        }
+        // HomeKitManager.shared.start() is called from HeadlessSceneDelegate
+        // after the first scene connects. Creating HMHomeManager before a
+        // window exists causes a TCC privacy violation crash on macOS 26.4+.
+        _ = HomeKitManager.shared
 
         // Start socket server for CLI and MCP clients
         SocketServer.shared.start()
@@ -625,6 +624,11 @@ class HeadlessSceneDelegate: UIResponder, UIWindowSceneDelegate {
         #endif
 
         AppLogger.app.info("Default scene connected (headless)")
+
+        // Start HomeKit now that a scene exists to host the TCC consent dialog.
+        // Creating HMHomeManager before this point crashes on macOS 26.4+ with
+        // __TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__.
+        HomeKitManager.shared.start()
     }
 
     #if targetEnvironment(macCatalyst)

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -6,7 +6,7 @@ import HomeKit
 final class HomeKitManager: NSObject, Observable {
     static let shared = HomeKitManager()
 
-    private let homeManager = HMHomeManager()
+    private var homeManager: HMHomeManager?
     private var homesReady = false
     private var pendingContinuations: [CheckedContinuation<Void, Never>] = []
 
@@ -18,7 +18,18 @@ final class HomeKitManager: NSObject, Observable {
 
     override private init() {
         super.init()
-        homeManager.delegate = self
+    }
+
+    /// Create the HMHomeManager and begin HomeKit discovery.
+    /// Call this after the first scene is connected so macOS can host
+    /// the TCC consent dialog. On macOS 26.4+, creating HMHomeManager
+    /// before a window exists causes a TCC privacy violation crash.
+    func start() {
+        guard homeManager == nil else { return }
+        let manager = HMHomeManager()
+        manager.delegate = self
+        homeManager = manager
+        AppLogger.homekit.info("HMHomeManager created, waiting for homes...")
     }
 
     // MARK: - Readiness

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -37,6 +37,9 @@ final class HomeKitManager: NSObject, Observable {
     /// Waits until HomeKit has delivered the initial set of homes.
     func waitForReady() async {
         if homesReady { return }
+        if homeManager == nil {
+            AppLogger.homekit.warning("waitForReady() called before start() — HomeKit not yet initialised")
+        }
         await withCheckedContinuation { continuation in
             pendingContinuations.append(continuation)
         }


### PR DESCRIPTION
## Summary

- Defer `HMHomeManager` creation from `didFinishLaunchingWithOptions` to `HeadlessSceneDelegate.scene(_:willConnectTo:)` to prevent TCC privacy violation crash on macOS 26.4+
- Change `homeManager` from eager `let` to lazy `var` with explicit `start()` method
- macOS 26.4 changed TCC behavior: accessing HomeKit before a window exists now aborts the process instead of silently returning zero homes

## Context

TestFlight crash report from build 132 on Mac16,11 running macOS 26.4 (25E246):
```
Termination Reason: Namespace TCC, Code 0
__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__
```

The `NSHomeKitUsageDescription` key was present in Info.plist, but `HMHomeManager()` was created in `didFinishLaunchingWithOptions` before any scene/window existed to host the TCC consent dialog.

## Test plan

- [x] Release build compiles cleanly
- [x] Installed to /Applications and launched
- [x] HomeKit connects successfully (2 homes, 189 accessories)
- [x] CLI communicates over socket (`homeclaw-cli status` returns ready: true)
- [ ] Verify on clean macOS 26.4 install (no prior TCC grant) — requires TestFlight tester

🤖 Generated with [Claude Code](https://claude.com/claude-code)