### PR TITLE
feat: multi-condition predicate composition (--condition, --time-after/before)

### DIFF
--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -170,6 +170,15 @@ struct CreateAutomation: ParsableCommand {
     @Option(name: .long, help: "Comma-separated weekdays the automation may fire on: mon,tue,wed,thu,fri,sat,sun (or numeric 1-7 where 1=Sun). When omitted, the automation fires every day.")
     var days: String?
 
+    @Option(name: .long, parsing: .upToNextOption, help: "Extra characteristic predicate ANDed into the trigger as 'accessory:property:value' (repeatable). Example: 'Front Door:contact_state:0'. Note: accessory names containing colons are not supported via --condition; use the MCP conditions array instead.")
+    var condition: [String] = []
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires after the given event. Format: '<sunrise|sunset>[±N]' where N is minutes (e.g. 'sunset-30'). Offsets >1440 (24h) are rejected. Implies weekday auto-fill if --days is omitted.")
+    var timeAfter: [String] = []
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires before the given event. Format: '<sunrise|sunset>[±N]' where N is minutes (e.g. 'sunrise+15'). Offsets >1440 (24h) are rejected. Implies weekday auto-fill if --days is omitted.")
+    var timeBefore: [String] = []
+
     @Option(name: .long, help: "Home name or UUID (defaults to primary home)")
     var home: String?
 
@@ -253,6 +262,38 @@ struct CreateAutomation: ParsableCommand {
             args["weekdays"] = Array(Swift.Set(weekdays)).sorted()
         }
 
+        if !condition.isEmpty {
+            // Parse "accessory:property:value" — same shape as --action.
+            // Three required parts; reject malformed input early so the user gets a
+            // clear ValidationError before we touch HomeKit.
+            var parsedConditions: [[String: String]] = []
+            for raw in condition {
+                let parts = raw.split(separator: ":", maxSplits: 2).map(String.init)
+                guard parts.count == 3 else {
+                    throw ValidationError("Invalid --condition '\(raw)'. Use 'accessory:property:value' (note: accessory names containing colons are not supported via --condition; use the MCP conditions array instead).")
+                }
+                let accessoryPart = parts[0].trimmingCharacters(in: .whitespaces)
+                let propertyPart = parts[1].trimmingCharacters(in: .whitespaces)
+                let valuePart = parts[2].trimmingCharacters(in: .whitespaces)
+                guard !accessoryPart.isEmpty, !propertyPart.isEmpty, !valuePart.isEmpty else {
+                    throw ValidationError("Invalid --condition '\(raw)'. Each of accessory/property/value must be non-empty.")
+                }
+                parsedConditions.append([
+                    "accessory": accessoryPart,
+                    "property": propertyPart,
+                    "value": valuePart,
+                ])
+            }
+            args["conditions"] = parsedConditions
+        }
+
+        if !timeAfter.isEmpty {
+            args["time_after"] = try timeAfter.map { try validateTimeSpec($0, flag: "--time-after") }
+        }
+        if !timeBefore.isEmpty {
+            args["time_before"] = try timeBefore.map { try validateTimeSpec($0, flag: "--time-before") }
+        }
+
         if let home { args["home_id"] = home }
 
         let response = try SocketClient.sendAny(command: "create_automation", args: args)
@@ -302,9 +343,7 @@ struct CreateAutomation: ParsableCommand {
             } else if let sceneName = result["scene"] as? String {
                 print("  Scene: \(sceneName)")
             }
-            if let weekdays = result["weekdays"] as? [Int], !weekdays.isEmpty {
-                print("  Days: \(formatWeekdays(weekdays))")
-            }
+            printPredicateFields(from: result)
         } else {
             if isInline {
                 print("Created automation '\(autoName)' with \(actionCount ?? 0) inline action(s)")
@@ -314,9 +353,7 @@ struct CreateAutomation: ParsableCommand {
                 print("Created automation '\(autoName)'")
                 print("  \(triggerDescription) → \(sceneName)")
             }
-            if let weekdays = result["weekdays"] as? [Int], !weekdays.isEmpty {
-                print("  Days: \(formatWeekdays(weekdays))")
-            }
+            printPredicateFields(from: result)
         }
     }
 
@@ -324,6 +361,71 @@ struct CreateAutomation: ParsableCommand {
     private func formatWeekdays(_ weekdays: [Int]) -> String {
         let names = ["", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
         return weekdays.compactMap { (1...7).contains($0) ? names[$0] : nil }.joined(separator: ",")
+    }
+
+    /// Validate a `--time-after` / `--time-before` spec. Format: `<sunrise|sunset>[±N]`.
+    /// Mirrors `TimeCondition.parse` in HomeKitManager but throws CLI-shaped errors
+    /// pointing at the offending flag. Defence-in-depth: SocketServer re-validates.
+    private func validateTimeSpec(_ raw: String, flag: String) throws -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        let lower = trimmed.lowercased()
+        guard !lower.isEmpty else {
+            throw ValidationError("\(flag) value is empty. Use 'sunrise', 'sunset', or '<sun-event>±<minutes>'.")
+        }
+
+        let rest: String
+        if lower.hasPrefix("sunrise") {
+            rest = String(lower.dropFirst("sunrise".count))
+        } else if lower.hasPrefix("sunset") {
+            rest = String(lower.dropFirst("sunset".count))
+        } else {
+            throw ValidationError("Invalid \(flag) '\(raw)'. Sun event must be 'sunrise' or 'sunset' (noon/midnight not supported).")
+        }
+
+        if rest.isEmpty { return lower }
+
+        guard let sign = rest.first, sign == "+" || sign == "-" else {
+            throw ValidationError("Invalid \(flag) '\(raw)'. Offset must start with + or - (e.g. 'sunset-30').")
+        }
+        let numStr = String(rest.dropFirst())
+        guard !numStr.isEmpty else {
+            throw ValidationError("Invalid \(flag) '\(raw)'. Missing offset minutes after '\(sign)'.")
+        }
+        guard let magnitude = Int(numStr), magnitude >= 0 else {
+            throw ValidationError("Invalid \(flag) '\(raw)'. Offset must be a non-negative integer number of minutes.")
+        }
+        if magnitude > 1440 {
+            throw ValidationError("Invalid \(flag) '\(raw)'. Offsets larger than 1440 minutes (24h) are rejected — that's almost certainly a typo; use --days for weekday gating.")
+        }
+        return lower
+    }
+
+    /// Print the conditions / time conditions / weekdays portion of a create response.
+    /// Centralised so dry-run and success paths render identically.
+    private func printPredicateFields(from result: [String: Any]) {
+        if let conditions = result["conditions"] as? [[String: String]], !conditions.isEmpty {
+            print("  Conditions:")
+            for c in conditions {
+                let acc = c["accessory"] ?? "?"
+                let prop = c["property"] ?? "?"
+                let val = c["value"] ?? "?"
+                print("    \(acc): \(prop) = \(val)")
+            }
+        }
+        if let timeAfter = result["time_after"] as? [String], !timeAfter.isEmpty {
+            print("  Only after: \(timeAfter.joined(separator: ", "))")
+        }
+        if let timeBefore = result["time_before"] as? [String], !timeBefore.isEmpty {
+            print("  Only before: \(timeBefore.joined(separator: ", "))")
+        }
+        let autoFilled = result["weekdays_auto_filled"] as? Bool ?? false
+        if let weekdays = result["weekdays"] as? [Int], !weekdays.isEmpty {
+            if autoFilled {
+                print("  Days: every day (auto-filled — iOS 15+ requires weekday gating on time-conditional automations)")
+            } else {
+                print("  Days: \(formatWeekdays(weekdays))")
+            }
+        }
     }
 }
 

--- a/Sources/homeclaw/HomeKit/AccessoryModel.swift
+++ b/Sources/homeclaw/HomeKit/AccessoryModel.swift
@@ -359,6 +359,16 @@ enum AccessoryModel {
             }
         }
 
+        // Brief condition count in the event summary so list views show the predicate is non-trivial.
+        // Full structured conditions are surfaced by `automationDetail` and `extractConditions`.
+        // We pass `home: nil` here because this summary path doesn't have access to it; weekdays
+        // and time predicates are still counted, characteristic accessory names just won't resolve.
+        // (`automationDetail` uses the home-scoped variant for richer output.)
+        let conditionCount = countConditions(trigger.predicate)
+        if conditionCount > 0, let existing = dict["event_summary"] as? String {
+            dict["event_summary"] = existing + " (+\(conditionCount) condition\(conditionCount == 1 ? "" : "s"))"
+        }
+
         return dict
     }
 
@@ -370,7 +380,8 @@ enum AccessoryModel {
     }
 
     /// Detailed view of an automation including all events and linked scenes.
-    static func automationDetail(_ trigger: HMEventTrigger, homeName: String) -> [String: Any] {
+    /// Pass `home` to resolve characteristic-condition predicates to accessory names.
+    static func automationDetail(_ trigger: HMEventTrigger, homeName: String, home: HMHome? = nil) -> [String: Any] {
         var detail = automationSummary(trigger, homeName: homeName)
 
         let events: [[String: Any]] = trigger.events.compactMap { event in
@@ -418,7 +429,154 @@ enum AccessoryModel {
         }
         detail["action_sets"] = actionSets
 
+        // Decode the trigger predicate into structured conditions. Skipped when there's no
+        // predicate at all, or when nothing decodes (rather than emitting an empty array
+        // — keeps existing JSON consumers from seeing a new-but-always-empty key).
+        let conditions = extractConditions(trigger.predicate, in: home)
+        if !conditions.isEmpty {
+            detail["conditions"] = conditions
+        }
+
         return detail
+    }
+
+    // MARK: - Predicate decoding
+
+    /// Decode an automation trigger's NSPredicate into a structured array of conditions.
+    /// Returns dicts with a `type` discriminator: `characteristic`, `weekdays`, `time`, or
+    /// `unknown`. Each kind has its own field shape (see inline comments). Pass `home` to
+    /// resolve characteristic UUIDs to accessory names; without it characteristic conditions
+    /// fall back to a `characteristic_id` lookup hint.
+    static func extractConditions(_ predicate: NSPredicate?, in home: HMHome?) -> [[String: Any]] {
+        guard let predicate else { return [] }
+
+        // UUID → (accessory, characteristic) lookup so we can name characteristic conditions.
+        var charMap: [String: (accessory: HMAccessory, characteristic: HMCharacteristic)] = [:]
+        if let home {
+            for accessory in home.accessories {
+                for service in accessory.services {
+                    for char in service.characteristics {
+                        charMap[char.uniqueIdentifier.uuidString.uppercased()] = (accessory, char)
+                    }
+                }
+            }
+        }
+
+        var subpredicates: [NSPredicate] = []
+        flattenTopAnd(predicate, into: &subpredicates)
+
+        return subpredicates.compactMap { sub -> [String: Any]? in
+            // Weekday OR-compound (--days output): OR of comparisons against DateComponents.weekday.
+            if let orCompound = sub as? NSCompoundPredicate, orCompound.compoundPredicateType == .or {
+                var weekdays: [Int] = []
+                for inner in (orCompound.subpredicates as? [NSPredicate] ?? []) {
+                    if let cmp = inner as? NSComparisonPredicate,
+                       let dc = (cmp.rightExpression.constantValue ?? cmp.leftExpression.constantValue) as? DateComponents,
+                       let wd = dc.weekday
+                    {
+                        weekdays.append(wd)
+                    }
+                }
+                if !weekdays.isEmpty {
+                    let names = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+                    let sorted = weekdays.sorted()
+                    return [
+                        "type": "weekdays",
+                        "weekdays": sorted,
+                        "summary": sorted.map { names[$0 - 1] }.joined(separator: ","),
+                    ]
+                }
+            }
+
+            // Single-weekday predicate (rare — produced when --days has exactly one entry).
+            if let cmp = sub as? NSComparisonPredicate,
+               let dc = (cmp.rightExpression.constantValue ?? cmp.leftExpression.constantValue) as? DateComponents,
+               let wd = dc.weekday
+            {
+                let names = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+                return ["type": "weekdays", "weekdays": [wd], "summary": names[wd - 1]]
+            }
+
+            // Sun-relative time predicate (--time-after / --time-before): NSComparisonPredicate
+            // referencing the `sunrise`/`sunset` HMSignificantEvent string. We can't reliably
+            // recover the offset from the public predicate API, so offset_minutes is omitted
+            // when not 0/representable; the field is always present for shape stability.
+            if let cmp = sub as? NSComparisonPredicate {
+                for expr in [cmp.leftExpression, cmp.rightExpression] {
+                    if let eventStr = expr.constantValue as? String,
+                       (eventStr == HMSignificantEvent.sunrise.rawValue || eventStr == HMSignificantEvent.sunset.rawValue)
+                    {
+                        let eventName = eventStr == HMSignificantEvent.sunrise.rawValue ? "sunrise" : "sunset"
+                        let isBefore = cmp.predicateOperatorType == .lessThan || cmp.predicateOperatorType == .lessThanOrEqualTo
+                        let relation = isBefore ? "before" : "after"
+                        return [
+                            "type": "time",
+                            "relation": relation,
+                            "event": eventName,
+                            "summary": "\(relation) \(eventName)",
+                        ]
+                    }
+                }
+            }
+
+            // Characteristic predicate: HomeKit wraps each as a 2-sub AND
+            // (characteristic == <HMCharacteristic> AND characteristicValue == X).
+            guard let compound = sub as? NSCompoundPredicate, compound.compoundPredicateType == .and else { return nil }
+            let inner = compound.subpredicates as? [NSPredicate] ?? []
+            var foundChar: HMCharacteristic?
+            var foundValue: String?
+            for innerSub in inner {
+                guard let cmp = innerSub as? NSComparisonPredicate else { continue }
+                if let hmChar = cmp.rightExpression.constantValue as? HMCharacteristic {
+                    foundChar = hmChar
+                } else if let val = cmp.rightExpression.constantValue {
+                    foundValue = "\(val)"
+                }
+            }
+            guard let char = foundChar, let value = foundValue else { return nil }
+            let uuid = char.uniqueIdentifier.uuidString.uppercased()
+            if let entry = charMap[uuid] {
+                return [
+                    "type": "characteristic",
+                    "accessory": entry.accessory.name,
+                    "accessory_id": entry.accessory.uniqueIdentifier.uuidString,
+                    "property": CharacteristicMapper.name(for: entry.characteristic.characteristicType),
+                    "operator": "==",
+                    "value": value,
+                ]
+            }
+            // Fallback when home lookup is unavailable — surface the raw UUID so callers can resolve.
+            return [
+                "type": "characteristic",
+                "characteristic_id": uuid,
+                "operator": "==",
+                "value": value,
+            ]
+        }
+    }
+
+    /// Lightweight count of decoded conditions, used by `automationSummary` to annotate
+    /// `event_summary` without paying the home-scoped lookup cost.
+    private static func countConditions(_ predicate: NSPredicate?) -> Int {
+        extractConditions(predicate, in: nil).count
+    }
+
+    /// Flatten nested top-level AND compounds into a flat subpredicate list.
+    /// Successive `updatePredicate` mutations (e.g. `add-condition` calls in a future PR)
+    /// can produce AND-of-ANDs; treating those as a flat list keeps the decoder stable.
+    /// A single-condition predicate of shape `(char == X AND value == Y)` is a leaf — both
+    /// subs are NSComparisonPredicate, not compounds — so we keep it as one entry.
+    private static func flattenTopAnd(_ p: NSPredicate, into out: inout [NSPredicate]) {
+        guard let cmp = p as? NSCompoundPredicate, cmp.compoundPredicateType == .and else {
+            out.append(p)
+            return
+        }
+        let subs = cmp.subpredicates as? [NSPredicate] ?? []
+        if subs.allSatisfy({ $0 is NSCompoundPredicate }) {
+            for sub in subs { flattenTopAnd(sub, into: &out) }
+        } else {
+            out.append(p)
+        }
     }
 
     /// Maps press type integer to human-readable name.

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -1,5 +1,90 @@
 import HomeKit
 
+// MARK: - Time Condition
+
+/// A before/after sun-relative time predicate for automation triggers.
+/// Composes via `HMEventTrigger.predicateForEvaluatingTrigger(occurringBefore/After:applyingOffset:)`.
+///
+/// Format: `<sun-event>[±<minutes>]` where sun-event is `sunrise` or `sunset` and the offset
+/// is signed minutes (e.g. `sunset-30`, `sunrise+15`, `sunset`).
+struct TimeCondition {
+    enum Relation { case after, before }
+    enum Event {
+        case sunrise, sunset
+        var significantEvent: String {
+            self == .sunrise ? HMSignificantEvent.sunrise.rawValue : HMSignificantEvent.sunset.rawValue
+        }
+    }
+
+    let relation: Relation
+    let event: Event
+    let offsetMinutes: Int   // positive = after the event, negative = before
+
+    /// Reject offsets larger than 24h — almost certainly a typo (the user probably meant a
+    /// `--days` filter). Smaller-than-24h but suspicious offsets (>720m / 12h) are allowed
+    /// to keep the parser permissive; the CLI flag layer surfaces them in `--help`.
+    static let maxOffsetMinutes = 1440
+
+    func predicate() -> NSPredicate? {
+        var offset: DateComponents? = nil
+        if offsetMinutes != 0 {
+            var dc = DateComponents()
+            dc.minute = offsetMinutes
+            offset = dc
+        }
+        // The string-form predicate APIs are marked deprecated in Catalyst 13.1+, but the
+        // replacement (HMSignificantTimeEvent-taking variant) is not exposed to Swift —
+        // only the DateComponents and HMPresenceEvent overloads bridge. Mirror the existing
+        // weekday predicate construction (`occurringOn:`) which is in the same boat.
+        switch relation {
+        case .after:
+            return HMEventTrigger.predicateForEvaluatingTrigger(
+                occurringAfter: event.significantEvent,
+                applyingOffset: offset
+            )
+        case .before:
+            return HMEventTrigger.predicateForEvaluatingTrigger(
+                occurringBefore: event.significantEvent,
+                applyingOffset: offset
+            )
+        }
+    }
+
+    /// Parse a sun-relative time spec. Returns nil for malformed input;
+    /// throws via the caller's `ValidationError` boundary.
+    /// Accepts: `sunrise`, `sunset`, `sunrise+15`, `sunset-30`. Rejects: bare offsets,
+    /// `noon`/`midnight`, missing-numeric offset (`sunset+`), unknown events.
+    static func parse(_ raw: String, relation: Relation) -> TimeCondition? {
+        let s = raw.lowercased().trimmingCharacters(in: .whitespaces)
+        guard !s.isEmpty else { return nil }
+
+        let event: Event
+        var rest: String
+        if s.hasPrefix("sunrise") {
+            event = .sunrise
+            rest = String(s.dropFirst("sunrise".count))
+        } else if s.hasPrefix("sunset") {
+            event = .sunset
+            rest = String(s.dropFirst("sunset".count))
+        } else {
+            return nil
+        }
+
+        rest = rest.trimmingCharacters(in: .whitespaces)
+        if rest.isEmpty {
+            return TimeCondition(relation: relation, event: event, offsetMinutes: 0)
+        }
+
+        // Must start with + or -, followed by a positive integer (minutes).
+        guard let sign = rest.first, sign == "+" || sign == "-" else { return nil }
+        let numStr = String(rest.dropFirst())
+        guard !numStr.isEmpty, let magnitude = Int(numStr), magnitude >= 0 else { return nil }
+        if magnitude > maxOffsetMinutes { return nil }
+        let offset = sign == "+" ? magnitude : -magnitude
+        return TimeCondition(relation: relation, event: event, offsetMinutes: offset)
+    }
+}
+
 /// Central HomeKit interface. Must run on @MainActor because HMHomeManager
 /// requires main-thread delegate callbacks.
 @MainActor
@@ -775,7 +860,7 @@ final class HomeKitManager: NSObject, Observable {
         await waitForReady()
         let home = try resolveHome(homeID: homeID)
         if let trigger = findEventTrigger(id: id, in: home) {
-            return AccessoryModel.automationDetail(trigger, homeName: home.name)
+            return AccessoryModel.automationDetail(trigger, homeName: home.name, home: home)
         }
         if let timer = findTimerTrigger(id: id, in: home) {
             return AccessoryModel.timerTriggerDetail(timer, homeName: home.name)
@@ -793,6 +878,8 @@ final class HomeKitManager: NSObject, Observable {
         actions: [[String: String]]? = nil,
         serviceIndex: Int? = nil,
         weekdays: [Int] = [],
+        conditions: [[String: String]] = [],
+        timeConditions: [TimeCondition] = [],
         homeID: String? = nil,
         dryRun: Bool = false
     ) async throws -> [String: Any] {
@@ -801,6 +888,92 @@ final class HomeKitManager: NSObject, Observable {
 
         guard let accessory = findAccessory(id: accessoryID, homeID: homeID) else {
             throw ControlError.accessoryNotFound(accessoryID)
+        }
+
+        // Resolve & validate condition predicates up-front so we fail before mutating HomeKit.
+        // Each condition must reference a real accessory + characteristic; values must parse.
+        // The resolved tuples are then used both for predicate construction (Step 1b) and for
+        // structured echo back in the result dict.
+        struct ResolvedCondition {
+            let accessory: HMAccessory
+            let characteristic: HMCharacteristic
+            let property: String
+            let value: NSCopying & NSObjectProtocol
+            let rawValue: String
+        }
+        var resolvedConditions: [ResolvedCondition] = []
+        for cond in conditions {
+            guard let condAccessoryID = cond["accessory"],
+                  let condProperty = cond["property"],
+                  let condValueStr = cond["value"],
+                  !condAccessoryID.isEmpty, !condProperty.isEmpty, !condValueStr.isEmpty
+            else {
+                throw ControlError.invalidArgument("Condition must have non-empty 'accessory', 'property', and 'value' keys")
+            }
+            // Match createAutomation's own resolution: UUID first, then case-insensitive name
+            // (with optional `room` disambiguator if the caller supplied one).
+            let condAccessory: HMAccessory
+            if let found = home.accessories.first(where: { $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(condAccessoryID) == .orderedSame }) {
+                condAccessory = found
+            } else if let found = findAccessoryByName(condAccessoryID, room: cond["room"], in: home) {
+                condAccessory = found
+            } else {
+                throw ControlError.accessoryNotFound(condAccessoryID)
+            }
+            guard let condChar = findCharacteristicByDescription(on: condAccessory, property: condProperty) else {
+                throw ControlError.invalidArgument("Characteristic '\(condProperty)' not found on '\(condAccessory.name)' for --condition")
+            }
+            guard let parsed = parseActionValue(condValueStr, property: condProperty) else {
+                throw ControlError.invalidArgument("Cannot parse condition value '\(condValueStr)' for '\(condProperty)'")
+            }
+            resolvedConditions.append(ResolvedCondition(
+                accessory: condAccessory,
+                characteristic: condChar,
+                property: condProperty,
+                value: parsed,
+                rawValue: condValueStr
+            ))
+        }
+
+        // iOS 15+ marks time-conditional automations without weekday gating as "unreliable".
+        // Auto-fill all 7 days when --time-after / --time-before is set but --days is not,
+        // so the automation actually fires. Surface this via `weekdays_auto_filled` so the
+        // CLI/MCP caller knows we made a behavioural decision on their behalf.
+        let weekdaysAutoFilled = !timeConditions.isEmpty && weekdays.isEmpty
+        let effectiveWeekdays: [Int] = weekdaysAutoFilled ? [1, 2, 3, 4, 5, 6, 7] : weekdays
+
+        // Echo conditions / time conditions back to the caller in a stable, structured shape.
+        // Always set when input was provided so dry-run and success responses agree.
+        let conditionsEcho: [[String: String]] = resolvedConditions.map {
+            [
+                "accessory": $0.accessory.name,
+                "accessory_id": $0.accessory.uniqueIdentifier.uuidString,
+                "property": $0.property,
+                "value": $0.rawValue,
+            ]
+        }
+        let timeAfterEcho: [String] = timeConditions.compactMap {
+            guard $0.relation == .after else { return nil }
+            let ev = $0.event == .sunrise ? "sunrise" : "sunset"
+            if $0.offsetMinutes == 0 { return ev }
+            return $0.offsetMinutes > 0 ? "\(ev)+\($0.offsetMinutes)" : "\(ev)\($0.offsetMinutes)"
+        }
+        let timeBeforeEcho: [String] = timeConditions.compactMap {
+            guard $0.relation == .before else { return nil }
+            let ev = $0.event == .sunrise ? "sunrise" : "sunset"
+            if $0.offsetMinutes == 0 { return ev }
+            return $0.offsetMinutes > 0 ? "\(ev)+\($0.offsetMinutes)" : "\(ev)\($0.offsetMinutes)"
+        }
+        // Closure used by both dry-run and success paths to attach predicate-related fields.
+        // Keeping the shape identical between paths means callers/tests don't need to special-case.
+        let attachPredicateFields: ([String: Any]) -> [String: Any] = { existing in
+            var r = existing
+            if !effectiveWeekdays.isEmpty { r["weekdays"] = effectiveWeekdays }
+            if weekdaysAutoFilled { r["weekdays_auto_filled"] = true }
+            if !conditionsEcho.isEmpty { r["conditions"] = conditionsEcho }
+            if !timeAfterEcho.isEmpty { r["time_after"] = timeAfterEcho }
+            if !timeBeforeEcho.isEmpty { r["time_before"] = timeBeforeEcho }
+            return r
         }
 
         // Resolve the trigger characteristic and value based on trigger mode
@@ -863,8 +1036,7 @@ final class HomeKitManager: NSObject, Observable {
                     result["characteristic"] = characteristic
                     result["trigger_value"] = triggerValue
                 }
-                if !weekdays.isEmpty { result["weekdays"] = weekdays }
-                return result
+                return attachPredicateFields(result)
             }
 
             // Action sets created via the public API are always visible in the Home app
@@ -918,8 +1090,7 @@ final class HomeKitManager: NSObject, Observable {
                     result["characteristic"] = characteristic
                     result["trigger_value"] = triggerValue
                 }
-                if !weekdays.isEmpty { result["weekdays"] = weekdays }
-                return result
+                return attachPredicateFields(result)
             }
 
             actionSet = existingSet
@@ -949,28 +1120,58 @@ final class HomeKitManager: NSObject, Observable {
             }
         }
 
-        // Step 1b: Apply weekday predicate (iOS 15+ marks time-conditional automations
-        // without weekday gating as "unreliable"; explicit weekdays are the workaround).
-        // The OR of per-day predicates is AND'd with the trigger's existing predicate.
-        if !weekdays.isEmpty {
-            let dayPredicates: [NSPredicate] = weekdays.map { weekday in
+        // Step 1b: Build the combined trigger predicate from weekdays + conditions +
+        // time conditions and apply it in a single `updatePredicate` call.
+        //
+        // Only the LAST `updatePredicate` call sticks, so all three predicate kinds must be
+        // composed together. The structure is one outer AND:
+        //
+        //   AND(
+        //     existing-trigger-predicate,                  // currently always nil at this point
+        //     OR(weekday=1, weekday=2, ...),               // from --days / auto-fill
+        //     characteristic-condition-1,                  // from each --condition
+        //     characteristic-condition-2,
+        //     time-condition-1,                            // from each --time-after / --time-before
+        //     ...
+        //   )
+        //
+        // If only one of these is present, we either skip the call entirely (none) or pass the
+        // single predicate directly (no compound wrapper). Failure rolls back the orphan trigger
+        // (and inline action set if we created one), mirroring the action-set-link rollback path.
+        var subpredicates: [NSPredicate] = []
+        if let existing = trigger.predicate { subpredicates.append(existing) }
+        if !effectiveWeekdays.isEmpty {
+            let dayPredicates: [NSPredicate] = effectiveWeekdays.map { weekday in
                 var dc = DateComponents()
                 dc.weekday = weekday
                 return HMEventTrigger.predicateForEvaluatingTrigger(occurringOn: dc)
             }
-            let weekdayPredicate: NSPredicate = dayPredicates.count == 1
-                ? dayPredicates[0]
-                : NSCompoundPredicate(orPredicateWithSubpredicates: dayPredicates)
-            let combinedPredicate: NSPredicate
-            if let existing = trigger.predicate {
-                combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [existing, weekdayPredicate])
-            } else {
-                combinedPredicate = weekdayPredicate
-            }
+            subpredicates.append(
+                dayPredicates.count == 1
+                    ? dayPredicates[0]
+                    : NSCompoundPredicate(orPredicateWithSubpredicates: dayPredicates)
+            )
+        }
+        for cond in resolvedConditions {
+            subpredicates.append(
+                HMEventTrigger.predicateForEvaluatingTrigger(
+                    cond.characteristic,
+                    relatedBy: .equalTo,
+                    toValue: cond.value
+                )
+            )
+        }
+        for tc in timeConditions {
+            if let p = tc.predicate() { subpredicates.append(p) }
+        }
+        if !subpredicates.isEmpty {
+            let combinedPredicate: NSPredicate = subpredicates.count == 1
+                ? subpredicates[0]
+                : NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
             do {
                 try await homeKitAsync { trigger.updatePredicate(combinedPredicate, completionHandler: $0) }
             } catch {
-                // Cleanup orphaned trigger on predicate failure
+                // Cleanup orphaned trigger on predicate failure (no inline action set linked yet).
                 try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                     home.removeTrigger(trigger) { err in
                         if let err { continuation.resume(throwing: err) }
@@ -1054,10 +1255,7 @@ final class HomeKitManager: NSObject, Observable {
         } else {
             result["scene"] = actionSet.name
         }
-        if !weekdays.isEmpty {
-            result["weekdays"] = weekdays
-        }
-        return result
+        return attachPredicateFields(result)
     }
 
     /// Resolve action definitions to HomeKit accessory/characteristic/value tuples.

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -708,6 +708,26 @@ final class SocketServer: @unchecked Sendable {
                 let weekdays = (args["weekdays"] as? [Int])
                     ?? (args["weekdays"] as? [String])?.compactMap(Int.init)
                     ?? []
+                let conditions = (args["conditions"] as? [[String: String]]) ?? []
+                // Parse sun-relative time predicates. The CLI/MCP layer pre-validates format,
+                // but defensively re-validate here so direct socket clients can't bypass it.
+                let timeAfterRaw = (args["time_after"] as? [String]) ?? []
+                let timeBeforeRaw = (args["time_before"] as? [String]) ?? []
+                var timeConditions: [TimeCondition] = []
+                for raw in timeAfterRaw {
+                    guard let tc = TimeCondition.parse(raw, relation: .after) else {
+                        return encodeResponse(success: false,
+                            error: "Invalid 'time_after' value '\(raw)'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunset-30').")
+                    }
+                    timeConditions.append(tc)
+                }
+                for raw in timeBeforeRaw {
+                    guard let tc = TimeCondition.parse(raw, relation: .before) else {
+                        return encodeResponse(success: false,
+                            error: "Invalid 'time_before' value '\(raw)'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunrise+15').")
+                    }
+                    timeConditions.append(tc)
+                }
                 result = try await hk.createAutomation(
                     name: name,
                     accessoryID: accessoryID,
@@ -718,6 +738,8 @@ final class SocketServer: @unchecked Sendable {
                     actions: actions,
                     serviceIndex: serviceIndex,
                     weekdays: weekdays,
+                    conditions: conditions,
+                    timeConditions: timeConditions,
                     homeID: args["home_id"] as? String,
                     dryRun: parseBool(args, key: "dry_run")
                 )

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -134,6 +134,17 @@ export async function handleAutomations(args) {
       if (Array.isArray(args.weekdays) && args.weekdays.length > 0) {
         socketArgs.weekdays = args.weekdays;
       }
+      if (Array.isArray(args.conditions) && args.conditions.length > 0) {
+        // Pass through; HomeKitManager validates each entry's accessory + characteristic
+        // and rejects malformed shapes via ControlError.invalidArgument.
+        socketArgs.conditions = args.conditions;
+      }
+      if (Array.isArray(args.time_after) && args.time_after.length > 0) {
+        socketArgs.time_after = args.time_after;
+      }
+      if (Array.isArray(args.time_before) && args.time_before.length > 0) {
+        socketArgs.time_before = args.time_before;
+      }
       if (args.home_id) socketArgs.home_id = args.home_id;
       if (args.dry_run) socketArgs.dry_run = 'true';
       return sendCommand('create_automation', socketArgs);

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -266,7 +266,31 @@ export const tools = [
         weekdays: {
           type: 'array',
           items: { type: 'number', enum: [1, 2, 3, 4, 5, 6, 7] },
-          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, the automation fires every day. iOS 15+ marks time-conditional automations without weekday gating as "unreliable", so pass weekdays explicitly when combining with time-of-day conditions. (create action)',
+          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, the automation fires every day. iOS 15+ marks time-conditional automations without weekday gating as "unreliable", so pass weekdays explicitly when combining with time-of-day conditions. If you set time_after/time_before but omit weekdays, HomeClaw auto-fills all 7 days and sets `weekdays_auto_filled: true` in the response. (create action)',
+        },
+        conditions: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              accessory: { type: 'string', description: 'Condition accessory UUID (preferred) or name' },
+              property: { type: 'string', description: 'Characteristic name (e.g., contact_state, occupancy_detected, power)' },
+              value: { type: 'string', description: 'Required value as string (e.g., "true", "0", "50"). Uses exact match (==).' },
+              room: { type: 'string', description: 'Room name for accessory disambiguation (optional)' },
+            },
+            required: ['accessory', 'property', 'value'],
+          },
+          description: 'Extra characteristic predicates ANDed into the trigger predicate (create action). The trigger fires only when the trigger event happens AND every condition holds. Example: porch motion that only triggers when the front door is closed AND nobody is home. Each condition is a (characteristic == value) match against any accessory in the home. (create action)',
+        },
+        time_after: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Sun-relative time predicates ANDed into the trigger so it only fires after the given event (create action). Format: "<sunrise|sunset>[±N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create action)',
+        },
+        time_before: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Sun-relative time predicates ANDed into the trigger so it only fires before the given event (create action). Same format and offset rules as time_after. (create action)',
         },
         dry_run: {
           type: 'boolean',

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21078,7 +21078,31 @@ var tools = [
         weekdays: {
           type: "array",
           items: { type: "number", enum: [1, 2, 3, 4, 5, 6, 7] },
-          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, the automation fires every day. iOS 15+ marks time-conditional automations without weekday gating as "unreliable", so pass weekdays explicitly when combining with time-of-day conditions. (create action)'
+          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, the automation fires every day. iOS 15+ marks time-conditional automations without weekday gating as "unreliable", so pass weekdays explicitly when combining with time-of-day conditions. If you set time_after/time_before but omit weekdays, HomeClaw auto-fills all 7 days and sets `weekdays_auto_filled: true` in the response. (create action)'
+        },
+        conditions: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              accessory: { type: "string", description: "Condition accessory UUID (preferred) or name" },
+              property: { type: "string", description: "Characteristic name (e.g., contact_state, occupancy_detected, power)" },
+              value: { type: "string", description: 'Required value as string (e.g., "true", "0", "50"). Uses exact match (==).' },
+              room: { type: "string", description: "Room name for accessory disambiguation (optional)" }
+            },
+            required: ["accessory", "property", "value"]
+          },
+          description: "Extra characteristic predicates ANDed into the trigger predicate (create action). The trigger fires only when the trigger event happens AND every condition holds. Example: porch motion that only triggers when the front door is closed AND nobody is home. Each condition is a (characteristic == value) match against any accessory in the home. (create action)"
+        },
+        time_after: {
+          type: "array",
+          items: { type: "string" },
+          description: 'Sun-relative time predicates ANDed into the trigger so it only fires after the given event (create action). Format: "<sunrise|sunset>[\xB1N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create action)'
+        },
+        time_before: {
+          type: "array",
+          items: { type: "string" },
+          description: "Sun-relative time predicates ANDed into the trigger so it only fires before the given event (create action). Same format and offset rules as time_after. (create action)"
         },
         dry_run: {
           type: "boolean",
@@ -21307,6 +21331,15 @@ async function handleAutomations(args) {
       if (args.service_index != null) socketArgs.service_index = String(args.service_index);
       if (Array.isArray(args.weekdays) && args.weekdays.length > 0) {
         socketArgs.weekdays = args.weekdays;
+      }
+      if (Array.isArray(args.conditions) && args.conditions.length > 0) {
+        socketArgs.conditions = args.conditions;
+      }
+      if (Array.isArray(args.time_after) && args.time_after.length > 0) {
+        socketArgs.time_after = args.time_after;
+      }
+      if (Array.isArray(args.time_before) && args.time_before.length > 0) {
+        socketArgs.time_before = args.time_before;
       }
       if (args.home_id) socketArgs.home_id = args.home_id;
       if (args.dry_run) socketArgs.dry_run = "true";


### PR DESCRIPTION
## What this lights up

Multi-condition rule composition — the kind of "fire only when motion *and* contact *and* between dusk and dawn" logic Controller for HomeKit exposes in its rule editor, but scriptable from the CLI and discoverable from MCP/LLM agents.

Real examples this enables:

```bash
# Porch lights at sunset, but only when nobody's home
homeclaw-cli automations create \
  --name "Porch Welcome" \
  --accessory "Front Door" --characteristic motion_detected --trigger-value true \
  --condition "Presence Sensor:occupancy_detected:false" \
  --time-after  "sunset-30" \
  --time-before "sunrise+15" \
  --scene "Porch On"

# Bathroom fan that only fires on weekday mornings when humidity spikes
homeclaw-cli automations create \
  --name "Bathroom Fan AM Boost" \
  --accessory "Bathroom Humidity" --characteristic relative_humidity --trigger-value 75 \
  --days mon,tue,wed,thu,fri \
  --time-after "06:00" --time-before "10:00" \
  --action "Bathroom Fan:power:1"

# Garage door alert if left open after dark
homeclaw-cli automations create \
  --name "Garage Open Alert" \
  --accessory "Garage Door" --characteristic contact_state --trigger-value 1 \
  --time-after "sunset" \
  --action "Garage Light:power:1" --action "Bedroom Speaker:active:1"
```

Each `--condition` adds a `(characteristic == value)` conjunct. Each `--time-after` / `--time-before` adds a sun-relative time conjunct. Combined with `--days` from #49 and the trigger event itself, the trigger fires only when **everything** holds — predicate composition exactly as Controller for HomeKit does it, but accessible to MCP-using LLMs and shell scripts.

## What changed

**Write side**

- **`Sources/homeclaw-cli/Commands/AutomationsCommand.swift`** — `--condition`, `--time-after`, `--time-before` repeatable flags on `CreateAutomation`. CLI parses, validates with specific error messages, surfaces every applied predicate in success/dry-run output. New `validateTimeSpec` helper for time format validation.
- **`Sources/homeclaw/HomeKit/SocketServer.swift`** — extended `case "create_automation":` parses `conditions`, `time_after`, `time_before` from socket args and re-validates time specs via `TimeCondition.parse` so direct socket / MCP callers can't bypass CLI validation.
- **`Sources/homeclaw/HomeKit/HomeKitManager.swift`** — `createAutomation` gains `conditions: [[String:String]] = []`, `timeConditionsAfter: [String] = []`, `timeConditionsBefore: [String] = []` parameters. Conditions are resolved (accessory + characteristic + value) **before any HomeKit mutation** so failures throw `ControlError.invalidArgument` cleanly. Auto-fills `weekdays = [1...7]` when time conditions are present without `--days`, surfacing `weekdays_auto_filled: true` in the result.

**Step 1b restructured**

#49 added a Step 1b that calls `trigger.updatePredicate` with the weekday predicate. This PR adds two more predicate kinds that need the same call. Only the **last** `updatePredicate` sticks, so all predicate kinds (existing + weekdays + conditions + time-conditions) are now collected into one `[NSPredicate]` and applied via a **single combined** `NSCompoundPredicate(andPredicateWithSubpredicates:)`. The single-element fast path skips the AND wrapper, matching #49's pattern. Cleanup-on-failure removes the orphan trigger and inline action set if applicable, mirroring #49 exactly.

**Read side (ships with write side per API symmetry)**

- **`Sources/homeclaw/HomeKit/AccessoryModel.swift`** — new `extractConditions(_:in:)` decodes the trigger predicate into a structured array. Discriminated union by `type`:
  - `{type: "characteristic", accessory, accessory_id, property, operator: "==", value}` — characteristic conjuncts (with `characteristic_id` fallback when `home` is unavailable to the caller)
  - `{type: "weekdays", weekdays: [Int], summary}` — weekday OR-compound (decodes both single weekday and OR-of-weekdays cases)
  - `{type: "time", relation, event, summary}` — sun-relative time predicates
- New `flattenTopAnd` helper handles nested AND compounds from successive predicate-mutation (the structure PR6's `add-condition` will produce).
- `automationSummary.event_summary` annotated with `(+N condition(s))` when conjuncts beyond the bare event exist.
- `automationDetail` returns the full structured `conditions` array.

**MCP/lib parity**

- **`lib/handlers/homekit.js`** — `case 'create':` forwards `conditions` (array of objects), `time_after`, `time_before` (arrays of strings).
- **`lib/schemas.js`** — three new properties under `homekit_automations`'s `create` action with rich descriptions explaining use cases (motion + door-closed, dusk-to-dawn windows). The `weekdays` description references the auto-fill behavior so LLMs know to expect `weekdays_auto_filled: true`.
- **`mcp-server/dist/server.js`** — rebuilt.

## New result-dict fields

| Field | Type | Set when |
|---|---|---|
| `conditions` | array of `{accessory, property, value}` | `--condition` provided |
| `time_after` | array of strings | `--time-after` provided |
| `time_before` | array of strings | `--time-before` provided |
| `weekdays_auto_filled` | bool | auto-fill triggered (only set true) |

## Defense-in-depth validation

Three layers, each carrying the same error messages:

1. CLI: `validateTimeSpec` rejects `noon`, `sunset+1500`, `sunset+`, `sunset-abc`, `+30`, empty string, and condition strings with the wrong split count or empty parts. Each error names the offending flag.
2. SocketServer: re-runs `TimeCondition.parse` on every time spec; rejects malformed input from non-CLI clients.
3. HomeKitManager: resolves accessory + characteristic + value before any HomeKit mutation; throws `ControlError.invalidArgument` with a specific message naming the unresolvable bit.

Offsets above 1440 minutes (24h) are rejected at all three layers.

## Testing status

- ✅ `swift build --product homeclaw-cli` — clean
- ✅ `npm install && npm run build:mcp` — clean
- ✅ `xcodebuild` Catalyst — Swift compile passes (codesign step fails as expected; provisioning mismatch on `com.shahine.*`)
- ✅ Validation tested: `noon`, `sunset+1500`, `sunset+`, `sunset-abc`, `+30`, empty, `Acc::Val`, `Acc:Prop:` — each yields a specific `ValidationError` pointing at the offending flag
- ⚠️ Runtime end-to-end against real HomeKit — same provisioning caveat as #49/#50. The composition machinery is byte-equivalent to the sibling code path running in my own deployment for a few weeks. Standing by for your spot-check.

## Notes

- **Deprecated API caveat (same as #49)** — `predicateForEvaluatingTrigger(occurringAfter:applyingOffset:)` and `occurringBefore:` are marked deprecated in Catalyst 13.1+; the `HMSignificantTimeEvent`-taking replacement isn't bridged to Swift yet (only `DateComponents` and `HMPresenceEvent` overloads are available). Inline comment in `TimeCondition.predicate()` explains the constraint.
- **Sun-event offset round-trip limitation** — Apple's predicate API doesn't preserve the offset on the recovered `NSPredicate`, so `extractConditions` surfaces `"after sunset"` rather than `"after sunset-30"` for time conditions in `list/get` output. The original spec is echoed back in the create-time result dict (so callers who need the exact spec have it from the create response), and a future change to surface the offset would need HomeKit to expose `HMSignificantTimeEvent` on the recovered trigger.
- No build-number / version-manifest changes (per the `chore(release):` separation pattern).

## Sequence

Per #48: PR 3 of 6. Builds on #49 and #50. Next:

- **PR4** — `--duration` (HMDurationEvent on `endEvents`); already implemented locally on `feat/automations-duration`, will rebase + push next.
- **PR5** — `create-time` subcommand reusing all the predicate flags from PRs 1, 3, 4.
- **PR6** — `add-condition` modify-in-place verb. With this PR's read-side decoder + `flattenTopAnd` already in place, PR6 becomes a small focused PR that lets users tune existing automations without losing the trigger UUID (so button bindings and Siri references survive).

Refs #48.
