### PR TITLE
feat: add --duration N to auto-revert trigger actions after N seconds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build homeclaw-cli
         run: swift build --product homeclaw-cli
 
+      - name: Run Swift tests
+        run: swift test
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/Package.swift
+++ b/Package.swift
@@ -20,5 +20,9 @@ let package = Package(
             ],
             exclude: ["Commands/_disabled"]
         ),
+        .testTarget(
+            name: "homeclaw-cliTests",
+            dependencies: ["homeclaw-cli"]
+        ),
     ]
 )

--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -179,6 +179,9 @@ struct CreateAutomation: ParsableCommand {
     @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires before the given event. Format: '<sunrise|sunset>[±N]' where N is minutes (e.g. 'sunrise+15'). Offsets >1440 (24h) are rejected. Implies weekday auto-fill if --days is omitted.")
     var timeBefore: [String] = []
 
+    @Option(name: .long, help: "Auto-revert the trigger's actions after this many seconds via HMDurationEvent (1-86400). Useful for motion-triggered lights that should turn off again after a delay.")
+    var duration: Int?
+
     @Option(name: .long, help: "Home name or UUID (defaults to primary home)")
     var home: String?
 
@@ -294,6 +297,15 @@ struct CreateAutomation: ParsableCommand {
             args["time_before"] = try timeBefore.map { try validateTimeSpec($0, flag: "--time-before") }
         }
 
+        if let duration {
+            guard (1...86400).contains(duration) else {
+                throw ValidationError(
+                    "--duration must be a positive integer between 1 and 86400 (24 hours)"
+                )
+            }
+            args["duration_seconds"] = duration
+        }
+
         if let home { args["home_id"] = home }
 
         let response = try SocketClient.sendAny(command: "create_automation", args: args)
@@ -344,6 +356,9 @@ struct CreateAutomation: ParsableCommand {
                 print("  Scene: \(sceneName)")
             }
             printPredicateFields(from: result)
+            if let durationSeconds = result["duration_seconds"] as? Int {
+                print("  Auto-off: \(Self.formatDuration(durationSeconds))")
+            }
         } else {
             if isInline {
                 print("Created automation '\(autoName)' with \(actionCount ?? 0) inline action(s)")
@@ -354,6 +369,9 @@ struct CreateAutomation: ParsableCommand {
                 print("  \(triggerDescription) → \(sceneName)")
             }
             printPredicateFields(from: result)
+            if let durationSeconds = result["duration_seconds"] as? Int {
+                print("  Auto-off: \(Self.formatDuration(durationSeconds))")
+            }
         }
     }
 
@@ -426,6 +444,20 @@ struct CreateAutomation: ParsableCommand {
                 print("  Days: \(formatWeekdays(weekdays))")
             }
         }
+    }
+
+    /// Format a duration in seconds as a short human label (e.g. `45s`, `5m`, `1h30m`).
+    /// Matches the surfacing PR #50 added to `automations list/get` output.
+    static func formatDuration(_ seconds: Int) -> String {
+        if seconds < 60 { return "\(seconds)s" }
+        let minutes = seconds / 60
+        let remSeconds = seconds % 60
+        if minutes < 60 {
+            return remSeconds == 0 ? "\(minutes)m" : "\(minutes)m\(remSeconds)s"
+        }
+        let hours = minutes / 60
+        let remMinutes = minutes % 60
+        return remMinutes == 0 ? "\(hours)h" : "\(hours)h\(remMinutes)m"
     }
 }
 

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -1174,7 +1174,18 @@ final class HomeKitManager: NSObject, Observable {
             do {
                 try await homeKitAsync { trigger.updatePredicate(combinedPredicate, completionHandler: $0) }
             } catch {
-                // Cleanup orphaned trigger on predicate failure (no inline action set linked yet).
+                // Cleanup on predicate failure: remove the orphaned trigger AND the inline
+                // action set if we created one. (The action set exists in `home.actionSets`
+                // from Step 1's `addActionSet` call even though it's not yet linked to the
+                // trigger — without this removal it would persist as an orphaned scene tile.)
+                if isInlineActionSet {
+                    try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                        home.removeActionSet(actionSet) { err in
+                            if let err { continuation.resume(throwing: err) }
+                            else { continuation.resume() }
+                        }
+                    }
+                }
                 try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                     home.removeTrigger(trigger) { err in
                         if let err { continuation.resume(throwing: err) }

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -880,6 +880,7 @@ final class HomeKitManager: NSObject, Observable {
         weekdays: [Int] = [],
         conditions: [[String: String]] = [],
         timeConditions: [TimeCondition] = [],
+        durationSeconds: Int? = nil,
         homeID: String? = nil,
         dryRun: Bool = false
     ) async throws -> [String: Any] {
@@ -1036,6 +1037,7 @@ final class HomeKitManager: NSObject, Observable {
                     result["characteristic"] = characteristic
                     result["trigger_value"] = triggerValue
                 }
+                if let durationSeconds { result["duration_seconds"] = durationSeconds }
                 return attachPredicateFields(result)
             }
 
@@ -1090,6 +1092,7 @@ final class HomeKitManager: NSObject, Observable {
                     result["characteristic"] = characteristic
                     result["trigger_value"] = triggerValue
                 }
+                if let durationSeconds { result["duration_seconds"] = durationSeconds }
                 return attachPredicateFields(result)
             }
 
@@ -1182,6 +1185,32 @@ final class HomeKitManager: NSObject, Observable {
             }
         }
 
+        // Step 1c: Attach an HMDurationEvent end-event so HomeKit reverts the
+        // trigger's actions after N seconds (e.g. motion-triggered light auto-off).
+        // Mirrors the predicate cleanup pattern: on failure, tear down the orphan
+        // trigger (and inline action set if we created one) before rethrowing.
+        if let durationSeconds {
+            do {
+                try await applyDuration(seconds: durationSeconds, to: trigger)
+            } catch {
+                if isInlineActionSet {
+                    try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                        home.removeActionSet(actionSet) { err in
+                            if let err { continuation.resume(throwing: err) }
+                            else { continuation.resume() }
+                        }
+                    }
+                }
+                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    home.removeTrigger(trigger) { err in
+                        if let err { continuation.resume(throwing: err) }
+                        else { continuation.resume() }
+                    }
+                }
+                throw error
+            }
+        }
+
         // Step 2: Link the action set
         do {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
@@ -1255,7 +1284,24 @@ final class HomeKitManager: NSObject, Observable {
         } else {
             result["scene"] = actionSet.name
         }
+        if let durationSeconds {
+            result["duration_seconds"] = durationSeconds
+        }
         return attachPredicateFields(result)
+    }
+
+    /// Add an HMDurationEvent to the trigger's `endEvents` so HomeKit reverts
+    /// any characteristics turned on by the trigger after the given duration.
+    /// Used by `--duration N` on `automations create` to implement auto-off
+    /// for motion-triggered lights and similar patterns.
+    private func applyDuration(seconds: Int, to trigger: HMEventTrigger) async throws {
+        let durationEvent = HMDurationEvent(duration: TimeInterval(seconds))
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            trigger.updateEndEvents([durationEvent]) { error in
+                if let error { continuation.resume(throwing: error) }
+                else { continuation.resume() }
+            }
+        }
     }
 
     /// Resolve action definitions to HomeKit accessory/characteristic/value tuples.

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -728,13 +728,29 @@ final class SocketServer: @unchecked Sendable {
                     }
                     timeConditions.append(tc)
                 }
-                let durationSeconds = (args["duration_seconds"] as? Int)
-                    ?? (args["duration_seconds"] as? String).flatMap(Int.init)
-                if let durationSeconds, !(1...86400).contains(durationSeconds) {
-                    return encodeResponse(
-                        success: false,
-                        error: "'duration_seconds' must be a positive integer between 1 and 86400 (24 hours)"
-                    )
+                // Distinguish "missing" from "present but invalid" so unparseable values
+                // (e.g. "300s", 300.5, true) return a validation error instead of silently
+                // creating an automation without auto-off.
+                let durationSeconds: Int?
+                if let raw = args["duration_seconds"] {
+                    // JSONSerialization bridges JSON booleans as __NSCFBoolean which casts
+                    // to Int(0/1); reject explicitly so `true` doesn't become a 1s auto-off.
+                    let isBool: Bool = {
+                        guard let nsNum = raw as? NSNumber else { return false }
+                        return CFGetTypeID(nsNum) == CFBooleanGetTypeID()
+                    }()
+                    let parsed: Int? = isBool
+                        ? nil
+                        : ((raw as? Int) ?? (raw as? String).flatMap(Int.init))
+                    guard let parsed, (1...86400).contains(parsed) else {
+                        return encodeResponse(
+                            success: false,
+                            error: "'duration_seconds' must be a positive integer between 1 and 86400 (24 hours)"
+                        )
+                    }
+                    durationSeconds = parsed
+                } else {
+                    durationSeconds = nil
                 }
                 result = try await hk.createAutomation(
                     name: name,

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -728,6 +728,14 @@ final class SocketServer: @unchecked Sendable {
                     }
                     timeConditions.append(tc)
                 }
+                let durationSeconds = (args["duration_seconds"] as? Int)
+                    ?? (args["duration_seconds"] as? String).flatMap(Int.init)
+                if let durationSeconds, !(1...86400).contains(durationSeconds) {
+                    return encodeResponse(
+                        success: false,
+                        error: "'duration_seconds' must be a positive integer between 1 and 86400 (24 hours)"
+                    )
+                }
                 result = try await hk.createAutomation(
                     name: name,
                     accessoryID: accessoryID,
@@ -740,6 +748,7 @@ final class SocketServer: @unchecked Sendable {
                     weekdays: weekdays,
                     conditions: conditions,
                     timeConditions: timeConditions,
+                    durationSeconds: durationSeconds,
                     homeID: args["home_id"] as? String,
                     dryRun: parseBool(args, key: "dry_run")
                 )

--- a/Tests/homeclaw-cliTests/FormatDurationTests.swift
+++ b/Tests/homeclaw-cliTests/FormatDurationTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import homeclaw_cli
+
+@Suite("CreateAutomation.formatDuration")
+struct FormatDurationTests {
+    @Test("seconds-only under one minute")
+    func secondsOnly() {
+        #expect(CreateAutomation.formatDuration(1) == "1s")
+        #expect(CreateAutomation.formatDuration(45) == "45s")
+        #expect(CreateAutomation.formatDuration(59) == "59s")
+    }
+
+    @Test("exact minute boundary")
+    func exactMinute() {
+        #expect(CreateAutomation.formatDuration(60) == "1m")
+        #expect(CreateAutomation.formatDuration(120) == "2m")
+        #expect(CreateAutomation.formatDuration(300) == "5m")
+    }
+
+    @Test("minutes with leftover seconds")
+    func minutesAndSeconds() {
+        #expect(CreateAutomation.formatDuration(61) == "1m1s")
+        #expect(CreateAutomation.formatDuration(125) == "2m5s")
+        #expect(CreateAutomation.formatDuration(3599) == "59m59s")
+    }
+
+    @Test("exact hour boundary")
+    func exactHour() {
+        #expect(CreateAutomation.formatDuration(3600) == "1h")
+        #expect(CreateAutomation.formatDuration(7200) == "2h")
+    }
+
+    @Test("hours with leftover minutes")
+    func hoursAndMinutes() {
+        #expect(CreateAutomation.formatDuration(3660) == "1h1m")
+        #expect(CreateAutomation.formatDuration(5400) == "1h30m")
+        #expect(CreateAutomation.formatDuration(7500) == "2h5m")
+    }
+
+    @Test("residual seconds collapse at hour scale")
+    func hoursDropResidualSeconds() {
+        // Past 1h the format intentionally renders hours + minutes only;
+        // a stray 1s within an hour-scale duration should not appear.
+        #expect(CreateAutomation.formatDuration(3661) == "1h1m")
+    }
+
+    @Test("maximum allowed value (24h)")
+    func maxValue() {
+        #expect(CreateAutomation.formatDuration(86400) == "24h")
+    }
+}

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -145,6 +145,13 @@ export async function handleAutomations(args) {
       if (Array.isArray(args.time_before) && args.time_before.length > 0) {
         socketArgs.time_before = args.time_before;
       }
+      if (args.duration_seconds != null) {
+        const d = args.duration_seconds;
+        if (!Number.isInteger(d) || d < 1 || d > 86400) {
+          throw new Error('duration_seconds must be an integer between 1 and 86400 (24 hours)');
+        }
+        socketArgs.duration_seconds = String(d);
+      }
       if (args.home_id) socketArgs.home_id = args.home_id;
       if (args.dry_run) socketArgs.dry_run = 'true';
       return sendCommand('create_automation', socketArgs);

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -203,7 +203,7 @@ export const tools = [
   },
   {
     name: 'homekit_automations',
-    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value. List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
+    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value. Use duration_seconds at create time to auto-revert actions after N seconds (e.g. motion-triggered lights that turn off again after a delay). List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -291,6 +291,12 @@ export const tools = [
           type: 'array',
           items: { type: 'string' },
           description: 'Sun-relative time predicates ANDed into the trigger so it only fires before the given event (create action). Same format and offset rules as time_after. (create action)',
+        },
+        duration_seconds: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 86400,
+          description: 'Auto-revert the trigger\'s actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger\'s endEvents — HomeKit handles the revert natively, no follow-up automation required. Common use case: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold). (create action)',
         },
         dry_run: {
           type: 'boolean',

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21015,7 +21015,7 @@ var tools = [
   },
   {
     name: "homekit_automations",
-    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value. List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
+    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value. Use duration_seconds at create time to auto-revert actions after N seconds (e.g. motion-triggered lights that turn off again after a delay). List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
     inputSchema: {
       type: "object",
       properties: {
@@ -21103,6 +21103,12 @@ var tools = [
           type: "array",
           items: { type: "string" },
           description: "Sun-relative time predicates ANDed into the trigger so it only fires before the given event (create action). Same format and offset rules as time_after. (create action)"
+        },
+        duration_seconds: {
+          type: "integer",
+          minimum: 1,
+          maximum: 86400,
+          description: "Auto-revert the trigger's actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger's endEvents \u2014 HomeKit handles the revert natively, no follow-up automation required. Common use case: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold). (create action)"
         },
         dry_run: {
           type: "boolean",
@@ -21340,6 +21346,13 @@ async function handleAutomations(args) {
       }
       if (Array.isArray(args.time_before) && args.time_before.length > 0) {
         socketArgs.time_before = args.time_before;
+      }
+      if (args.duration_seconds != null) {
+        const d = args.duration_seconds;
+        if (!Number.isInteger(d) || d < 1 || d > 86400) {
+          throw new Error("duration_seconds must be an integer between 1 and 86400 (24 hours)");
+        }
+        socketArgs.duration_seconds = String(d);
       }
       if (args.home_id) socketArgs.home_id = args.home_id;
       if (args.dry_run) socketArgs.dry_run = "true";


### PR DESCRIPTION
## Motivation

PR 4 of 6 from #48. Adds `--duration N` (seconds, 1-86400) to `automations create`. When provided, HomeKit reverts the trigger's actions after the specified delay via `HMDurationEvent` attached to the trigger's `endEvents` — no follow-up automation required. The classic use case is motion-triggered lights that should turn off again after a hold period.

```bash
homeclaw-cli automations create \
  --name "Hall light on motion" \
  --accessory "Hall Motion" --characteristic motion_detected --trigger-value true \
  --duration 300 \
  --action "Hall Light:power:1"

# Combines naturally with the predicate flags from #49 and #56
homeclaw-cli automations create \
  --name "Driveway Welcome" \
  --accessory "Driveway Motion" --characteristic motion_detected --trigger-value true \
  --time-after "sunset-30" \
  --condition "Presence Sensor:occupancy_detected:false" \
  --duration 600 \
  --scene "Driveway On"
```

Output:

```
Created automation 'Hall light on motion'
  Hall Motion motion_detected = true → 1 action(s)
  Auto-off: 5m
```

## What changed

Threaded through all four layers, with defense-in-depth validation:

- **`Sources/homeclaw-cli/Commands/AutomationsCommand.swift`** — `--duration` flag with range validation (1-86400). New `formatDuration` helper renders the value back as `45s` / `5m` / `1h30m` style for success and dry-run output.
- **`Sources/homeclaw/HomeKit/SocketServer.swift`** — parses `duration_seconds` (Int with String fallback per the existing pattern) and re-validates the range so MCP / direct socket callers can't bypass the CLI bounds.
- **`Sources/homeclaw/HomeKit/HomeKitManager.swift`** — new `applyDuration(seconds:to:)` helper called as Step 1c after `addTrigger` and after the combined Step 1b predicate (the weekday + condition + time-condition path established by #49 and #56). Cleanup-on-failure removes the orphan trigger and inline action set if present, mirroring Step 1b's pattern exactly.
- **`lib/handlers/homekit.js` + `lib/schemas.js`** — `duration_seconds` property with `minimum`/`maximum`, description explaining `HMDurationEvent` semantics and the motion-revert use case. The `homekit_automations` description now mentions `duration_seconds` from both the request side (this PR) and the response side (already there from #50).
- **`mcp-server/dist/server.js`** — rebuilt via `npm run build:mcp`.

## Read-side parity (already in main)

#50 already surfaces `duration_seconds` + `(off after Xm)` in `event_summary` by reading `HMDurationEvent` from `trigger.endEvents`. This PR produces exactly that structure — a single `HMDurationEvent(duration: TimeInterval(seconds))` in `updateEndEvents([durationEvent])` after `addTrigger` — so once this lands, `automations list` and `automations get` will surface duration-bound automations created via `--duration` automatically with no further changes.

## Defense-in-depth validation

Three layers, each carrying the same `1-86400` bounds and an aligned error message:

1. CLI: `ValidationError("--duration must be a positive integer between 1 and 86400 (24 hours)")` on bad input.
2. SocketServer: re-validates the range, rejecting non-CLI clients with the equivalent socket error.
3. JS handler: `Number.isInteger(d) && 1 <= d <= 86400`, throws on violation.

Negative values are also rejected by ArgumentParser's `Int` type-coercion before reaching our validator.

## Why `updateEndEvents` after `addTrigger`

Two reasons: (1) source matches the working pattern from my private deployment that's been in production for weeks; (2) the existing `addTrigger` → `updatePredicate` → `updateEndEvents` sequencing established by #49/#56 stays intact — Step 1c slots in naturally as the post-predicate symmetric twin to Step 1b's predicate cleanup.

## Testing status

- ✅ `swift build --product homeclaw-cli` — clean
- ✅ `npm install && npm run build:mcp` — clean
- ✅ `xcodebuild ... CODE_SIGNING_ALLOWED=NO build` — `** BUILD SUCCEEDED **`, zero warnings on changed files (codesign step naturally fails with the `com.shahine.*` provisioning gap I've flagged on the prior PRs)
- ✅ Validation tested: `--duration 0`, `--duration 90000`, `--duration -5` — each rejected with the appropriate error
- ⚠️ Runtime end-to-end against real HomeKit — same caveat as #49/#50/#56. Same `HMDurationEvent` construction is running in my private deployment for a few weeks. Standing by for your spot-check.

## Notes

- No build-number / version-manifest changes (per the `chore(release):` separation pattern).
- Result-dict consistency matches PR3's pattern: `duration_seconds` set in BOTH dry-run paths AND the success path; never silently dropped between them.
- A small `formatDuration` helper lives in `CreateAutomation` (CLI side) for output formatting. It's a near-duplicate of the existing `formatDuration` helper in `AccessoryModel` (read-side, from #50), but they live in different SPM targets that don't share a common module — happy to extract to a shared utility target later if you'd prefer the deduplication. Currently ~10 lines of intentional duplication.

## Sequence

Per #48: PR 4 of 6. Builds on #49 (`--days`) and #56 (`--condition` + `--time-after`/`-before`). Next:

- **PR5** — `create-time` subcommand reusing all the predicate flags from PRs 1, 3, 4. (HMCalendarEvent + HMSignificantTimeEvent triggers, parallel to the characteristic path.)
- **PR6** — `add-condition` modify-in-place verb. With the read-side decoder + `flattenTopAnd` already in place from #56 (and your `34fd00f` fix to handle mixed AND-children), PR6 becomes a small focused PR.

Refs #48.
