### PR TITLE
feat: add --days flag to scope automations to specific weekdays

### DIFF
--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -167,6 +167,9 @@ struct CreateAutomation: ParsableCommand {
     @Option(name: .long, help: "Button index for multi-button accessories (e.g., 1 or 2). For button triggers only.")
     var serviceIndex: Int?
 
+    @Option(name: .long, help: "Comma-separated weekdays the automation may fire on: mon,tue,wed,thu,fri,sat,sun (or numeric 1-7 where 1=Sun). When omitted, the automation fires every day.")
+    var days: String?
+
     @Option(name: .long, help: "Home name or UUID (defaults to primary home)")
     var home: String?
 
@@ -229,6 +232,19 @@ struct CreateAutomation: ParsableCommand {
         }
 
         if let serviceIndex { args["service_index"] = serviceIndex }
+
+        if let days {
+            let dayMap = ["sun": 1, "mon": 2, "tue": 3, "wed": 4, "thu": 5, "fri": 6, "sat": 7]
+            var weekdays: [Int] = []
+            for raw in days.split(separator: ",") {
+                let key = raw.trimmingCharacters(in: .whitespaces).lowercased()
+                if let n = dayMap[String(key.prefix(3))] { weekdays.append(n) }
+                else if let n = Int(key), (1...7).contains(n) { weekdays.append(n) }
+                else { throw ValidationError("Invalid day '\(raw)'. Use mon/tue/wed/thu/fri/sat/sun or 1-7 (1=Sun)") }
+            }
+            args["weekdays"] = weekdays
+        }
+
         if let home { args["home_id"] = home }
 
         let response = try SocketClient.sendAny(command: "create_automation", args: args)
@@ -278,6 +294,9 @@ struct CreateAutomation: ParsableCommand {
             } else if let sceneName = result["scene"] as? String {
                 print("  Scene: \(sceneName)")
             }
+            if let weekdays = result["weekdays"] as? [Int], !weekdays.isEmpty {
+                print("  Days: \(formatWeekdays(weekdays))")
+            }
         } else {
             if isInline {
                 print("Created automation '\(autoName)' with \(actionCount ?? 0) inline action(s)")
@@ -287,7 +306,16 @@ struct CreateAutomation: ParsableCommand {
                 print("Created automation '\(autoName)'")
                 print("  \(triggerDescription) → \(sceneName)")
             }
+            if let weekdays = result["weekdays"] as? [Int], !weekdays.isEmpty {
+                print("  Days: \(formatWeekdays(weekdays))")
+            }
         }
+    }
+
+    /// Format an array of HomeKit weekday numbers (1=Sun ... 7=Sat) as a comma-separated label.
+    private func formatWeekdays(_ weekdays: [Int]) -> String {
+        let names = ["", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+        return weekdays.compactMap { (1...7).contains($0) ? names[$0] : nil }.joined(separator: ",")
     }
 }
 

--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -234,15 +234,23 @@ struct CreateAutomation: ParsableCommand {
         if let serviceIndex { args["service_index"] = serviceIndex }
 
         if let days {
-            let dayMap = ["sun": 1, "mon": 2, "tue": 3, "wed": 4, "thu": 5, "fri": 6, "sat": 7]
+            let dayMap: [String: Int] = [
+                "sun": 1, "sunday": 1,
+                "mon": 2, "monday": 2,
+                "tue": 3, "tuesday": 3,
+                "wed": 4, "wednesday": 4,
+                "thu": 5, "thursday": 5,
+                "fri": 6, "friday": 6,
+                "sat": 7, "saturday": 7,
+            ]
             var weekdays: [Int] = []
             for raw in days.split(separator: ",") {
                 let key = raw.trimmingCharacters(in: .whitespaces).lowercased()
-                if let n = dayMap[String(key.prefix(3))] { weekdays.append(n) }
+                if let n = dayMap[key] { weekdays.append(n) }
                 else if let n = Int(key), (1...7).contains(n) { weekdays.append(n) }
                 else { throw ValidationError("Invalid day '\(raw)'. Use mon/tue/wed/thu/fri/sat/sun or 1-7 (1=Sun)") }
             }
-            args["weekdays"] = weekdays
+            args["weekdays"] = Array(Swift.Set(weekdays)).sorted()
         }
 
         if let home { args["home_id"] = home }

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -720,6 +720,7 @@ final class HomeKitManager: NSObject, Observable {
         sceneID: String? = nil,
         actions: [[String: String]]? = nil,
         serviceIndex: Int? = nil,
+        weekdays: [Int] = [],
         homeID: String? = nil,
         dryRun: Bool = false
     ) async throws -> [String: Any] {
@@ -790,6 +791,7 @@ final class HomeKitManager: NSObject, Observable {
                     result["characteristic"] = characteristic
                     result["trigger_value"] = triggerValue
                 }
+                if !weekdays.isEmpty { result["weekdays"] = weekdays }
                 return result
             }
 
@@ -844,6 +846,7 @@ final class HomeKitManager: NSObject, Observable {
                     result["characteristic"] = characteristic
                     result["trigger_value"] = triggerValue
                 }
+                if !weekdays.isEmpty { result["weekdays"] = weekdays }
                 return result
             }
 
@@ -871,6 +874,38 @@ final class HomeKitManager: NSObject, Observable {
             home.addTrigger(trigger) { error in
                 if let error { continuation.resume(throwing: error) }
                 else { continuation.resume() }
+            }
+        }
+
+        // Step 1b: Apply weekday predicate (iOS 15+ marks time-conditional automations
+        // without weekday gating as "unreliable"; explicit weekdays are the workaround).
+        // The OR of per-day predicates is AND'd with the trigger's existing predicate.
+        if !weekdays.isEmpty {
+            let dayPredicates: [NSPredicate] = weekdays.map { weekday in
+                var dc = DateComponents()
+                dc.weekday = weekday
+                return HMEventTrigger.predicateForEvaluatingTrigger(occurringOn: dc)
+            }
+            let weekdayPredicate: NSPredicate = dayPredicates.count == 1
+                ? dayPredicates[0]
+                : NSCompoundPredicate(orPredicateWithSubpredicates: dayPredicates)
+            let combinedPredicate: NSPredicate
+            if let existing = trigger.predicate {
+                combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [existing, weekdayPredicate])
+            } else {
+                combinedPredicate = weekdayPredicate
+            }
+            do {
+                try await homeKitAsync { trigger.updatePredicate(combinedPredicate, completionHandler: $0) }
+            } catch {
+                // Cleanup orphaned trigger on predicate failure
+                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    home.removeTrigger(trigger) { err in
+                        if let err { continuation.resume(throwing: err) }
+                        else { continuation.resume() }
+                    }
+                }
+                throw error
             }
         }
 
@@ -946,6 +981,9 @@ final class HomeKitManager: NSObject, Observable {
             result["inline_actions"] = true
         } else {
             result["scene"] = actionSet.name
+        }
+        if !weekdays.isEmpty {
+            result["weekdays"] = weekdays
         }
         return result
     }

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -705,6 +705,9 @@ final class SocketServer: @unchecked Sendable {
                     ?? 0
                 let serviceIndex = (args["service_index"] as? Int)
                     ?? (args["service_index"] as? String).flatMap(Int.init)
+                let weekdays = (args["weekdays"] as? [Int])
+                    ?? (args["weekdays"] as? [String])?.compactMap(Int.init)
+                    ?? []
                 result = try await hk.createAutomation(
                     name: name,
                     accessoryID: accessoryID,
@@ -714,6 +717,7 @@ final class SocketServer: @unchecked Sendable {
                     sceneID: sceneID,
                     actions: actions,
                     serviceIndex: serviceIndex,
+                    weekdays: weekdays,
                     homeID: args["home_id"] as? String,
                     dryRun: parseBool(args, key: "dry_run")
                 )

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -131,6 +131,9 @@ export async function handleAutomations(args) {
       if (args.scene_id) socketArgs.scene_id = args.scene_id;
       if (args.actions) socketArgs.actions = args.actions;
       if (args.service_index != null) socketArgs.service_index = String(args.service_index);
+      if (Array.isArray(args.weekdays) && args.weekdays.length > 0) {
+        socketArgs.weekdays = args.weekdays;
+      }
       if (args.home_id) socketArgs.home_id = args.home_id;
       if (args.dry_run) socketArgs.dry_run = 'true';
       return sendCommand('create_automation', socketArgs);

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -263,6 +263,11 @@ export const tools = [
           type: 'number',
           description: 'Button index for multi-button accessories (1 or 2). For button triggers only. (create action)',
         },
+        weekdays: {
+          type: 'array',
+          items: { type: 'number', enum: [1, 2, 3, 4, 5, 6, 7] },
+          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, the automation fires every day. iOS 15+ marks time-conditional automations without weekday gating as "unreliable", so pass weekdays explicitly when combining with time-of-day conditions. (create action)',
+        },
         dry_run: {
           type: 'boolean',
           description: 'Preview changes without applying (create/delete actions)',

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21075,6 +21075,11 @@ var tools = [
           type: "number",
           description: "Button index for multi-button accessories (1 or 2). For button triggers only. (create action)"
         },
+        weekdays: {
+          type: "array",
+          items: { type: "number", enum: [1, 2, 3, 4, 5, 6, 7] },
+          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, the automation fires every day. iOS 15+ marks time-conditional automations without weekday gating as "unreliable", so pass weekdays explicitly when combining with time-of-day conditions. (create action)'
+        },
         dry_run: {
           type: "boolean",
           description: "Preview changes without applying (create/delete actions)"
@@ -21300,6 +21305,9 @@ async function handleAutomations(args) {
       if (args.scene_id) socketArgs.scene_id = args.scene_id;
       if (args.actions) socketArgs.actions = args.actions;
       if (args.service_index != null) socketArgs.service_index = String(args.service_index);
+      if (Array.isArray(args.weekdays) && args.weekdays.length > 0) {
+        socketArgs.weekdays = args.weekdays;
+      }
       if (args.home_id) socketArgs.home_id = args.home_id;
       if (args.dry_run) socketArgs.dry_run = "true";
       return sendCommand("create_automation", socketArgs);


### PR DESCRIPTION
## Motivation

First of the PRs from #48. Smallest of the bunch — adds `--days mon,tue,wed,thu,fri,sat,sun` (or numeric `1-7`, 1=Sun) to `automations create` and gates the trigger predicate to those weekdays.

Why now: iOS 15+ marks time-conditional automations without explicit weekday gating as "unreliable" and they often skip. The `--days` flag is the documented workaround. It also stands on its own as a useful "weekday-mornings only" scoping primitive even without time conditions.

## What changed

Threaded through all four layers PR #44 set:

- **`Sources/homeclaw-cli/Commands/AutomationsCommand.swift`** — `--days` flag with `mon`/`tue`/.../`sun` (case-insensitive, 3-char prefix accepted) or `1-7` numeric. Surfaces the parsed days back in success and dry-run output (`Days: Mon,Tue,Wed,Thu,Fri`).
- **`Sources/homeclaw/HomeKit/SocketServer.swift`** — parses `weekdays` (Int array, with String fallback) and forwards to `HomeKitManager`.
- **`Sources/homeclaw/HomeKit/HomeKitManager.swift`** — `weekdays: [Int] = []` parameter on `createAutomation`. When non-empty, builds an OR-compound of per-day `predicateForEvaluatingTrigger(occurringOn:)`, ANDs with any existing trigger predicate, and applies via `trigger.updatePredicate(_:)` after `addTrigger`. Cleanup-on-failure removes the orphaned trigger if `updatePredicate` errors (matches existing post-`addTrigger` rollback pattern).
- **`lib/handlers/homekit.js` + `lib/schemas.js`** — `weekdays` array with `enum: [1..7]`, schema description cites the iOS 15+ "unreliable" reason for discoverability.
- **`mcp-server/dist/server.js`** — rebuilt via `npm run build:mcp`.

## Example

```bash
homeclaw-cli automations create \
  --name "Coffee maker weekday mornings" \
  --accessory "Wall Switch" --press single \
  --days mon,tue,wed,thu,fri \
  --scene "Brew"
```

Output:

```
Created automation 'Coffee maker weekday mornings'
  Wall Switch single press → Brew
  Days: Mon,Tue,Wed,Thu,Fri
```

## Testing status

- ✅ `swift build --product homeclaw-cli` — clean
- ✅ `npm install && npm run build:mcp` — clean
- ✅ `automations create --help` renders the new flag with documented help text
- ⚠️ **Runtime end-to-end (real HomeKit, automation actually firing on the right weekdays) not verified on this branch's bundle ID.** My local provisioning covers `com.midson.*` (my private fork's bundle ID), not `com.shahine.*`, so I couldn't sign+install upstream's bundle ID with HomeKit entitlement to test against my own home.
- The predicate-construction code (`predicateForEvaluatingTrigger(occurringOn:)` per day → `NSCompoundPredicate` OR → AND-with-existing → `updatePredicate`) is byte-equivalent to a sibling code path that's been running in my own deployment for a few weeks (under a different parent function on my private fork). Reasonably confident, but **happy to wait for your verification before merge** if you'd like to take it for a spin first.

## Notes

- No build-number / version-manifest changes (per your `chore(release):` separation pattern).
- `--days` is opt-in only in this PR — no auto-fill defaulting. The "default to all 7 days when time conditions are present" logic from #48 belongs in PR3 (`--time-after`/`--time-before`) where it has a meaningful trigger.

## Sequence

Per #48: this is PR 1 of 6. Next up: PR 2 (read-side surfacing of `HMTimerTrigger` + calendar/significant-time events in `list/get`) — independent, ready to start whenever.

Refs #48.
