### PR TITLE
feat: in-place scene + automation mutators (preserve UUIDs)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>139</string>
+	<string>140</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>138</string>
+	<string>139</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>140</string>
+	<string>141</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>136</string>
+	<string>138</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -12,6 +12,7 @@ struct Automations: ParsableCommand {
             DeleteAutomation.self,
             EnableAutomation.self,
             DisableAutomation.self,
+            RewireAutomation.self,
         ],
         defaultSubcommand: ListAutomations.self
     )
@@ -404,6 +405,88 @@ struct DisableAutomation: ParsableCommand {
             print("Disabled automation '\(name)'")
         } else {
             print("Automation disabled.")
+        }
+    }
+}
+
+// MARK: - Rewire (mutate attached scenes in place)
+
+struct RewireAutomation: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rewire",
+        abstract:
+            "Add or remove scenes attached to an existing automation in place (preserves trigger UUID)"
+    )
+
+    @Argument(help: "Automation name or UUID")
+    var id: String
+
+    @Option(name: .long, parsing: .singleValue, help: "Scene name or UUID to attach (repeatable)")
+    var addScene: [String] = []
+
+    @Option(
+        name: .long, parsing: .singleValue, help: "Scene name or UUID to detach (repeatable)")
+    var removeScene: [String] = []
+
+    @Option(name: .long, help: "Home name or UUID (defaults to primary home)")
+    var home: String?
+
+    @Flag(name: .long, help: "Preview without modifying the automation")
+    var dryRun = false
+
+    @Flag(name: .long, help: "Output raw JSON")
+    var json = false
+
+    func run() throws {
+        guard !addScene.isEmpty || !removeScene.isEmpty else {
+            throw ValidationError("Provide at least one --add-scene or --remove-scene")
+        }
+
+        var args: [String: Any] = [
+            "id": id,
+            "add_scenes": addScene,
+            "remove_scenes": removeScene,
+            "dry_run": dryRun,
+        ]
+        if let home { args["home_id"] = home }
+
+        let response = try SocketClient.sendAny(command: "update_automation", args: args)
+        guard response.success else {
+            throw ValidationError(response.error ?? "Unknown error")
+        }
+
+        if shouldOutputJSON(json) {
+            printJSON(response.data?.value)
+            return
+        }
+
+        guard let result = response.data?.value as? [String: Any] else {
+            print("Done.")
+            return
+        }
+
+        let isDryRun = result["dry_run"] as? Bool ?? false
+        let autoName = result["name"] as? String ?? id
+        let before = (result["before"] as? [String]) ?? []
+        let toAdd = (result["to_add"] as? [String]) ?? []
+        let toRemove = (result["to_remove"] as? [String]) ?? []
+        let warnings = (result["warnings"] as? [String]) ?? []
+
+        if isDryRun {
+            print("DRY RUN — \(autoName)")
+            print("  Currently attached: \(before.joined(separator: ", "))")
+            print("  Would add:    \(toAdd.joined(separator: ", "))")
+            print("  Would remove: \(toRemove.joined(separator: ", "))")
+        } else {
+            let after = (result["after"] as? [String]) ?? []
+            print("Rewired '\(autoName)'")
+            print("  Before: \(before.joined(separator: ", "))")
+            print("  After:  \(after.joined(separator: ", "))")
+        }
+
+        if !warnings.isEmpty {
+            print("\nWarnings:")
+            for w in warnings { print("  ⚠ \(w)") }
         }
     }
 }

--- a/Sources/homeclaw-cli/Commands/UpdateSceneCommand.swift
+++ b/Sources/homeclaw-cli/Commands/UpdateSceneCommand.swift
@@ -1,0 +1,105 @@
+import ArgumentParser
+import Foundation
+
+struct UpdateScene: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "update-scene",
+        abstract:
+            "Replace the actions on an existing scene in-place (preserves UUID; automations remain wired)"
+    )
+
+    @Argument(help: "Path to JSON file with scene definition")
+    var file: String
+
+    @Option(name: .long, help: "Home name or UUID (defaults to primary home)")
+    var home: String?
+
+    @Flag(name: .long, help: "Preview changes without modifying the scene")
+    var dryRun = false
+
+    @Flag(name: .long, help: "Output raw JSON")
+    var json = false
+
+    func run() throws {
+        let url = URL(fileURLWithPath: file)
+        let data = try Data(contentsOf: url)
+        guard let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let actions = parsed["actions"] as? [[String: String]]
+        else {
+            throw ValidationError(
+                "JSON file must contain 'actions' array of "
+                    + "{\"accessory\": \"...\", \"property\": \"...\", \"value\": \"...\"} objects, "
+                    + "plus either 'id' (preferred) or 'name' to identify the scene"
+            )
+        }
+        let id = parsed["id"] as? String
+        let name = parsed["name"] as? String
+        guard id != nil || name != nil else {
+            throw ValidationError("JSON file must contain 'id' or 'name'")
+        }
+
+        var args: [String: Any] = [
+            "actions": actions,
+            "dry_run": dryRun,
+        ]
+        if let id { args["id"] = id }
+        if let name { args["name"] = name }
+        if let home { args["home"] = home }
+
+        let response = try SocketClient.sendAny(command: "update_scene", args: args)
+
+        guard response.success else {
+            throw ValidationError(response.error ?? "Unknown error")
+        }
+
+        if shouldOutputJSON(json) {
+            printJSON(response.data?.value)
+            return
+        }
+
+        guard let result = response.data?.value as? [String: Any] else {
+            print("Done.")
+            return
+        }
+
+        let isDryRun = result["dry_run"] as? Bool ?? false
+        let sceneName = result["name"] as? String ?? name ?? id ?? "?"
+        let sceneID = result["id"] as? String ?? id ?? "?"
+        let homeName = result["home"] as? String ?? "?"
+        let warnings = result["warnings"] as? [String] ?? []
+
+        if isDryRun {
+            let existingCount = result["existing_action_count"] as? Int ?? 0
+            let resolvedCount = result["resolved_actions"] as? Int ?? 0
+            print("DRY RUN — no changes made\n")
+            print("Scene: \(sceneName) [\(sceneID)]")
+            print("Home: \(homeName)")
+            print("Existing actions: \(existingCount) (will be removed)")
+            print("New actions:      \(resolvedCount) (will be added)")
+
+            if let actions = result["actions"] as? [[String: String]] {
+                for action in actions {
+                    let accessory = action["accessory"] ?? "?"
+                    let room = action["room"] ?? "?"
+                    let characteristic = action["characteristic"] ?? "?"
+                    let value = action["value"] ?? "?"
+                    print("  \(accessory) (\(room)): \(characteristic) = \(value)")
+                }
+            }
+        } else {
+            let removed = result["removed_action_count"] as? Int ?? 0
+            let added = result["added_action_count"] as? Int ?? 0
+            print(
+                "Updated scene '\(sceneName)' in \(homeName): removed \(removed), added \(added) action(s)"
+            )
+            print("UUID preserved: \(sceneID)")
+        }
+
+        if !warnings.isEmpty {
+            print("\nWarnings:")
+            for warning in warnings {
+                print("  ⚠ \(warning)")
+            }
+        }
+    }
+}

--- a/Sources/homeclaw-cli/HomeKitCLI.swift
+++ b/Sources/homeclaw-cli/HomeKitCLI.swift
@@ -14,6 +14,7 @@ struct HomeKitCLI: ParsableCommand {
             Trigger.self,
             DeleteScene.self,
             ImportScene.self,
+            UpdateScene.self,
             AssignRooms.self,
             Rename.self,
             CreateRoom.self,

--- a/Sources/homeclaw/HomeKit/AccessoryModel.swift
+++ b/Sources/homeclaw/HomeKit/AccessoryModel.swift
@@ -140,12 +140,22 @@ enum AccessoryModel {
     }
 
     /// Summary of a scene (action set).
+    /// Includes the distinct rooms touched by the scene's actions, so callers
+    /// can decide whether the scene is room-scoped or home-scoped.
     static func sceneSummary(_ actionSet: HMActionSet) -> [String: Any] {
-        [
+        var rooms = Set<String>()
+        for action in actionSet.actions {
+            guard let write = action as? HMCharacteristicWriteAction<NSCopying> else { continue }
+            if let room = write.characteristic.service?.accessory?.room?.name {
+                rooms.insert(room)
+            }
+        }
+        return [
             "id": actionSet.uniqueIdentifier.uuidString,
             "name": actionSet.name,
             "action_count": actionSet.actions.count,
             "type": actionSetType(actionSet),
+            "rooms": Array(rooms).sorted(),
         ]
     }
 

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -1022,6 +1022,95 @@ final class HomeKitManager: NSObject, Observable {
         return ["name": triggerName, "home": home.name, "dry_run": false] as [String: Any]
     }
 
+    /// Mutates the action sets attached to an existing automation trigger.
+    /// Resolves scene names/UUIDs to HMActionSet, then adds/removes them.
+    /// Preserves the trigger's UUID — physical buttons / motion sensors keep firing it.
+    func updateAutomationActionSets(
+        id: String,
+        addSceneIDs: [String],
+        removeSceneIDs: [String],
+        homeID: String? = nil,
+        dryRun: Bool = false
+    ) async throws -> [String: Any] {
+        await waitForReady()
+        let home = try resolveHome(homeID: homeID)
+        guard let trigger = findTrigger(id: id, in: home) else {
+            throw ControlError.triggerNotFound(id)
+        }
+
+        var resolvedAdd: [HMActionSet] = []
+        var resolvedRemove: [HMActionSet] = []
+        var warnings: [String] = []
+
+        for nameOrID in addSceneIDs {
+            if let actionSet = home.actionSets.first(where: {
+                $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(nameOrID) == .orderedSame
+                    || $0.name.localizedCaseInsensitiveCompare(nameOrID) == .orderedSame
+            }) {
+                if trigger.actionSets.contains(actionSet) {
+                    warnings.append("Already attached, skipping add: \(actionSet.name)")
+                } else {
+                    resolvedAdd.append(actionSet)
+                }
+            } else {
+                warnings.append("Scene not found (add): \(nameOrID)")
+            }
+        }
+
+        for nameOrID in removeSceneIDs {
+            if let actionSet = trigger.actionSets.first(where: {
+                $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(nameOrID) == .orderedSame
+                    || $0.name.localizedCaseInsensitiveCompare(nameOrID) == .orderedSame
+            }) {
+                resolvedRemove.append(actionSet)
+            } else {
+                warnings.append("Scene not attached to this automation (remove): \(nameOrID)")
+            }
+        }
+
+        let summary: [String: Any] = [
+            "id": trigger.uniqueIdentifier.uuidString,
+            "name": trigger.name,
+            "home": home.name,
+            "before": trigger.actionSets.map { $0.name },
+            "to_add": resolvedAdd.map { $0.name },
+            "to_remove": resolvedRemove.map { $0.name },
+            "warnings": warnings,
+        ]
+
+        if dryRun {
+            var dry = summary
+            dry["dry_run"] = true
+            return dry
+        }
+
+        // Add first so we never leave the trigger with zero action sets midway.
+        for actionSet in resolvedAdd {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                trigger.addActionSet(actionSet) { error in
+                    if let error { continuation.resume(throwing: error) }
+                    else { continuation.resume() }
+                }
+            }
+        }
+        for actionSet in resolvedRemove {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                trigger.removeActionSet(actionSet) { error in
+                    if let error { continuation.resume(throwing: error) }
+                    else { continuation.resume() }
+                }
+            }
+        }
+
+        AppLogger.homekit.info(
+            "[\(home.name)] Rewired automation '\(trigger.name)': +\(resolvedAdd.count) -\(resolvedRemove.count)")
+
+        var result = summary
+        result["dry_run"] = false
+        result["after"] = trigger.actionSets.map { $0.name }
+        return result
+    }
+
     func enableAutomation(
         id: String,
         enabled: Bool,
@@ -1269,6 +1358,133 @@ final class HomeKitManager: NSObject, Observable {
             "name": actionSet.name,
             "home": home.name,
             "action_count": addedCount,
+            "warnings": warnings,
+        ] as [String: Any]
+    }
+
+    /// Replaces the actions on an existing scene in-place, preserving its UUID
+    /// so any automations that reference the scene continue to work.
+    /// Lookup by UUID first, then by case-insensitive name.
+    func updateScene(
+        nameOrID: String,
+        homeName: String? = nil,
+        actions: [[String: String]],
+        dryRun: Bool = false
+    ) async throws -> [String: Any] {
+        await waitForReady()
+        let targetHomes = filteredHomes(homeID: homeName)
+
+        var foundActionSet: HMActionSet?
+        var foundHome: HMHome?
+        for home in targetHomes {
+            if let actionSet = home.actionSets.first(where: {
+                $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(nameOrID) == .orderedSame
+                    || $0.name.localizedCaseInsensitiveCompare(nameOrID) == .orderedSame
+            }) {
+                foundActionSet = actionSet
+                foundHome = home
+                break
+            }
+        }
+        guard let actionSet = foundActionSet, let home = foundHome else {
+            throw ControlError.accessoryNotFound("Scene not found: \(nameOrID)")
+        }
+
+        var resolvedActions: [(accessory: HMAccessory, characteristic: HMCharacteristic, value: Any)] = []
+        var warnings: [String] = []
+
+        for action in actions {
+            guard let accessoryID = action["accessory"],
+                  let property = action["property"],
+                  let valueStr = action["value"]
+            else {
+                warnings.append("Skipping action with missing fields: \(action)")
+                continue
+            }
+
+            let accessory: HMAccessory
+            if let found = home.accessories.first(where: {
+                $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(accessoryID) == .orderedSame
+            }) {
+                accessory = found
+            } else {
+                let roomName = action["room"]
+                guard let found = findAccessoryByName(accessoryID, room: roomName, in: home) else {
+                    warnings.append("Accessory not found: \(accessoryID)" + (roomName.map { " in \($0)" } ?? ""))
+                    continue
+                }
+                accessory = found
+            }
+
+            guard let characteristic = findCharacteristicByDescription(on: accessory, property: property) else {
+                warnings.append("Characteristic '\(property)' not found on \(accessory.name)")
+                continue
+            }
+
+            guard let parsedValue = parseActionValue(valueStr, property: property) else {
+                warnings.append("Cannot parse value '\(valueStr)' for \(property) on \(accessory.name)")
+                continue
+            }
+
+            resolvedActions.append((accessory, characteristic, parsedValue))
+        }
+
+        if dryRun {
+            return [
+                "dry_run": true,
+                "name": actionSet.name,
+                "id": actionSet.uniqueIdentifier.uuidString,
+                "home": home.name,
+                "existing_action_count": actionSet.actions.count,
+                "resolved_actions": resolvedActions.count,
+                "warnings": warnings,
+                "actions": resolvedActions.map { action in
+                    [
+                        "accessory": action.accessory.name,
+                        "room": action.accessory.room?.name ?? "Default Room",
+                        "characteristic": CharacteristicMapper.name(for: action.characteristic.characteristicType),
+                        "value": "\(action.value)",
+                    ] as [String: String]
+                },
+            ] as [String: Any]
+        }
+
+        let existingActions = Array(actionSet.actions)
+        for action in existingActions {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                actionSet.removeAction(action) { error in
+                    if let error { continuation.resume(throwing: error) }
+                    else { continuation.resume() }
+                }
+            }
+        }
+        let removedCount = existingActions.count
+
+        var addedCount = 0
+        for resolved in resolvedActions {
+            let writeAction = HMCharacteristicWriteAction(
+                characteristic: resolved.characteristic,
+                targetValue: resolved.value as! NSCopying & NSObjectProtocol
+            )
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                actionSet.addAction(writeAction) { error in
+                    if let error { continuation.resume(throwing: error) }
+                    else { continuation.resume() }
+                }
+            }
+            addedCount += 1
+        }
+
+        AppLogger.homekit.info(
+            "[\(home.name)] Updated scene '\(actionSet.name)': removed \(removedCount), added \(addedCount)")
+
+        return [
+            "updated": true,
+            "name": actionSet.name,
+            "id": actionSet.uniqueIdentifier.uuidString,
+            "home": home.name,
+            "removed_action_count": removedCount,
+            "added_action_count": addedCount,
             "warnings": warnings,
         ] as [String: Any]
     }

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -1468,6 +1468,14 @@ final class HomeKitManager: NSObject, Observable {
                 "All \(actions.count) action(s) failed to resolve; scene '\(actionSet.name)' not modified.")
         }
 
+        // Snapshot the pre-existing actions BEFORE any mutation. Used to drive
+        // the remove loop below. We can't rely on `actionSet.actions.subtracting(addedActions)`
+        // post-add because HomeKit may wrap/replace the HMAction we provide
+        // before storing it; the reference we hold in `addedActions` may not
+        // match the one in `actionSet.actions` by identity, and HMAction is
+        // hashed/equated as NSObject (reference equality).
+        let oldActions = Array(actionSet.actions)
+
         // Add new actions BEFORE removing the old ones. If `addAction` throws
         // partway through, the original actions are still attached, so the
         // scene retains its prior behavior (and the partial adds will trigger
@@ -1499,8 +1507,8 @@ final class HomeKitManager: NSObject, Observable {
         }
         let addedCount = addedActions.count
 
-        let existingActions = actionSet.actions.subtracting(addedActions)
-        for action in existingActions {
+        // Remove only the pre-snapshotted originals.
+        for action in oldActions {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 actionSet.removeAction(action) { error in
                     if let error { continuation.resume(throwing: error) }
@@ -1508,7 +1516,7 @@ final class HomeKitManager: NSObject, Observable {
                 }
             }
         }
-        let removedCount = existingActions.count
+        let removedCount = oldActions.count
 
         AppLogger.homekit.info(
             "[\(home.name)] Updated scene '\(actionSet.name)': added \(addedCount), removed \(removedCount)")

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -152,6 +152,7 @@ final class HomeKitManager: NSObject, Observable {
         case triggerNotFound(String)
         case sceneNotFound(String)
         case serviceNotFound(String)
+        case invalidArgument(String)
 
         var errorDescription: String? {
             switch self {
@@ -169,6 +170,7 @@ final class HomeKitManager: NSObject, Observable {
             case .triggerNotFound(let id): "Automation not found: \(id)"
             case .sceneNotFound(let id): "Scene not found: \(id)"
             case .serviceNotFound(let detail): "Service not found: \(detail)"
+            case .invalidArgument(let detail): "Invalid argument: \(detail)"
             }
         }
     }
@@ -1078,6 +1080,16 @@ final class HomeKitManager: NSObject, Observable {
             "warnings": warnings,
         ]
 
+        // Refuse operations that would leave the trigger with zero scenes attached.
+        // HomeKit doesn't define behavior for an empty actionSets collection — the
+        // trigger fires but does nothing, and may become hard to manage in the Home
+        // app. Callers wanting to retire a trigger should delete it instead.
+        let resultingCount = trigger.actionSets.count + resolvedAdd.count - resolvedRemove.count
+        guard resultingCount > 0 else {
+            throw ControlError.invalidArgument(
+                "Operation would leave trigger '\(trigger.name)' with no attached scenes. Delete the automation instead, or attach a replacement scene.")
+        }
+
         if dryRun {
             var dry = summary
             dry["dry_run"] = true
@@ -1449,7 +1461,45 @@ final class HomeKitManager: NSObject, Observable {
             ] as [String: Any]
         }
 
-        let existingActions = Array(actionSet.actions)
+        // Refuse to wipe a scene when caller asked for actions but every one
+        // failed to resolve. (Empty input is a legitimate clear-all request.)
+        if !actions.isEmpty && resolvedActions.isEmpty {
+            throw ControlError.invalidArgument(
+                "All \(actions.count) action(s) failed to resolve; scene '\(actionSet.name)' not modified.")
+        }
+
+        // Add new actions BEFORE removing the old ones. If `addAction` throws
+        // partway through, the original actions are still attached, so the
+        // scene retains its prior behavior (and the partial adds will trigger
+        // alongside the originals — redundant but not destructive). We then
+        // best-effort clean up any partial adds before propagating the error.
+        var addedActions: [HMAction] = []
+        do {
+            for resolved in resolvedActions {
+                let writeAction = HMCharacteristicWriteAction(
+                    characteristic: resolved.characteristic,
+                    targetValue: resolved.value as! NSCopying & NSObjectProtocol
+                )
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    actionSet.addAction(writeAction) { error in
+                        if let error { continuation.resume(throwing: error) }
+                        else { continuation.resume() }
+                    }
+                }
+                addedActions.append(writeAction)
+            }
+        } catch {
+            // Roll back the partial adds so the scene returns to its prior state.
+            for action in addedActions {
+                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    actionSet.removeAction(action) { _ in continuation.resume() }
+                }
+            }
+            throw error
+        }
+        let addedCount = addedActions.count
+
+        let existingActions = actionSet.actions.subtracting(addedActions)
         for action in existingActions {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 actionSet.removeAction(action) { error in
@@ -1460,23 +1510,8 @@ final class HomeKitManager: NSObject, Observable {
         }
         let removedCount = existingActions.count
 
-        var addedCount = 0
-        for resolved in resolvedActions {
-            let writeAction = HMCharacteristicWriteAction(
-                characteristic: resolved.characteristic,
-                targetValue: resolved.value as! NSCopying & NSObjectProtocol
-            )
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                actionSet.addAction(writeAction) { error in
-                    if let error { continuation.resume(throwing: error) }
-                    else { continuation.resume() }
-                }
-            }
-            addedCount += 1
-        }
-
         AppLogger.homekit.info(
-            "[\(home.name)] Updated scene '\(actionSet.name)': removed \(removedCount), added \(addedCount)")
+            "[\(home.name)] Updated scene '\(actionSet.name)': added \(addedCount), removed \(removedCount)")
 
         return [
             "updated": true,

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -660,6 +660,20 @@ final class SocketServer: @unchecked Sendable {
                     dryRun: parseBool(args, key: "dry_run")
                 )
 
+            case "update_scene":
+                guard let nameOrID = (args["id"] as? String) ?? (args["name"] as? String) else {
+                    return encodeResponse(success: false, error: "Missing 'name' or 'id' argument")
+                }
+                guard let actions = args["actions"] as? [[String: String]] else {
+                    return encodeResponse(success: false, error: "Missing 'actions' array")
+                }
+                result = try await hk.updateScene(
+                    nameOrID: nameOrID,
+                    homeName: args["home"] as? String,
+                    actions: actions,
+                    dryRun: parseBool(args, key: "dry_run")
+                )
+
             case "list_automations":
                 result = await hk.listAutomations(homeID: args["home_id"] as? String)
 
@@ -710,6 +724,23 @@ final class SocketServer: @unchecked Sendable {
                 }
                 result = try await hk.deleteAutomation(
                     id: id,
+                    homeID: args["home_id"] as? String,
+                    dryRun: parseBool(args, key: "dry_run")
+                )
+
+            case "update_automation":
+                guard let id = args["id"] as? String else {
+                    return encodeResponse(success: false, error: "Missing 'id' argument")
+                }
+                let addList = (args["add_scenes"] as? [String]) ?? []
+                let removeList = (args["remove_scenes"] as? [String]) ?? []
+                if addList.isEmpty && removeList.isEmpty {
+                    return encodeResponse(success: false, error: "Provide at least one of 'add_scenes' or 'remove_scenes'")
+                }
+                result = try await hk.updateAutomationActionSets(
+                    id: id,
+                    addSceneIDs: addList,
+                    removeSceneIDs: removeList,
                     homeID: args["home_id"] as? String,
                     dryRun: parseBool(args, key: "dry_run")
                 )

--- a/Sources/macOSBridge/MacOSController.swift
+++ b/Sources/macOSBridge/MacOSController.swift
@@ -209,22 +209,28 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
 
         menu.addItem(.separator())
 
-        // Scenes
-        if !scenes.isEmpty {
+        // Classify scenes by room scope.
+        // - Built-ins (wake_up/sleep/leave/arrive) → always home-level (Apple intent)
+        // - Multi-room or unscoped scenes → home-level
+        // - Single-room scenes → nested under that room's section
+        var homeLevelScenes: [[String: Any]] = []
+        var roomScenes: [String: [[String: Any]]] = [:]
+        for scene in scenes {
+            let type = scene["type"] as? String ?? "user_defined"
+            let sceneRooms = scene["rooms"] as? [String] ?? []
+            if type != "user_defined" || sceneRooms.count != 1 {
+                homeLevelScenes.append(scene)
+            } else {
+                let room = sceneRooms[0]
+                roomScenes[room, default: []].append(scene)
+            }
+        }
+
+        // Top "Scenes" section: home-level only
+        if !homeLevelScenes.isEmpty {
             addSectionHeader("Scenes", to: menu)
-            for scene in scenes {
-                let name = scene["name"] as? String ?? "?"
-                let id = scene["id"] as? String ?? ""
-                let type = scene["type"] as? String ?? "user_defined"
-                let item = NSMenuItem(
-                    title: name, action: #selector(triggerScene(_:)), keyEquivalent: "")
-                item.target = self
-                item.representedObject = id
-                item.image = NSImage(
-                    systemSymbolName: symbolForSceneType(type),
-                    accessibilityDescription: nil)
-                item.indentationLevel = 1
-                menu.addItem(item)
+            for scene in homeLevelScenes {
+                addSceneItem(scene, to: menu)
             }
             menu.addItem(.separator())
         }
@@ -236,9 +242,11 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
         for room in rooms {
             let roomName = room["name"] as? String ?? "?"
             let accessories = room["accessories"] as? [[String: Any]] ?? []
+            let scenesHere = roomScenes[roomName] ?? []
 
-            // Skip rooms where no accessory will actually be displayed
-            guard accessories.contains(where: { isAccessoryVisible($0) }) else { continue }
+            // Skip rooms where nothing will be displayed
+            let hasVisibleAccessory = accessories.contains(where: { isAccessoryVisible($0) })
+            guard hasVisibleAccessory || !scenesHere.isEmpty else { continue }
 
             menu.addItem(.separator())
 
@@ -258,7 +266,26 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
             for accessory in accessories {
                 addAccessoryItem(accessory, to: menu)
             }
+
+            for scene in scenesHere {
+                addSceneItem(scene, to: menu)
+            }
         }
+    }
+
+    private func addSceneItem(_ scene: [String: Any], to menu: NSMenu) {
+        let name = scene["name"] as? String ?? "?"
+        let id = scene["id"] as? String ?? ""
+        let type = scene["type"] as? String ?? "user_defined"
+        let item = NSMenuItem(
+            title: name, action: #selector(triggerScene(_:)), keyEquivalent: "")
+        item.target = self
+        item.representedObject = id
+        item.image = NSImage(
+            systemSymbolName: symbolForSceneType(type),
+            accessibilityDescription: nil)
+        item.indentationLevel = 1
+        menu.addItem(item)
     }
 
     private func addSectionHeader(_ title: String, to menu: NSMenu) {


### PR DESCRIPTION
## Summary
- Add `HomeKitManager.updateScene` to replace an existing scene's actions in place via `HMActionSet.removeAction`/`addAction` (preserves UUID).
- Add `HomeKitManager.updateAutomationActionSets` to add/remove scene refs on an existing `HMEventTrigger` (preserves trigger UUID — physical button bindings unchanged).
- New CLI: `homeclaw-cli update-scene <file>` and `homeclaw-cli automations rewire <id> --add-scene X --remove-scene Y` (both with `--dry-run`).
- Bumps build to 138.

## Why
The existing `import-scene` + `delete-scene` primitives can only create *new* scenes with *new* UUIDs. That orphans every automation referencing the old scene by UUID. With these mutators we can:

1. Populate a previously-empty scene without invalidating button bindings that already point at its UUID.
2. Migrate a button automation off a duplicate scene by attaching the canonical and detaching the duplicate, again without changing UUIDs.

## Real-world use today
Used these primitives to clean up the Shahine Cabin home:
- Populated 8 empty duplicate scenes (e.g. `Open Main Blinds`) by copying actions from their canonical counterparts (`Main Blinds - Open`).
- Rewired 10 button automations off the duplicates onto the canonical scenes.
- Deleted the 8 duplicates safely.
- Then populated 5 personal routines (`Bedtime Sarah/Miles`, `Morning Sarah/Miles`, `Evening Blinds`) and created a `Lights out` scene.
- 31 scenes → 18, all functional except 3 Apple system scenes (which HomeKit refuses to delete).

## Test plan
- [x] `update-scene` dry-run shows existing/resolved counts and warnings without mutating
- [x] `update-scene` apply preserves the scene's UUID (verified across 13 scenes)
- [x] `automations rewire` add/remove preserves trigger UUID (verified across 10 automations)
- [x] Full end-to-end: 23-scene cabin home cleaned up, every Family Room button still fires the correct canonical scene
- [ ] Reviewer: open `update-scene` source on a scene that's referenced by an automation; ensure the trigger still resolves the same scene by UUID after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)