### PR TITLE
feat: support characteristic-based automation triggers

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>133</string>
+	<string>135</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -139,13 +139,13 @@ struct GetAutomation: ParsableCommand {
 struct CreateAutomation: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "create",
-        abstract: "Create a button press automation"
+        abstract: "Create an automation triggered by a characteristic change (button press, motion, contact, occupancy, etc.)"
     )
 
     @Option(name: .long, help: "Name for the automation")
     var name: String
 
-    @Option(name: .long, help: "Button accessory name or UUID")
+    @Option(name: .long, help: "Trigger accessory name or UUID")
     var accessory: String
 
     @Option(name: .long, help: "Scene name or UUID to trigger (alternative to --action)")
@@ -154,10 +154,16 @@ struct CreateAutomation: ParsableCommand {
     @Option(name: .long, parsing: .upToNextOption, help: "Inline action as 'accessory:property:value' (repeatable, alternative to --scene). Accessory names with colons are not supported; use the MCP actions array instead.")
     var action: [String] = []
 
-    @Option(name: .long, help: "Press type: single, double, or long (default: single)")
+    @Option(name: .long, help: "Press type: single, double, or long (default: single). For button triggers only; mutually exclusive with --characteristic.")
     var press: String = "single"
 
-    @Option(name: .long, help: "Button index for multi-button accessories (e.g., 1 or 2)")
+    @Option(name: .long, help: "Characteristic to trigger on (e.g., motion_detected, contact_state, occupancy_detected). Mutually exclusive with --press.")
+    var characteristic: String?
+
+    @Option(name: .long, help: "Value that triggers the automation (e.g., true, false, 1, 0). Required when --characteristic is set.")
+    var triggerValue: String?
+
+    @Option(name: .long, help: "Button index for multi-button accessories (e.g., 1 or 2). For button triggers only.")
     var serviceIndex: Int?
 
     @Option(name: .long, help: "Home name or UUID (defaults to primary home)")
@@ -174,20 +180,33 @@ struct CreateAutomation: ParsableCommand {
             throw ValidationError("Either --scene or --action is required")
         }
 
-        let pressType: Int
-        switch press.lowercased() {
-        case "single", "0": pressType = 0
-        case "double", "1": pressType = 1
-        case "long", "2": pressType = 2
-        default: throw ValidationError("Invalid press type '\(press)'. Use: single, double, or long")
-        }
-
         var args: [String: Any] = [
             "name": name,
             "accessory_id": accessory,
-            "press_type": pressType,
             "dry_run": dryRun,
         ]
+
+        if let characteristic {
+            // Generic characteristic trigger mode
+            guard press == "single" else {
+                throw ValidationError("--press and --characteristic are mutually exclusive")
+            }
+            guard let triggerValue else {
+                throw ValidationError("--trigger-value is required when --characteristic is set")
+            }
+            args["characteristic"] = characteristic
+            args["trigger_value"] = triggerValue
+        } else {
+            // Button press trigger mode
+            let pressType: Int
+            switch press.lowercased() {
+            case "single", "0": pressType = 0
+            case "double", "1": pressType = 1
+            case "long", "2": pressType = 2
+            default: throw ValidationError("Invalid press type '\(press)'. Use: single, double, or long")
+            }
+            args["press_type"] = pressType
+        }
 
         if let scene {
             args["scene_id"] = scene
@@ -230,13 +249,23 @@ struct CreateAutomation: ParsableCommand {
         let isDryRun = result["dry_run"] as? Bool ?? false
         let autoName = result["name"] as? String ?? name
         let accessoryName = result["accessory"] as? String ?? "?"
-        let pressName = result["press_type"] as? String ?? "?"
+        let triggerType = result["trigger_type"] as? String ?? "button"
         let actionCount = result["action_count"] as? Int
         let isInline = result["inline_actions"] as? Bool ?? false
 
+        let triggerDescription: String
+        if triggerType == "button" {
+            let pressName = result["press_type"] as? String ?? "?"
+            triggerDescription = "\(accessoryName) \(pressName)"
+        } else {
+            let charName = result["characteristic"] as? String ?? "?"
+            let charValue = result["trigger_value"] as? String ?? "?"
+            triggerDescription = "\(accessoryName) \(charName) = \(charValue)"
+        }
+
         if isDryRun {
             print("DRY RUN — would create automation '\(autoName)'")
-            print("  Button: \(accessoryName) (\(pressName))")
+            print("  Trigger: \(triggerDescription)")
             if isInline, let actions = result["actions"] as? [[String: String]] {
                 print("  Actions:")
                 for a in actions {
@@ -251,11 +280,11 @@ struct CreateAutomation: ParsableCommand {
         } else {
             if isInline {
                 print("Created automation '\(autoName)' with \(actionCount ?? 0) inline action(s)")
-                print("  \(accessoryName) \(pressName) → \(actionCount ?? 0) action(s)")
+                print("  \(triggerDescription) → \(actionCount ?? 0) action(s)")
             } else {
                 let sceneName = result["scene"] as? String ?? "?"
                 print("Created automation '\(autoName)'")
-                print("  \(accessoryName) \(pressName) → \(sceneName)")
+                print("  \(triggerDescription) → \(sceneName)")
             }
         }
     }

--- a/Sources/homeclaw/HomeKit/AccessoryModel.swift
+++ b/Sources/homeclaw/HomeKit/AccessoryModel.swift
@@ -185,19 +185,37 @@ enum AccessoryModel {
         if let event = trigger.events.first as? HMCharacteristicEvent<NSCopying>,
            let accessory = event.characteristic.service?.accessory
         {
-            let pressValue = (event.triggerValue as? NSNumber)?.intValue
-            let pressName = pressValue.map { pressTypeName($0) } ?? "any_press"
-            dict["event_summary"] = "\(accessory.name) \(pressName)"
+            let charType = event.characteristic.characteristicType
+            let isButton = charType == HMCharacteristicTypeInputEvent
 
-            var buttonInfo: [String: Any] = [
-                "accessory_id": accessory.uniqueIdentifier.uuidString,
-                "accessory_name": accessory.name,
-                "press_type": pressName,
-            ]
-            if let idx = serviceIndexForCharacteristic(event.characteristic) {
-                buttonInfo["service_index"] = idx
+            if isButton {
+                let pressValue = (event.triggerValue as? NSNumber)?.intValue
+                let pressName = pressValue.map { pressTypeName($0) } ?? "any_press"
+                dict["event_summary"] = "\(accessory.name) \(pressName)"
+                dict["trigger_type"] = "button"
+
+                var buttonInfo: [String: Any] = [
+                    "accessory_id": accessory.uniqueIdentifier.uuidString,
+                    "accessory_name": accessory.name,
+                    "press_type": pressName,
+                ]
+                if let idx = serviceIndexForCharacteristic(event.characteristic) {
+                    buttonInfo["service_index"] = idx
+                }
+                dict["button_info"] = buttonInfo
+            } else {
+                let charName = CharacteristicMapper.name(for: charType)
+                let formattedValue = CharacteristicMapper.formatValue(event.triggerValue, for: charType)
+                dict["event_summary"] = "\(accessory.name) \(charName) = \(formattedValue)"
+                dict["trigger_type"] = "characteristic"
+
+                dict["trigger_info"] = [
+                    "accessory_id": accessory.uniqueIdentifier.uuidString,
+                    "accessory_name": accessory.name,
+                    "characteristic": charName,
+                    "trigger_value": formattedValue,
+                ] as [String: Any]
             }
-            dict["button_info"] = buttonInfo
         }
 
         return dict
@@ -210,12 +228,14 @@ enum AccessoryModel {
         let events: [[String: Any]] = trigger.events.compactMap { event in
             guard let charEvent = event as? HMCharacteristicEvent<NSCopying> else { return nil }
             let characteristic = charEvent.characteristic
+            let charType = characteristic.characteristicType
             let accessory = characteristic.service?.accessory
-            let pressValue = (charEvent.triggerValue as? NSNumber)?.intValue
+            let isButton = charType == HMCharacteristicTypeInputEvent
 
             var eventDict: [String: Any] = [
                 "type": "characteristic",
-                "characteristic": CharacteristicMapper.name(for: characteristic.characteristicType),
+                "characteristic": CharacteristicMapper.name(for: charType),
+                "trigger_type": isButton ? "button" : "characteristic",
             ]
             if let accessory {
                 eventDict["accessory"] = accessory.name
@@ -224,9 +244,15 @@ enum AccessoryModel {
             if let service = characteristic.service {
                 eventDict["service_type"] = CharacteristicMapper.serviceCategory(for: service.serviceType) ?? service.serviceType
             }
-            if let pressValue {
-                eventDict["trigger_value"] = pressValue
-                eventDict["press_type"] = pressTypeName(pressValue)
+            if isButton {
+                let pressValue = (charEvent.triggerValue as? NSNumber)?.intValue
+                if let pressValue {
+                    eventDict["trigger_value"] = pressValue
+                    eventDict["press_type"] = pressTypeName(pressValue)
+                }
+            } else {
+                let formattedValue = CharacteristicMapper.formatValue(charEvent.triggerValue, for: charType)
+                eventDict["trigger_value"] = formattedValue
             }
             if let idx = serviceIndexForCharacteristic(characteristic) {
                 eventDict["service_index"] = idx

--- a/Sources/homeclaw/HomeKit/CharacteristicMapper.swift
+++ b/Sources/homeclaw/HomeKit/CharacteristicMapper.swift
@@ -65,6 +65,11 @@ enum CharacteristicMapper {
         typeNames[characteristicType] ?? characteristicType
     }
 
+    /// Returns the HMCharacteristicType UUID for a human-readable snake_case name.
+    static func characteristicType(forName name: String) -> String? {
+        typeNames.first(where: { $0.value == name })?.key
+    }
+
     // MARK: - Writable Characteristics
 
     /// Characteristic types that can be written to (controlled).

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -740,10 +740,11 @@ final class HomeKitManager: NSObject, Observable {
             guard let triggerValue else {
                 throw ControlError.writeFailed("'trigger_value' is required when 'characteristic' is specified")
             }
-            guard let parsed = CharacteristicMapper.parseValue(triggerValue, for: triggerChar) else {
+            guard let parsed = CharacteristicMapper.parseValue(triggerValue, for: triggerChar),
+                  let nsCopying = (parsed as AnyObject) as? NSCopying else {
                 throw ControlError.writeFailed("Cannot parse trigger value '\(triggerValue)' for characteristic '\(characteristic)'")
             }
-            triggerNSValue = parsed as! NSCopying
+            triggerNSValue = nsCopying
             isButtonTrigger = false
             let formattedValue = CharacteristicMapper.formatValue(parsed, for: triggerChar.characteristicType)
             triggerLabel = "\(characteristic) = \(formattedValue)"

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -712,7 +712,9 @@ final class HomeKitManager: NSObject, Observable {
     func createAutomation(
         name: String,
         accessoryID: String,
-        pressType: Int,
+        pressType: Int = 0,
+        characteristic: String? = nil,
+        triggerValue: String? = nil,
         sceneID: String? = nil,
         actions: [[String: String]]? = nil,
         serviceIndex: Int? = nil,
@@ -726,8 +728,32 @@ final class HomeKitManager: NSObject, Observable {
             throw ControlError.accessoryNotFound(accessoryID)
         }
 
-        let inputEventChar = try findInputEventCharacteristic(on: accessory, serviceIndex: serviceIndex)
-        let pressName = AccessoryModel.pressTypeName(pressType)
+        // Resolve the trigger characteristic and value based on trigger mode
+        let triggerChar: HMCharacteristic
+        let triggerNSValue: NSCopying
+        let isButtonTrigger: Bool
+        let triggerLabel: String
+
+        if let characteristic {
+            // Generic characteristic trigger (motion, contact, occupancy, etc.)
+            triggerChar = try findTriggerCharacteristic(on: accessory, characteristicName: characteristic)
+            guard let triggerValue else {
+                throw ControlError.writeFailed("'trigger_value' is required when 'characteristic' is specified")
+            }
+            guard let parsed = CharacteristicMapper.parseValue(triggerValue, for: triggerChar) else {
+                throw ControlError.writeFailed("Cannot parse trigger value '\(triggerValue)' for characteristic '\(characteristic)'")
+            }
+            triggerNSValue = parsed as! NSCopying
+            isButtonTrigger = false
+            let formattedValue = CharacteristicMapper.formatValue(parsed, for: triggerChar.characteristicType)
+            triggerLabel = "\(characteristic) = \(formattedValue)"
+        } else {
+            // Button press trigger (existing path)
+            triggerChar = try findInputEventCharacteristic(on: accessory, serviceIndex: serviceIndex)
+            triggerNSValue = NSNumber(value: pressType) as NSCopying
+            isButtonTrigger = true
+            triggerLabel = AccessoryModel.pressTypeName(pressType)
+        }
 
         // Resolve the action set: either find an existing scene or create an inline one
         let actionSet: HMActionSet
@@ -744,7 +770,7 @@ final class HomeKitManager: NSObject, Observable {
                     "name": name,
                     "home": home.name,
                     "accessory": accessory.name,
-                    "press_type": pressName,
+                    "trigger_type": isButtonTrigger ? "button" : "characteristic",
                     "action_count": resolvedActions.count,
                     "actions": resolvedActions.map { action in
                         [
@@ -754,7 +780,13 @@ final class HomeKitManager: NSObject, Observable {
                         ] as [String: String]
                     },
                 ]
-                if let serviceIndex { result["service_index"] = serviceIndex }
+                if isButtonTrigger {
+                    result["press_type"] = triggerLabel
+                    if let serviceIndex { result["service_index"] = serviceIndex }
+                } else {
+                    result["characteristic"] = characteristic
+                    result["trigger_value"] = triggerValue
+                }
                 return result
             }
 
@@ -799,10 +831,16 @@ final class HomeKitManager: NSObject, Observable {
                     "name": name,
                     "home": home.name,
                     "accessory": accessory.name,
-                    "press_type": pressName,
+                    "trigger_type": isButtonTrigger ? "button" : "characteristic",
                     "scene": existingSet.name,
                 ]
-                if let serviceIndex { result["service_index"] = serviceIndex }
+                if isButtonTrigger {
+                    result["press_type"] = triggerLabel
+                    if let serviceIndex { result["service_index"] = serviceIndex }
+                } else {
+                    result["characteristic"] = characteristic
+                    result["trigger_value"] = triggerValue
+                }
                 return result
             }
 
@@ -814,8 +852,8 @@ final class HomeKitManager: NSObject, Observable {
 
         // Create the event trigger
         let event = HMCharacteristicEvent(
-            characteristic: inputEventChar,
-            triggerValue: NSNumber(value: pressType) as NSCopying
+            characteristic: triggerChar,
+            triggerValue: triggerNSValue
         )
         let trigger = HMEventTrigger(
             name: name,
@@ -883,23 +921,29 @@ final class HomeKitManager: NSObject, Observable {
         }
 
         let actionLabel = isInlineActionSet ? "\(actionSet.actions.count) inline action(s)" : actionSet.name
-        AppLogger.homekit.info("[\(home.name)] Created automation '\(name)': \(accessory.name) \(pressName) → \(actionLabel)")
+        AppLogger.homekit.info("[\(home.name)] Created automation '\(name)': \(accessory.name) \(triggerLabel) → \(actionLabel)")
         var result: [String: Any] = [
             "id": trigger.uniqueIdentifier.uuidString,
             "name": name,
             "home": home.name,
             "accessory": accessory.name,
-            "press_type": pressName,
+            "trigger_type": isButtonTrigger ? "button" : "characteristic",
             "enabled": true,
             "dry_run": false,
             "action_count": actionSet.actions.count,
         ]
+        if isButtonTrigger {
+            result["press_type"] = triggerLabel
+            if let serviceIndex { result["service_index"] = serviceIndex }
+        } else {
+            result["characteristic"] = characteristic
+            result["trigger_value"] = triggerValue
+        }
         if isInlineActionSet {
             result["inline_actions"] = true
         } else {
             result["scene"] = actionSet.name
         }
-        if let serviceIndex { result["service_index"] = serviceIndex }
         return result
     }
 
@@ -1073,6 +1117,24 @@ final class HomeKitManager: NSObject, Observable {
         }
 
         return inputEvent
+    }
+
+    /// Finds a characteristic by its human-readable name on any service of the accessory.
+    private func findTriggerCharacteristic(
+        on accessory: HMAccessory,
+        characteristicName: String
+    ) throws -> HMCharacteristic {
+        guard let charType = CharacteristicMapper.characteristicType(forName: characteristicName) else {
+            throw ControlError.characteristicNotFound("Unknown characteristic: '\(characteristicName)'")
+        }
+        for service in accessory.services {
+            if let char = service.characteristics.first(where: { $0.characteristicType == charType }) {
+                return char
+            }
+        }
+        throw ControlError.characteristicNotFound(
+            "'\(accessory.name)' has no '\(characteristicName)' characteristic"
+        )
     }
 
     private func resolveHome(homeID: String?) throws -> HMHome {

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -684,6 +684,8 @@ final class SocketServer: @unchecked Sendable {
                 guard sceneID != nil || (actions != nil && !actions!.isEmpty) else {
                     return encodeResponse(success: false, error: "Either 'scene_id' or 'actions' array is required")
                 }
+                let characteristic = args["characteristic"] as? String
+                let triggerValue = args["trigger_value"] as? String
                 let pressType = (args["press_type"] as? Int)
                     ?? (args["press_type"] as? String).flatMap(Int.init)
                     ?? 0
@@ -693,6 +695,8 @@ final class SocketServer: @unchecked Sendable {
                     name: name,
                     accessoryID: accessoryID,
                     pressType: pressType,
+                    characteristic: characteristic,
+                    triggerValue: triggerValue,
                     sceneID: sceneID,
                     actions: actions,
                     serviceIndex: serviceIndex,

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -122,8 +122,9 @@ export async function handleAutomations(args) {
         accessory_id: args.accessory_id,
       };
       if (args.characteristic) {
+        if (args.trigger_value == null) throw new Error('trigger_value is required when characteristic is set');
         socketArgs.characteristic = args.characteristic;
-        if (args.trigger_value != null) socketArgs.trigger_value = args.trigger_value;
+        socketArgs.trigger_value = args.trigger_value;
       } else {
         socketArgs.press_type = String(args.press_type ?? 0);
       }

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -120,8 +120,13 @@ export async function handleAutomations(args) {
       const socketArgs = {
         name: args.name,
         accessory_id: args.accessory_id,
-        press_type: String(args.press_type ?? 0),
       };
+      if (args.characteristic) {
+        socketArgs.characteristic = args.characteristic;
+        if (args.trigger_value != null) socketArgs.trigger_value = args.trigger_value;
+      } else {
+        socketArgs.press_type = String(args.press_type ?? 0);
+      }
       if (args.scene_id) socketArgs.scene_id = args.scene_id;
       if (args.actions) socketArgs.actions = args.actions;
       if (args.service_index != null) socketArgs.service_index = String(args.service_index);

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -203,7 +203,7 @@ export const tools = [
   },
   {
     name: 'homekit_automations',
-    description: 'Manage HomeKit automations (event triggers). List existing automations, inspect their events and linked scenes, create button-press automations for programmable switches (single/double/long press, multi-button support via service_index) with either a scene reference or inline actions, delete automations, or enable/disable them.',
+    description: 'Manage HomeKit automations (event triggers). List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -226,7 +226,7 @@ export const tools = [
         },
         accessory_id: {
           type: 'string',
-          description: 'Button accessory UUID or name (create action)',
+          description: 'Trigger accessory UUID or name (create action)',
         },
         scene_id: {
           type: 'string',
@@ -249,11 +249,19 @@ export const tools = [
         press_type: {
           type: 'number',
           enum: [0, 1, 2],
-          description: 'Button press type: 0=single (default), 1=double, 2=long press (create action)',
+          description: 'Button press type: 0=single (default), 1=double, 2=long press. For button triggers only; mutually exclusive with characteristic. (create action)',
+        },
+        characteristic: {
+          type: 'string',
+          description: 'Characteristic name to trigger on (e.g., motion_detected, contact_state, occupancy_detected, current_temperature). Alternative to press_type for non-button triggers. (create action)',
+        },
+        trigger_value: {
+          type: 'string',
+          description: 'Value that triggers the automation (e.g., "true", "false", "1", "0"). Required when characteristic is set. Uses exact value matching. (create action)',
         },
         service_index: {
           type: 'number',
-          description: 'Button index for multi-button accessories (1 or 2). Required when accessory has multiple buttons. (create action)',
+          description: 'Button index for multi-button accessories (1 or 2). For button triggers only. (create action)',
         },
         dry_run: {
           type: 'boolean',

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21291,8 +21291,9 @@ async function handleAutomations(args) {
         accessory_id: args.accessory_id
       };
       if (args.characteristic) {
+        if (args.trigger_value == null) throw new Error("trigger_value is required when characteristic is set");
         socketArgs.characteristic = args.characteristic;
-        if (args.trigger_value != null) socketArgs.trigger_value = args.trigger_value;
+        socketArgs.trigger_value = args.trigger_value;
       } else {
         socketArgs.press_type = String(args.press_type ?? 0);
       }

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21015,7 +21015,7 @@ var tools = [
   },
   {
     name: "homekit_automations",
-    description: "Manage HomeKit automations (event triggers). List existing automations, inspect their events and linked scenes, create button-press automations for programmable switches (single/double/long press, multi-button support via service_index) with either a scene reference or inline actions, delete automations, or enable/disable them.",
+    description: "Manage HomeKit automations (event triggers). List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value.",
     inputSchema: {
       type: "object",
       properties: {
@@ -21038,7 +21038,7 @@ var tools = [
         },
         accessory_id: {
           type: "string",
-          description: "Button accessory UUID or name (create action)"
+          description: "Trigger accessory UUID or name (create action)"
         },
         scene_id: {
           type: "string",
@@ -21061,11 +21061,19 @@ var tools = [
         press_type: {
           type: "number",
           enum: [0, 1, 2],
-          description: "Button press type: 0=single (default), 1=double, 2=long press (create action)"
+          description: "Button press type: 0=single (default), 1=double, 2=long press. For button triggers only; mutually exclusive with characteristic. (create action)"
+        },
+        characteristic: {
+          type: "string",
+          description: "Characteristic name to trigger on (e.g., motion_detected, contact_state, occupancy_detected, current_temperature). Alternative to press_type for non-button triggers. (create action)"
+        },
+        trigger_value: {
+          type: "string",
+          description: 'Value that triggers the automation (e.g., "true", "false", "1", "0"). Required when characteristic is set. Uses exact value matching. (create action)'
         },
         service_index: {
           type: "number",
-          description: "Button index for multi-button accessories (1 or 2). Required when accessory has multiple buttons. (create action)"
+          description: "Button index for multi-button accessories (1 or 2). For button triggers only. (create action)"
         },
         dry_run: {
           type: "boolean",
@@ -21280,9 +21288,14 @@ async function handleAutomations(args) {
       }
       const socketArgs = {
         name: args.name,
-        accessory_id: args.accessory_id,
-        press_type: String(args.press_type ?? 0)
+        accessory_id: args.accessory_id
       };
+      if (args.characteristic) {
+        socketArgs.characteristic = args.characteristic;
+        if (args.trigger_value != null) socketArgs.trigger_value = args.trigger_value;
+      } else {
+        socketArgs.press_type = String(args.press_type ?? 0);
+      }
       if (args.scene_id) socketArgs.scene_id = args.scene_id;
       if (args.actions) socketArgs.actions = args.actions;
       if (args.service_index != null) socketArgs.service_index = String(args.service_index);


### PR DESCRIPTION
## Summary

Closes #42

- Generalize automation creation beyond programmable switch button presses to support **any characteristic-based trigger** (motion sensors, contact sensors, occupancy, temperature, etc.)
- Add `characteristic` and `trigger_value` parameters across CLI (`--characteristic`/`--trigger-value`), socket API, and MCP server
- Full backward compatibility: existing button automations work identically via `press_type`
- Serialization distinguishes `button_info` vs `trigger_info` with a `trigger_type` field

### New trigger examples
```bash
# Motion sensor trigger
homeclaw automations create --name "Motion Light" \
  --accessory "Motion Sensor" --characteristic motion_detected --trigger-value true \
  --action "Living Room Light:power:true"

# Contact sensor trigger
homeclaw automations create --name "Door Alert" \
  --accessory "Front Door" --characteristic contact_state --trigger-value 1 \
  --scene "Alert Scene"

# Button press (unchanged)
homeclaw automations create --name "Button Light" \
  --accessory "Wall Switch" --press single \
  --action "Kitchen:power:true"
```

## Test plan

- [ ] Build CLI via SPM (`swift build --target homeclaw-cli`)
- [ ] Build MCP server (`npm run build:mcp`)
- [ ] Create a button automation and verify identical behavior to before
- [ ] Create a characteristic-based automation (motion/contact/occupancy)
- [ ] List automations and verify both types serialize correctly with `trigger_type`
- [ ] Test `--dry-run` for both trigger paths
- [ ] Verify mutual exclusivity: `--press` + `--characteristic` rejects

🤖 Generated with [Claude Code](https://claude.com/claude-code)