### PR TITLE
feat: surface HMTimerTrigger + calendar/significant-time events in list/get

### DIFF
--- a/Sources/homeclaw/HomeKit/AccessoryModel.swift
+++ b/Sources/homeclaw/HomeKit/AccessoryModel.swift
@@ -228,6 +228,53 @@ enum AccessoryModel {
         return dict
     }
 
+    /// Detailed view of a timer trigger including full scene/action breakdown,
+    /// matching the richness of `automationDetail` for HMEventTriggers.
+    static func timerTriggerDetail(_ trigger: HMTimerTrigger, homeName: String) -> [String: Any] {
+        var detail = timerTriggerSummary(trigger, homeName: homeName)
+
+        let actionSets: [[String: Any]] = trigger.actionSets.map { actionSet in
+            let actions: [[String: String]] = actionSet.actions.compactMap { action in
+                guard let writeAction = action as? HMCharacteristicWriteAction<NSCopying> else { return nil }
+                let characteristic = writeAction.characteristic
+                let accessory = characteristic.service?.accessory
+                return [
+                    "accessory": accessory?.name ?? "Unknown",
+                    "room": accessory?.room?.name ?? "Default Room",
+                    "characteristic": CharacteristicMapper.name(for: characteristic.characteristicType),
+                    "value": "\(writeAction.targetValue)",
+                ]
+            }
+            return [
+                "id": actionSet.uniqueIdentifier.uuidString,
+                "name": actionSet.name,
+                "action_count": actionSet.actions.count,
+                "actions": actions,
+            ]
+        }
+        detail["action_sets"] = actionSets
+
+        // Surface unparsed recurrence DateComponents for callers that want raw access.
+        // (Partial decoding lives in `timerTriggerSummary`'s event_summary.)
+        if let recurrence = trigger.recurrence {
+            var raw: [String: Int] = [:]
+            if let v = recurrence.day { raw["day"] = v }
+            if let v = recurrence.weekday { raw["weekday"] = v }
+            if let v = recurrence.weekOfMonth { raw["weekOfMonth"] = v }
+            if let v = recurrence.weekOfYear { raw["weekOfYear"] = v }
+            if let v = recurrence.month { raw["month"] = v }
+            if let v = recurrence.year { raw["year"] = v }
+            if let v = recurrence.hour { raw["hour"] = v }
+            if let v = recurrence.minute { raw["minute"] = v }
+            if let v = recurrence.second { raw["second"] = v }
+            if !raw.isEmpty {
+                detail["recurrence_raw"] = raw
+            }
+        }
+
+        return detail
+    }
+
     /// Summary of an automation (event trigger) for list views.
     static func automationSummary(_ trigger: HMEventTrigger, homeName: String) -> [String: Any] {
         var dict: [String: Any] = [
@@ -288,16 +335,24 @@ enum AccessoryModel {
         else if let sigEvent = trigger.events.first as? HMSignificantTimeEvent {
             let label = sigEvent.significantEvent == .sunrise ? "sunrise" : "sunset"
             var summary = "at \(label)"
-            if let off = sigEvent.offset, let m = off.minute, m != 0 {
-                summary += m > 0 ? "+\(m)m" : "\(m)m"
+            if let off = sigEvent.offset {
+                let totalMinutes = (off.hour ?? 0) * 60 + (off.minute ?? 0)
+                if totalMinutes != 0 {
+                    summary += totalMinutes > 0 ? "+\(totalMinutes)m" : "\(totalMinutes)m"
+                }
             }
             dict["event_summary"] = summary
             dict["trigger_type"] = "significant_time"
         }
+        // Unrecognized HMEvent subclass — keep schema's "unknown" contract
+        // consistent with `triggerSummary`'s fallback for non-HMEventTrigger triggers.
+        else {
+            dict["trigger_type"] = "unknown"
+        }
 
         // Surface auto-off duration (HMDurationEvent in endEvents).
         if let durationEvent = trigger.endEvents.compactMap({ $0 as? HMDurationEvent }).first {
-            let seconds = Int(durationEvent.duration)
+            let seconds = Int(durationEvent.duration.rounded())
             dict["duration_seconds"] = seconds
             if let existing = dict["event_summary"] as? String {
                 dict["event_summary"] = existing + " (off after \(formatDuration(seconds)))"

--- a/Sources/homeclaw/HomeKit/AccessoryModel.swift
+++ b/Sources/homeclaw/HomeKit/AccessoryModel.swift
@@ -178,7 +178,55 @@ enum AccessoryModel {
         return detail
     }
 
-    // MARK: - Automations (Event Triggers)
+    // MARK: - Automations (Triggers)
+
+    /// Dispatch summary by trigger subclass. Routes HMEventTrigger to `automationSummary`,
+    /// HMTimerTrigger to `timerTriggerSummary`, and returns a minimal placeholder for any
+    /// other HMTrigger subclass so unknown triggers are still visible to callers.
+    static func triggerSummary(_ trigger: HMTrigger, homeName: String) -> [String: Any] {
+        if let event = trigger as? HMEventTrigger {
+            return automationSummary(event, homeName: homeName)
+        }
+        if let timer = trigger as? HMTimerTrigger {
+            return timerTriggerSummary(timer, homeName: homeName)
+        }
+        return [
+            "id": trigger.uniqueIdentifier.uuidString,
+            "name": trigger.name,
+            "enabled": trigger.isEnabled,
+            "home": homeName,
+            "trigger_type": "unknown",
+        ]
+    }
+
+    /// Summary of a time-based timer trigger (Apple Home native time automation,
+    /// created via the iOS Home app).
+    static func timerTriggerSummary(_ trigger: HMTimerTrigger, homeName: String) -> [String: Any] {
+        var dict: [String: Any] = [
+            "id": trigger.uniqueIdentifier.uuidString,
+            "name": trigger.name,
+            "enabled": trigger.isEnabled,
+            "home": homeName,
+            "trigger_type": "timer",
+            "scene_count": trigger.actionSets.count,
+            "scenes": trigger.actionSets.map { $0.name },
+        ]
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        let timeOfDay = formatter.string(from: trigger.fireDate)
+        var summary = "at \(timeOfDay)"
+        if let recurrence = trigger.recurrence {
+            if let day = recurrence.day, day == 1 { summary += " daily" }
+            else if let weekday = recurrence.weekday {
+                let names = ["", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+                if (1...7).contains(weekday) { summary += " on \(names[weekday])s" }
+            }
+        }
+        dict["event_summary"] = summary
+        dict["fire_time"] = timeOfDay
+        dict["fire_date"] = ISO8601DateFormatter().string(from: trigger.fireDate)
+        return dict
+    }
 
     /// Summary of an automation (event trigger) for list views.
     static func automationSummary(_ trigger: HMEventTrigger, homeName: String) -> [String: Any] {
@@ -191,7 +239,7 @@ enum AccessoryModel {
             "scenes": trigger.actionSets.map { $0.name },
         ]
 
-        // Build a human-readable event summary from the first characteristic event
+        // Build a human-readable event summary from the first event.
         if let event = trigger.events.first as? HMCharacteristicEvent<NSCopying>,
            let accessory = event.characteristic.service?.accessory
         {
@@ -227,8 +275,43 @@ enum AccessoryModel {
                 ] as [String: Any]
             }
         }
+        // Calendar event (HH:MM time-of-day on an HMEventTrigger).
+        else if let calEvent = trigger.events.first as? HMCalendarEvent {
+            let dc = calEvent.fireDateComponents
+            if let hour = dc.hour, let minute = dc.minute {
+                dict["event_summary"] = String(format: "at %02d:%02d", hour, minute)
+                dict["fire_time"] = String(format: "%02d:%02d", hour, minute)
+            }
+            dict["trigger_type"] = "calendar"
+        }
+        // Significant-time event (sunrise/sunset).
+        else if let sigEvent = trigger.events.first as? HMSignificantTimeEvent {
+            let label = sigEvent.significantEvent == .sunrise ? "sunrise" : "sunset"
+            var summary = "at \(label)"
+            if let off = sigEvent.offset, let m = off.minute, m != 0 {
+                summary += m > 0 ? "+\(m)m" : "\(m)m"
+            }
+            dict["event_summary"] = summary
+            dict["trigger_type"] = "significant_time"
+        }
+
+        // Surface auto-off duration (HMDurationEvent in endEvents).
+        if let durationEvent = trigger.endEvents.compactMap({ $0 as? HMDurationEvent }).first {
+            let seconds = Int(durationEvent.duration)
+            dict["duration_seconds"] = seconds
+            if let existing = dict["event_summary"] as? String {
+                dict["event_summary"] = existing + " (off after \(formatDuration(seconds)))"
+            }
+        }
 
         return dict
+    }
+
+    /// Format a duration in seconds as a compact string (e.g. "5m", "2h", "30s").
+    private static func formatDuration(_ seconds: Int) -> String {
+        if seconds % 3600 == 0 { return "\(seconds / 3600)h" }
+        if seconds % 60 == 0 { return "\(seconds / 60)m" }
+        return "\(seconds)s"
     }
 
     /// Detailed view of an automation including all events and linked scenes.

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -694,9 +694,10 @@ final class HomeKitManager: NSObject, Observable {
         let targetHomes = filteredHomes(homeID: homeID)
         var results: [[String: Any]] = []
         for home in targetHomes {
-            let eventTriggers = home.triggers.compactMap { $0 as? HMEventTrigger }
-            for trigger in eventTriggers {
-                results.append(AccessoryModel.automationSummary(trigger, homeName: home.name))
+            // Iterate all triggers (event, timer, and any other HMTrigger subclass)
+            // so HMTimerTrigger automations created via the iOS Home app are visible.
+            for trigger in home.triggers {
+                results.append(AccessoryModel.triggerSummary(trigger, homeName: home.name))
             }
         }
         return results
@@ -705,10 +706,13 @@ final class HomeKitManager: NSObject, Observable {
     func getAutomation(id: String, homeID: String? = nil) async throws -> [String: Any] {
         await waitForReady()
         let home = try resolveHome(homeID: homeID)
-        guard let trigger = findTrigger(id: id, in: home) else {
-            throw ControlError.triggerNotFound(id)
+        if let trigger = findEventTrigger(id: id, in: home) {
+            return AccessoryModel.automationDetail(trigger, homeName: home.name)
         }
-        return AccessoryModel.automationDetail(trigger, homeName: home.name)
+        if let timer = findTimerTrigger(id: id, in: home) {
+            return AccessoryModel.timerTriggerSummary(timer, homeName: home.name)
+        }
+        throw ControlError.triggerNotFound(id)
     }
 
     func createAutomation(
@@ -999,17 +1003,20 @@ final class HomeKitManager: NSObject, Observable {
     ) async throws -> [String: Any] {
         await waitForReady()
         let home = try resolveHome(homeID: homeID)
-        guard let trigger = findTrigger(id: id, in: home) else {
+        // Use findAnyTrigger so HMTimerTrigger (Apple Home native time automations)
+        // can also be deleted, not just HMEventTrigger.
+        guard let trigger = findAnyTrigger(id: id, in: home) else {
             throw ControlError.triggerNotFound(id)
         }
 
         let triggerName = trigger.name
+        let sceneCount = trigger.actionSets.count
         if dryRun {
             return [
                 "dry_run": true,
                 "name": triggerName,
                 "home": home.name,
-                "scene_count": trigger.actionSets.count,
+                "scene_count": sceneCount,
             ] as [String: Any]
         }
 
@@ -1130,7 +1137,8 @@ final class HomeKitManager: NSObject, Observable {
     ) async throws -> [String: Any] {
         await waitForReady()
         let home = try resolveHome(homeID: homeID)
-        guard let trigger = findTrigger(id: id, in: home) else {
+        // Use findAnyTrigger so HMTimerTrigger automations can also be enabled/disabled.
+        guard let trigger = findAnyTrigger(id: id, in: home) else {
             throw ControlError.triggerNotFound(id)
         }
 
@@ -1148,13 +1156,34 @@ final class HomeKitManager: NSObject, Observable {
     // MARK: - Private Helpers
 
     private func findTrigger(id: String, in home: HMHome) -> HMEventTrigger? {
+        findEventTrigger(id: id, in: home)
+    }
+
+    /// Lookup an HMEventTrigger by UUID or name (case-insensitive).
+    private func findEventTrigger(id: String, in home: HMHome) -> HMEventTrigger? {
         let eventTriggers = home.triggers.compactMap { $0 as? HMEventTrigger }
-        // UUID first
         if let trigger = eventTriggers.first(where: { $0.uniqueIdentifier.uuidString == id }) {
             return trigger
         }
-        // Name fallback
         return eventTriggers.first(where: { $0.name.localizedCaseInsensitiveCompare(id) == .orderedSame })
+    }
+
+    /// Lookup an HMTimerTrigger (Apple Home native time automation) by UUID or name.
+    private func findTimerTrigger(id: String, in home: HMHome) -> HMTimerTrigger? {
+        let timerTriggers = home.triggers.compactMap { $0 as? HMTimerTrigger }
+        if let trigger = timerTriggers.first(where: { $0.uniqueIdentifier.uuidString == id }) {
+            return trigger
+        }
+        return timerTriggers.first(where: { $0.name.localizedCaseInsensitiveCompare(id) == .orderedSame })
+    }
+
+    /// Lookup any HMTrigger subclass by UUID or name. Used for delete/enable/disable
+    /// where the operation works on the abstract HMTrigger API regardless of subtype.
+    private func findAnyTrigger(id: String, in home: HMHome) -> HMTrigger? {
+        if let trigger = home.triggers.first(where: { $0.uniqueIdentifier.uuidString == id }) {
+            return trigger
+        }
+        return home.triggers.first(where: { $0.name.localizedCaseInsensitiveCompare(id) == .orderedSame })
     }
 
     private func findInputEventCharacteristic(

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -710,7 +710,7 @@ final class HomeKitManager: NSObject, Observable {
             return AccessoryModel.automationDetail(trigger, homeName: home.name)
         }
         if let timer = findTimerTrigger(id: id, in: home) {
-            return AccessoryModel.timerTriggerSummary(timer, homeName: home.name)
+            return AccessoryModel.timerTriggerDetail(timer, homeName: home.name)
         }
         throw ControlError.triggerNotFound(id)
     }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -203,7 +203,7 @@ export const tools = [
   },
   {
     name: 'homekit_automations',
-    description: 'Manage HomeKit automations (event triggers). List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value.',
+    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value. List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21015,7 +21015,7 @@ var tools = [
   },
   {
     name: "homekit_automations",
-    description: "Manage HomeKit automations (event triggers). List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value.",
+    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value. List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Motivation

PR 2 of 6 from #48 — pure read-side. `automations list` and `automations get` are blind to four classes of HomeKit automation today:

1. **`HMTimerTrigger`** — Apple Home native time automations (created via the iOS Home app). Listed as nothing today (filtered out by an `HMEventTrigger` cast).
2. **`HMCalendarEvent` on `HMEventTrigger`** — HH:MM time-of-day triggers (PR5 will create these).
3. **`HMSignificantTimeEvent` on `HMEventTrigger`** — sunrise/sunset triggers (PR5).
4. **`HMDurationEvent` in `endEvents`** — auto-revert duration (PR4).

This PR fixes (1) and (2)/(3) for any timer/calendar/significant-time automations the user already has from Apple Home or other sources, and lays the read-side groundwork for the write-side surfaces in PRs 4 and 5.

Bonus: `delete_automation` and `enable/disable_automation` now work on `HMTimerTrigger` too. Currently they fail on timer triggers because the underlying `findTrigger` helper only returns `HMEventTrigger`.

## What changed

**Swift side**

- **`AccessoryModel.swift`** — new `triggerSummary(_:homeName:)` dispatcher routes by `HMTrigger` subclass; new `timerTriggerSummary` for `HMTimerTrigger`; `automationSummary` now decodes `HMCalendarEvent` and `HMSignificantTimeEvent` in `trigger.events`, and surfaces `HMDurationEvent` from `trigger.endEvents`. New `formatDuration` helper.
- **`HomeKitManager.swift`** — `listAutomations` iterates `home.triggers` (no `HMEventTrigger` cast) so timer triggers appear; `getAutomation` falls back to `findTimerTrigger` if no event trigger matches; `delete_automation` and `enable/disable_automation` use a new `findAnyTrigger` helper. New helpers: `findEventTrigger`, `findTimerTrigger`, `findAnyTrigger`. Existing `findTrigger` kept as a thin alias to `findEventTrigger` so internal callers that need event-only typing (`updateAutomationActionSets`, `findTriggerCharacteristic`) keep working.

**MCP/lib side**

- **`lib/schemas.js`** — `homekit_automations` description updated to advertise the new visibility and response fields. Schema input properties unchanged (no new request-side surface).
- **`lib/handlers/homekit.js`** — no changes needed; the `list`/`get` handlers are opaque pass-throughs.
- **`mcp-server/dist/server.js`** — rebuilt via `npm run build:mcp`.

## New response fields

| Field | Type | Set on |
|---|---|---|
| `trigger_type` | string enum | every result row |
| `fire_time` | `"HH:MM"` | calendar + timer triggers |
| `fire_date` | ISO 8601 | timer triggers |
| `duration_seconds` | int | when `HMDurationEvent` in `endEvents` |

`trigger_type` values: `"button"` and `"characteristic"` (existing — preserved), plus new `"calendar"`, `"significant_time"`, `"timer"`, `"unknown"`.

`event_summary` formats also extended:
- `"at HH:MM"` (calendar)
- `"at sunrise"` / `"at sunrise+30m"` / `"at sunset-15m"` (significant-time)
- `"<existing> (off after Xm)"` (when HMDurationEvent present)
- Apple Home timer triggers: `"at HH:MM"` plus optional `" daily"` or `" on Mondays"` from the recurrence

## Testing status

- ✅ `swift build --product homeclaw-cli` — clean
- ✅ `npm install && npm run build:mcp` — clean
- ✅ `automations list --help` and `automations get --help` render unchanged (no new flags)
- ⚠️ Same caveat as #49 — runtime end-to-end against real HomeKit not verified on this branch's bundle ID (provisioning mismatch). The decode logic for HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent / HMTimerTrigger is all standard accessor-call code on Apple's frameworks; no novel framework-interaction patterns. Happy to wait for your verification.

## Notes

- `findTrigger` (the existing helper) is kept as `findEventTrigger`'s alias for backward compatibility with internal callers. It can be removed after a follow-up audit but I didn't want to scope-creep this PR.
- I left `flattenTopAnd` (a multi-condition decoder refactor that lives on my private fork) out of this PR — the matching `extractConditions` decoder doesn't exist in upstream yet. It will land naturally with PR3 or PR6 where the multi-condition write side ships.
- No build-number / version-manifest changes.

## Sequence

Per #48: PR 2 of 6. Independent of PR 1 (#49). Next blocked-on-review: PR 3 (`--condition` + `--time` on create), which depends on PR 1 landing first.

Refs #48.
