### PR TITLE
feat: create-time subcommand for HH:MM and sunrise/sunset triggers

### DIFF
--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -9,6 +9,7 @@ struct Automations: ParsableCommand {
             ListAutomations.self,
             GetAutomation.self,
             CreateAutomation.self,
+            CreateTimeAutomation.self,
             DeleteAutomation.self,
             EnableAutomation.self,
             DisableAutomation.self,
@@ -227,74 +228,27 @@ struct CreateAutomation: ParsableCommand {
         if let scene {
             args["scene_id"] = scene
         } else {
-            // Parse inline actions from "accessory:property:value" format
-            var parsedActions: [[String: String]] = []
-            for actionStr in action {
-                let parts = actionStr.split(separator: ":", maxSplits: 2).map(String.init)
-                guard parts.count == 3 else {
-                    throw ValidationError("Invalid action format '\(actionStr)'. Use 'accessory:property:value'")
-                }
-                parsedActions.append([
-                    "accessory": parts[0],
-                    "property": parts[1],
-                    "value": parts[2],
-                ])
-            }
-            args["actions"] = parsedActions
+            // Parse inline actions from "accessory:property:value" format.
+            // Shared with create-time via `parseActionRow` so whitespace handling
+            // matches `--condition` (trim per part, reject empty).
+            args["actions"] = try action.map { try Self.parseActionRow($0) }
         }
 
         if let serviceIndex { args["service_index"] = serviceIndex }
 
         if let days {
-            let dayMap: [String: Int] = [
-                "sun": 1, "sunday": 1,
-                "mon": 2, "monday": 2,
-                "tue": 3, "tuesday": 3,
-                "wed": 4, "wednesday": 4,
-                "thu": 5, "thursday": 5,
-                "fri": 6, "friday": 6,
-                "sat": 7, "saturday": 7,
-            ]
-            var weekdays: [Int] = []
-            for raw in days.split(separator: ",") {
-                let key = raw.trimmingCharacters(in: .whitespaces).lowercased()
-                if let n = dayMap[key] { weekdays.append(n) }
-                else if let n = Int(key), (1...7).contains(n) { weekdays.append(n) }
-                else { throw ValidationError("Invalid day '\(raw)'. Use mon/tue/wed/thu/fri/sat/sun or 1-7 (1=Sun)") }
-            }
-            args["weekdays"] = Array(Swift.Set(weekdays)).sorted()
+            args["weekdays"] = try Self.parseWeekdays(days)
         }
 
         if !condition.isEmpty {
-            // Parse "accessory:property:value" — same shape as --action.
-            // Three required parts; reject malformed input early so the user gets a
-            // clear ValidationError before we touch HomeKit.
-            var parsedConditions: [[String: String]] = []
-            for raw in condition {
-                let parts = raw.split(separator: ":", maxSplits: 2).map(String.init)
-                guard parts.count == 3 else {
-                    throw ValidationError("Invalid --condition '\(raw)'. Use 'accessory:property:value' (note: accessory names containing colons are not supported via --condition; use the MCP conditions array instead).")
-                }
-                let accessoryPart = parts[0].trimmingCharacters(in: .whitespaces)
-                let propertyPart = parts[1].trimmingCharacters(in: .whitespaces)
-                let valuePart = parts[2].trimmingCharacters(in: .whitespaces)
-                guard !accessoryPart.isEmpty, !propertyPart.isEmpty, !valuePart.isEmpty else {
-                    throw ValidationError("Invalid --condition '\(raw)'. Each of accessory/property/value must be non-empty.")
-                }
-                parsedConditions.append([
-                    "accessory": accessoryPart,
-                    "property": propertyPart,
-                    "value": valuePart,
-                ])
-            }
-            args["conditions"] = parsedConditions
+            args["conditions"] = try condition.map { try Self.parseConditionRow($0) }
         }
 
         if !timeAfter.isEmpty {
-            args["time_after"] = try timeAfter.map { try validateTimeSpec($0, flag: "--time-after") }
+            args["time_after"] = try timeAfter.map { try Self.validateTimeSpec($0, flag: "--time-after") }
         }
         if !timeBefore.isEmpty {
-            args["time_before"] = try timeBefore.map { try validateTimeSpec($0, flag: "--time-before") }
+            args["time_before"] = try timeBefore.map { try Self.validateTimeSpec($0, flag: "--time-before") }
         }
 
         if let duration {
@@ -355,7 +309,7 @@ struct CreateAutomation: ParsableCommand {
             } else if let sceneName = result["scene"] as? String {
                 print("  Scene: \(sceneName)")
             }
-            printPredicateFields(from: result)
+            Self.printPredicateFields(from: result)
             if let durationSeconds = result["duration_seconds"] as? Int {
                 print("  Auto-off: \(Self.formatDuration(durationSeconds))")
             }
@@ -368,7 +322,7 @@ struct CreateAutomation: ParsableCommand {
                 print("Created automation '\(autoName)'")
                 print("  \(triggerDescription) → \(sceneName)")
             }
-            printPredicateFields(from: result)
+            Self.printPredicateFields(from: result)
             if let durationSeconds = result["duration_seconds"] as? Int {
                 print("  Auto-off: \(Self.formatDuration(durationSeconds))")
             }
@@ -376,7 +330,7 @@ struct CreateAutomation: ParsableCommand {
     }
 
     /// Format an array of HomeKit weekday numbers (1=Sun ... 7=Sat) as a comma-separated label.
-    private func formatWeekdays(_ weekdays: [Int]) -> String {
+    static func formatWeekdays(_ weekdays: [Int]) -> String {
         let names = ["", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
         return weekdays.compactMap { (1...7).contains($0) ? names[$0] : nil }.joined(separator: ",")
     }
@@ -384,7 +338,7 @@ struct CreateAutomation: ParsableCommand {
     /// Validate a `--time-after` / `--time-before` spec. Format: `<sunrise|sunset>[±N]`.
     /// Mirrors `TimeCondition.parse` in HomeKitManager but throws CLI-shaped errors
     /// pointing at the offending flag. Defence-in-depth: SocketServer re-validates.
-    private func validateTimeSpec(_ raw: String, flag: String) throws -> String {
+    static func validateTimeSpec(_ raw: String, flag: String) throws -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespaces)
         let lower = trimmed.lowercased()
         guard !lower.isEmpty else {
@@ -418,9 +372,132 @@ struct CreateAutomation: ParsableCommand {
         return lower
     }
 
+    /// Parse `--days mon,tue,...` (or numeric `1-7` where 1=Sun) into the HomeKit
+    /// weekday-number array. Throws a CLI-shaped error pointing at the offending token.
+    /// Shared by `create` and `create-time` so both surfaces have identical day semantics.
+    static func parseWeekdays(_ days: String) throws -> [Int] {
+        let dayMap: [String: Int] = [
+            "sun": 1, "sunday": 1,
+            "mon": 2, "monday": 2,
+            "tue": 3, "tuesday": 3,
+            "wed": 4, "wednesday": 4,
+            "thu": 5, "thursday": 5,
+            "fri": 6, "friday": 6,
+            "sat": 7, "saturday": 7,
+        ]
+        var weekdays: [Int] = []
+        for raw in days.split(separator: ",") {
+            let key = raw.trimmingCharacters(in: .whitespaces).lowercased()
+            if let n = dayMap[key] { weekdays.append(n) }
+            else if let n = Int(key), (1...7).contains(n) { weekdays.append(n) }
+            else { throw ValidationError("Invalid day '\(raw)'. Use mon/tue/wed/thu/fri/sat/sun or 1-7 (1=Sun)") }
+        }
+        return Array(Swift.Set(weekdays)).sorted()
+    }
+
+    /// Parse a `--condition` row string in `accessory:property:value` shape into the
+    /// dict format the socket layer expects. Throws CLI-shaped ValidationErrors so
+    /// malformed input fails before hitting HomeKit. Shared by `create` and `create-time`.
+    static func parseConditionRow(_ raw: String) throws -> [String: String] {
+        let parts = raw.split(separator: ":", maxSplits: 2).map(String.init)
+        guard parts.count == 3 else {
+            throw ValidationError("Invalid --condition '\(raw)'. Use 'accessory:property:value' (note: accessory names containing colons are not supported via --condition; use the MCP conditions array instead).")
+        }
+        let accessoryPart = parts[0].trimmingCharacters(in: .whitespaces)
+        let propertyPart = parts[1].trimmingCharacters(in: .whitespaces)
+        let valuePart = parts[2].trimmingCharacters(in: .whitespaces)
+        guard !accessoryPart.isEmpty, !propertyPart.isEmpty, !valuePart.isEmpty else {
+            throw ValidationError("Invalid --condition '\(raw)'. Each of accessory/property/value must be non-empty.")
+        }
+        return [
+            "accessory": accessoryPart,
+            "property": propertyPart,
+            "value": valuePart,
+        ]
+    }
+
+    /// Parse a `--action` row string in `accessory:property:value` shape into the
+    /// dict format the socket layer expects. Mirrors `parseConditionRow`'s strictness
+    /// (trim per part, reject empty) so `--action` and `--condition` have identical
+    /// whitespace handling within the same command surface. Shared by `create` and `create-time`.
+    static func parseActionRow(_ raw: String) throws -> [String: String] {
+        let parts = raw.split(separator: ":", maxSplits: 2).map(String.init)
+        guard parts.count == 3 else {
+            throw ValidationError("Invalid action format '\(raw)'. Use 'accessory:property:value' (note: accessory names containing colons are not supported via --action; use the MCP actions array instead).")
+        }
+        let accessoryPart = parts[0].trimmingCharacters(in: .whitespaces)
+        let propertyPart = parts[1].trimmingCharacters(in: .whitespaces)
+        let valuePart = parts[2].trimmingCharacters(in: .whitespaces)
+        guard !accessoryPart.isEmpty, !propertyPart.isEmpty, !valuePart.isEmpty else {
+            throw ValidationError("Invalid action format '\(raw)'. Each of accessory/property/value must be non-empty.")
+        }
+        return [
+            "accessory": accessoryPart,
+            "property": propertyPart,
+            "value": valuePart,
+        ]
+    }
+
+    /// CLI-side mirror of `HomeKitManager.TimeSpec.parse(_:)`. Implements the
+    /// same rules so the CLI fails fast with friendly error messages before the
+    /// socket round-trip. SocketServer re-validates via `TimeSpec.parse`; manager
+    /// is the canonical source of truth. Keep these two in sync.
+    ///
+    /// Accepts: `HH:MM`, `sunrise`, `sunset`, `sunrise±N`, `sunset±N` (where N is
+    /// minutes, ≤ 1440). Returns the canonical lowercase string we pass to the
+    /// socket layer. Strict HH:MM (two digits each) so the user can't ambiguously
+    /// type `12:5` and silently mean `12:50`.
+    ///
+    /// This layer's job is to surface CLI-shaped error messages that say `--time`
+    /// not `time`. The SocketServer re-validates via `TimeSpec.parse` so direct
+    /// socket clients can't bypass the format check, and the manager re-runs
+    /// `TimeSpec.parse` at HomeKit-mutation time as the canonical source of truth.
+    static func validateTimeOfDaySpec(_ raw: String) throws -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            throw ValidationError("--time value is empty. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30').")
+        }
+        let lower = trimmed.lowercased()
+
+        // HH:MM
+        if lower.contains(":") {
+            let parts = lower.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else {
+                throw ValidationError("Invalid --time '\(raw)'. Use 'HH:MM' (e.g. '06:30').")
+            }
+            let hourStr = String(parts[0])
+            let minStr = String(parts[1])
+            // Reject ambiguous widths so '12:5' doesn't silently become '12:50'.
+            guard hourStr.count == 2 else {
+                throw ValidationError("Invalid --time '\(raw)'. Hour must be exactly two digits (e.g. '06:30', not '6:30').")
+            }
+            guard minStr.count == 2 else {
+                throw ValidationError("Invalid --time '\(raw)'. Minute must be exactly two digits (e.g. '06:05', not '06:5').")
+            }
+            guard let hour = Int(hourStr), (0...23).contains(hour) else {
+                throw ValidationError("Invalid --time '\(raw)'. Hour must be 0-23.")
+            }
+            guard let minute = Int(minStr), (0...59).contains(minute) else {
+                throw ValidationError("Invalid --time '\(raw)'. Minute must be 0-59.")
+            }
+            return String(format: "%02d:%02d", hour, minute)
+        }
+
+        // sunrise / sunset (with optional ±N offset). Inline-handle the
+        // unknown-prefix case (e.g. `noon`, `midnight`, `dawn`) with a tailored
+        // error listing all four valid `--time` forms. Once we know the prefix
+        // is `sunrise` or `sunset`, forward to `validateTimeSpec` for offset
+        // parsing — that path's existing error messages are correct for
+        // sun-event-with-bad-offset cases.
+        guard lower.hasPrefix("sunrise") || lower.hasPrefix("sunset") else {
+            throw ValidationError("Invalid --time '\(raw)'. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30').")
+        }
+        return try Self.validateTimeSpec(lower, flag: "--time")
+    }
+
     /// Print the conditions / time conditions / weekdays portion of a create response.
     /// Centralised so dry-run and success paths render identically.
-    private func printPredicateFields(from result: [String: Any]) {
+    static func printPredicateFields(from result: [String: Any]) {
         if let conditions = result["conditions"] as? [[String: String]], !conditions.isEmpty {
             print("  Conditions:")
             for c in conditions {
@@ -441,7 +518,7 @@ struct CreateAutomation: ParsableCommand {
             if autoFilled {
                 print("  Days: every day (auto-filled — iOS 15+ requires weekday gating on time-conditional automations)")
             } else {
-                print("  Days: \(formatWeekdays(weekdays))")
+                print("  Days: \(Self.formatWeekdays(weekdays))")
             }
         }
     }
@@ -458,6 +535,190 @@ struct CreateAutomation: ParsableCommand {
         let hours = minutes / 60
         let remMinutes = minutes % 60
         return remMinutes == 0 ? "\(hours)h" : "\(hours)h\(remMinutes)m"
+    }
+}
+
+// MARK: - Create (time-of-day)
+
+struct CreateTimeAutomation: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "create-time",
+        abstract: "Create an automation triggered by a time of day (clock or sunrise/sunset)",
+        discussion: """
+            Creates a HomeKit automation whose trigger event is a wall-clock time
+            (HMCalendarEvent) or a sun-relative event (HMSignificantTimeEvent).
+
+            --time values:
+              HH:MM        Wall-clock time, 00:00-23:59 (e.g. 06:30, 17:45)
+              sunrise      Fire at sunrise
+              sunset       Fire at sunset
+              sunrise+N    N minutes after sunrise (e.g. sunrise+15)
+              sunrise-N    N minutes before sunrise
+              sunset+N     N minutes after sunset
+              sunset-N     N minutes before sunset (e.g. sunset-30)
+
+            All predicate flags (--days, --condition, --time-after, --time-before,
+            --duration) compose with --time the same way they do on `create`. Without
+            --days, all 7 days are auto-filled — iOS 15+ marks time-conditional
+            automations without weekday gating as "unreliable".
+
+            EXAMPLES
+              # Weekday morning coffee
+              homeclaw-cli automations create-time \\
+                --name "Coffee Maker" --time "06:30" \\
+                --days mon,tue,wed,thu,fri \\
+                --action "Coffee Maker:power:1"
+
+              # Sunset porch light with 1-hour auto-off
+              homeclaw-cli automations create-time \\
+                --name "Porch Lights" --time "sunset-30" \\
+                --duration 3600 \\
+                --scene "Porch On"
+
+              # Sunset + occupancy condition
+              homeclaw-cli automations create-time \\
+                --name "Welcome Home Glow" --time "sunset" \\
+                --condition "Front Door:occupancy_detected:true" \\
+                --days mon,tue,wed,thu,fri \\
+                --scene "Welcome"
+            """
+    )
+
+    @Option(name: .long, help: "Name for the automation")
+    var name: String
+
+    @Option(name: .long, help: "Time of day the automation fires: 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30', 'sunrise+15').")
+    var time: String
+
+    @Option(name: .long, help: "Scene name or UUID to trigger (alternative to --action)")
+    var scene: String?
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Inline action as 'accessory:property:value' (repeatable, alternative to --scene). Accessory names with colons are not supported; use the MCP actions array instead.")
+    var action: [String] = []
+
+    @Option(name: .long, help: "Comma-separated weekdays the automation may fire on: mon,tue,wed,thu,fri,sat,sun (or numeric 1-7 where 1=Sun). When omitted, all 7 days are auto-filled — iOS 15+ requires weekday gating on time-conditional automations.")
+    var days: String?
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Extra characteristic predicate ANDed into the trigger as 'accessory:property:value' (repeatable). Example: 'Front Door:occupancy_detected:true'. Note: accessory names containing colons are not supported via --condition; use the MCP conditions array instead.")
+    var condition: [String] = []
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires after the given event. Format: '<sunrise|sunset>[±N]' where N is minutes. Composes with --time (e.g. --time 06:30 --time-after sunrise means '06:30, but only after sunrise').")
+    var timeAfter: [String] = []
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires before the given event. Same format as --time-after.")
+    var timeBefore: [String] = []
+
+    @Option(name: .long, help: "Auto-revert the trigger's actions after this many seconds via HMDurationEvent (1-86400). Useful for sunset porch lights that should turn off after an hour.")
+    var duration: Int?
+
+    @Option(name: .long, help: "Home name or UUID (defaults to primary home)")
+    var home: String?
+
+    @Flag(name: .long, help: "Preview changes without creating")
+    var dryRun = false
+
+    @Flag(name: .long, help: "Output raw JSON")
+    var json = false
+
+    func run() throws {
+        guard scene != nil || !action.isEmpty else {
+            throw ValidationError("Either --scene or --action is required")
+        }
+
+        let canonicalTime = try CreateAutomation.validateTimeOfDaySpec(time)
+
+        var args: [String: Any] = [
+            "name": name,
+            "time": canonicalTime,
+            "dry_run": dryRun,
+        ]
+
+        if let scene {
+            args["scene_id"] = scene
+        } else {
+            args["actions"] = try action.map { try CreateAutomation.parseActionRow($0) }
+        }
+
+        if let days {
+            args["weekdays"] = try CreateAutomation.parseWeekdays(days)
+        }
+
+        if !condition.isEmpty {
+            args["conditions"] = try condition.map { try CreateAutomation.parseConditionRow($0) }
+        }
+
+        if !timeAfter.isEmpty {
+            args["time_after"] = try timeAfter.map { try CreateAutomation.validateTimeSpec($0, flag: "--time-after") }
+        }
+        if !timeBefore.isEmpty {
+            args["time_before"] = try timeBefore.map { try CreateAutomation.validateTimeSpec($0, flag: "--time-before") }
+        }
+
+        if let duration {
+            guard (1...86400).contains(duration) else {
+                throw ValidationError(
+                    "--duration must be a positive integer between 1 and 86400 (24 hours)"
+                )
+            }
+            args["duration_seconds"] = duration
+        }
+
+        if let home { args["home_id"] = home }
+
+        let response = try SocketClient.sendAny(command: "create_time_automation", args: args)
+
+        guard response.success else {
+            throw ValidationError(response.error ?? "Unknown error")
+        }
+
+        if shouldOutputJSON(json) {
+            printJSON(response.data?.value)
+            return
+        }
+
+        guard let result = response.data?.value as? [String: Any] else {
+            print("Done.")
+            return
+        }
+
+        let isDryRun = result["dry_run"] as? Bool ?? false
+        let autoName = result["name"] as? String ?? name
+        let resolvedTime = result["time"] as? String ?? canonicalTime
+        let actionCount = result["action_count"] as? Int
+        let isInline = result["inline_actions"] as? Bool ?? false
+
+        if isDryRun {
+            print("DRY RUN — would create automation '\(autoName)'")
+            print("  Trigger: at \(resolvedTime)")
+            if isInline, let actions = result["actions"] as? [[String: String]] {
+                print("  Actions:")
+                for a in actions {
+                    let acc = a["accessory"] ?? "?"
+                    let char = a["characteristic"] ?? "?"
+                    let val = a["value"] ?? "?"
+                    print("    \(acc): \(char) = \(val)")
+                }
+            } else if let sceneName = result["scene"] as? String {
+                print("  Scene: \(sceneName)")
+            }
+            CreateAutomation.printPredicateFields(from: result)
+            if let durationSeconds = result["duration_seconds"] as? Int {
+                print("  Auto-off: \(CreateAutomation.formatDuration(durationSeconds))")
+            }
+        } else {
+            if isInline {
+                print("Created automation '\(autoName)' with \(actionCount ?? 0) inline action(s)")
+                print("  at \(resolvedTime) → \(actionCount ?? 0) action(s)")
+            } else {
+                let sceneName = result["scene"] as? String ?? "?"
+                print("Created automation '\(autoName)'")
+                print("  at \(resolvedTime) → \(sceneName)")
+            }
+            CreateAutomation.printPredicateFields(from: result)
+            if let durationSeconds = result["duration_seconds"] as? Int {
+                print("  Auto-off: \(CreateAutomation.formatDuration(durationSeconds))")
+            }
+        }
     }
 }
 

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -85,6 +85,178 @@ struct TimeCondition {
     }
 }
 
+// MARK: - Time Spec (trigger event)
+
+/// The TIME-OF-DAY trigger event a `create-time` automation fires on.
+///
+/// Distinct from `TimeCondition` (which is a *predicate* gating any trigger):
+/// a `TimeSpec` becomes the trigger's `HMEvent` itself — either an
+/// `HMCalendarEvent` (HH:MM clock fire) or an `HMSignificantTimeEvent`
+/// (sunrise/sunset, optionally offset by ±N minutes).
+///
+/// Accepted string forms (case-insensitive, whitespace-trimmed):
+/// - `HH:MM`         — clock time (00:00 ... 23:59), zero-padded
+/// - `sunrise`       — at sunrise
+/// - `sunset`        — at sunset
+/// - `sunrise+N`     — N minutes after sunrise
+/// - `sunset-N`      — N minutes before sunset
+/// - `sunrise-N`, `sunset+N` — same idea, signed offset
+///
+/// Offsets larger than ±1440 minutes (24h) are rejected (mirrors `TimeCondition`).
+enum TimeSpec: Equatable {
+    case calendar(hour: Int, minute: Int)
+    case significantTime(event: TimeCondition.Event, offsetMinutes: Int)
+
+    /// Largest offset accepted for sun-event variants. Larger values are
+    /// almost certainly typos (the user probably meant `--days`).
+    static let maxOffsetMinutes = TimeCondition.maxOffsetMinutes
+
+    /// Parsing errors. The caller maps these to its preferred error type
+    /// (CLI: `ValidationError`; socket/manager: `ControlError.invalidArgument`).
+    enum ParseError: Error, Equatable {
+        case empty
+        case unknownFormat(String)
+        case badHour(String)
+        case badMinute(String)
+        case badOffsetSign(String)
+        case missingOffset(String)
+        case badOffset(String)
+        case offsetOutOfRange(Int)
+
+        var message: String {
+            switch self {
+            case .empty:
+                return "time value is empty. Use 'HH:MM', 'sunrise', 'sunset', or '<sun-event>±<minutes>'."
+            case .unknownFormat(let raw):
+                return "Invalid time '\(raw)'. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30')."
+            case .badHour(let raw):
+                return "Invalid time '\(raw)'. Hour must be 0-23."
+            case .badMinute(let raw):
+                return "Invalid time '\(raw)'. Minute must be 0-59 and exactly two digits."
+            case .badOffsetSign(let raw):
+                return "Invalid time '\(raw)'. Offset must start with '+' or '-' (e.g. 'sunset-30')."
+            case .missingOffset(let raw):
+                return "Invalid time '\(raw)'. Missing offset minutes after the sign."
+            case .badOffset(let raw):
+                return "Invalid time '\(raw)'. Offset must be a non-negative integer number of minutes."
+            case .offsetOutOfRange(let n):
+                return "Invalid time offset \(n) minutes. Offsets larger than \(maxOffsetMinutes) minutes (24h) are rejected — that's almost certainly a typo; use --days for weekday gating."
+            }
+        }
+    }
+
+    /// Strict parser for time-spec strings. Manager-side source of truth for
+    /// `create-time` automations. Accepts: `HH:MM` (24-hour, range 00:00-23:59,
+    /// both components two digits exactly), `sunrise`/`sunset`, `sunrise+N`,
+    /// `sunrise-N`, `sunset+N`, `sunset-N` where |N| <= 1440 (24h).
+    ///
+    /// The CLI-side mirror is `CreateAutomation.validateTimeOfDaySpec(...)` in
+    /// `Sources/homeclaw-cli/Commands/AutomationsCommand.swift`. Both parsers
+    /// implement identical rules so the CLI fails fast with friendly error
+    /// messages, the SocketServer re-validates via this function (defense-in-
+    /// depth), and the manager has the canonical truth at HomeKit-mutation time.
+    /// If you change rules here, update `validateTimeOfDaySpec` to match. The
+    /// CLI parser's unit tests in `Tests/homeclaw-cliTests/CreateTimeTests.swift`
+    /// cover the shared rule set; a direct unit test for this function would
+    /// require a new SPM test target that depends on the Catalyst module.
+    ///
+    /// Strict format checks: HH:MM must be exactly two digits each (`12:3` and
+    /// `12:345` are rejected, matching the user expectation that a time-of-day
+    /// automation can't silently re-interpret `12:5` as `12:50`).
+    static func parse(_ raw: String) throws -> TimeSpec {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { throw ParseError.empty }
+        let lower = trimmed.lowercased()
+
+        // HH:MM
+        if lower.contains(":") {
+            let parts = lower.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { throw ParseError.unknownFormat(raw) }
+            let hourStr = String(parts[0])
+            let minStr = String(parts[1])
+            // Reject ambiguous widths — `12:3` and `12:345` are both errors.
+            guard hourStr.count == 2, minStr.count == 2 else {
+                if hourStr.count != 2 { throw ParseError.badHour(raw) }
+                throw ParseError.badMinute(raw)
+            }
+            guard let hour = Int(hourStr), (0...23).contains(hour) else { throw ParseError.badHour(raw) }
+            guard let minute = Int(minStr), (0...59).contains(minute) else { throw ParseError.badMinute(raw) }
+            return .calendar(hour: hour, minute: minute)
+        }
+
+        // sunrise / sunset (with optional ±N offset)
+        let event: TimeCondition.Event
+        var rest: String
+        if lower.hasPrefix("sunrise") {
+            event = .sunrise
+            rest = String(lower.dropFirst("sunrise".count))
+        } else if lower.hasPrefix("sunset") {
+            event = .sunset
+            rest = String(lower.dropFirst("sunset".count))
+        } else {
+            throw ParseError.unknownFormat(raw)
+        }
+
+        if rest.isEmpty { return .significantTime(event: event, offsetMinutes: 0) }
+
+        guard let sign = rest.first, sign == "+" || sign == "-" else { throw ParseError.badOffsetSign(raw) }
+        let numStr = String(rest.dropFirst())
+        guard !numStr.isEmpty else { throw ParseError.missingOffset(raw) }
+        guard let magnitude = Int(numStr), magnitude >= 0 else { throw ParseError.badOffset(raw) }
+        if magnitude > maxOffsetMinutes { throw ParseError.offsetOutOfRange(magnitude) }
+        let signed = sign == "+" ? magnitude : -magnitude
+        return .significantTime(event: event, offsetMinutes: signed)
+    }
+
+    /// Construct the HMEvent the trigger fires on.
+    func makeEvent() -> HMEvent {
+        switch self {
+        case .calendar(let hour, let minute):
+            var dc = DateComponents()
+            dc.hour = hour
+            dc.minute = minute
+            return HMCalendarEvent(fire: dc)
+        case .significantTime(let event, let offsetMinutes):
+            let sigEvent = event == .sunrise ? HMSignificantEvent.sunrise : HMSignificantEvent.sunset
+            var offset: DateComponents? = nil
+            if offsetMinutes != 0 {
+                var dc = DateComponents()
+                dc.minute = offsetMinutes
+                offset = dc
+            }
+            return HMSignificantTimeEvent(significantEvent: sigEvent, offset: offset)
+        }
+    }
+
+    /// Canonical echo form (matches what `AccessoryModel.automationSummary`
+    /// renders on read-back). Used in the create-time result dict so the
+    /// CLI/MCP caller sees the parsed spec, not the raw input.
+    var canonicalString: String {
+        switch self {
+        case .calendar(let hour, let minute):
+            return String(format: "%02d:%02d", hour, minute)
+        case .significantTime(let event, let offsetMinutes):
+            let label = event == .sunrise ? "sunrise" : "sunset"
+            if offsetMinutes == 0 { return label }
+            return offsetMinutes > 0 ? "\(label)+\(offsetMinutes)" : "\(label)\(offsetMinutes)"
+        }
+    }
+}
+
+// MARK: - Resolved Condition (predicate composition input)
+
+/// A `--condition` row resolved against a real HomeKit accessory + characteristic.
+/// Shared by `createAutomation` (button/characteristic triggers) and
+/// `createTimeAutomation` (HH:MM / sunrise/sunset triggers) so both call sites
+/// build identically-shaped predicates via the shared `buildCombinedPredicate` helper.
+fileprivate struct ResolvedCondition {
+    let accessory: HMAccessory
+    let characteristic: HMCharacteristic
+    let property: String
+    let value: NSCopying & NSObjectProtocol
+    let rawValue: String
+}
+
 /// Central HomeKit interface. Must run on @MainActor because HMHomeManager
 /// requires main-thread delegate callbacks.
 @MainActor
@@ -892,54 +1064,18 @@ final class HomeKitManager: NSObject, Observable {
         }
 
         // Resolve & validate condition predicates up-front so we fail before mutating HomeKit.
-        // Each condition must reference a real accessory + characteristic; values must parse.
-        // The resolved tuples are then used both for predicate construction (Step 1b) and for
-        // structured echo back in the result dict.
-        struct ResolvedCondition {
-            let accessory: HMAccessory
-            let characteristic: HMCharacteristic
-            let property: String
-            let value: NSCopying & NSObjectProtocol
-            let rawValue: String
-        }
-        var resolvedConditions: [ResolvedCondition] = []
-        for cond in conditions {
-            guard let condAccessoryID = cond["accessory"],
-                  let condProperty = cond["property"],
-                  let condValueStr = cond["value"],
-                  !condAccessoryID.isEmpty, !condProperty.isEmpty, !condValueStr.isEmpty
-            else {
-                throw ControlError.invalidArgument("Condition must have non-empty 'accessory', 'property', and 'value' keys")
-            }
-            // Match createAutomation's own resolution: UUID first, then case-insensitive name
-            // (with optional `room` disambiguator if the caller supplied one).
-            let condAccessory: HMAccessory
-            if let found = home.accessories.first(where: { $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(condAccessoryID) == .orderedSame }) {
-                condAccessory = found
-            } else if let found = findAccessoryByName(condAccessoryID, room: cond["room"], in: home) {
-                condAccessory = found
-            } else {
-                throw ControlError.accessoryNotFound(condAccessoryID)
-            }
-            guard let condChar = findCharacteristicByDescription(on: condAccessory, property: condProperty) else {
-                throw ControlError.invalidArgument("Characteristic '\(condProperty)' not found on '\(condAccessory.name)' for --condition")
-            }
-            guard let parsed = parseActionValue(condValueStr, property: condProperty) else {
-                throw ControlError.invalidArgument("Cannot parse condition value '\(condValueStr)' for '\(condProperty)'")
-            }
-            resolvedConditions.append(ResolvedCondition(
-                accessory: condAccessory,
-                characteristic: condChar,
-                property: condProperty,
-                value: parsed,
-                rawValue: condValueStr
-            ))
-        }
+        // Shared with `createTimeAutomation` via `resolveConditions(_:in:)`.
+        let resolvedConditions = try resolveConditions(conditions, in: home)
 
         // iOS 15+ marks time-conditional automations without weekday gating as "unreliable".
         // Auto-fill all 7 days when --time-after / --time-before is set but --days is not,
         // so the automation actually fires. Surface this via `weekdays_auto_filled` so the
         // CLI/MCP caller knows we made a behavioural decision on their behalf.
+        // See `createTimeAutomation`: it auto-fills whenever `weekdays` is empty, since
+        // the trigger event is itself time-of-day. `createAutomation` only auto-fills
+        // when explicit time conditions are present — the trigger event here is a
+        // characteristic change, so without time predicates there's nothing for iOS
+        // to gate on.
         let weekdaysAutoFilled = !timeConditions.isEmpty && weekdays.isEmpty
         let effectiveWeekdays: [Int] = weekdaysAutoFilled ? [1, 2, 3, 4, 5, 6, 7] : weekdays
 
@@ -1115,109 +1251,51 @@ final class HomeKitManager: NSObject, Observable {
             predicate: nil
         )
 
-        // Step 1: Add trigger to home
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            home.addTrigger(trigger) { error in
-                if let error { continuation.resume(throwing: error) }
-                else { continuation.resume() }
-            }
-        }
-
-        // Step 1b: Build the combined trigger predicate from weekdays + conditions +
-        // time conditions and apply it in a single `updatePredicate` call.
-        //
-        // Only the LAST `updatePredicate` call sticks, so all three predicate kinds must be
-        // composed together. The structure is one outer AND:
-        //
-        //   AND(
-        //     existing-trigger-predicate,                  // currently always nil at this point
-        //     OR(weekday=1, weekday=2, ...),               // from --days / auto-fill
-        //     characteristic-condition-1,                  // from each --condition
-        //     characteristic-condition-2,
-        //     time-condition-1,                            // from each --time-after / --time-before
-        //     ...
-        //   )
-        //
-        // If only one of these is present, we either skip the call entirely (none) or pass the
-        // single predicate directly (no compound wrapper). Failure rolls back the orphan trigger
-        // (and inline action set if we created one), mirroring the action-set-link rollback path.
-        var subpredicates: [NSPredicate] = []
-        if let existing = trigger.predicate { subpredicates.append(existing) }
-        if !effectiveWeekdays.isEmpty {
-            let dayPredicates: [NSPredicate] = effectiveWeekdays.map { weekday in
-                var dc = DateComponents()
-                dc.weekday = weekday
-                return HMEventTrigger.predicateForEvaluatingTrigger(occurringOn: dc)
-            }
-            subpredicates.append(
-                dayPredicates.count == 1
-                    ? dayPredicates[0]
-                    : NSCompoundPredicate(orPredicateWithSubpredicates: dayPredicates)
-            )
-        }
-        for cond in resolvedConditions {
-            subpredicates.append(
-                HMEventTrigger.predicateForEvaluatingTrigger(
-                    cond.characteristic,
-                    relatedBy: .equalTo,
-                    toValue: cond.value
-                )
-            )
-        }
-        for tc in timeConditions {
-            if let p = tc.predicate() { subpredicates.append(p) }
-        }
-        if !subpredicates.isEmpty {
-            let combinedPredicate: NSPredicate = subpredicates.count == 1
-                ? subpredicates[0]
-                : NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
-            do {
-                try await homeKitAsync { trigger.updatePredicate(combinedPredicate, completionHandler: $0) }
-            } catch {
-                // Cleanup on predicate failure: remove the orphaned trigger AND the inline
-                // action set if we created one. (The action set exists in `home.actionSets`
-                // from Step 1's `addActionSet` call even though it's not yet linked to the
-                // trigger — without this removal it would persist as an orphaned scene tile.)
-                if isInlineActionSet {
-                    try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                        home.removeActionSet(actionSet) { err in
-                            if let err { continuation.resume(throwing: err) }
-                            else { continuation.resume() }
-                        }
-                    }
+        // Step 1: Add trigger to home. On failure, clean up the inline action set
+        // (which already lives in `home.actionSets` from `addActionSet`) so a
+        // failed addTrigger doesn't leave an orphan scene tile in the Home app.
+        // Mirrors the cleanup shape used in `createTimeAutomation`'s Step 1 — fulfils
+        // the PR #59 follow-up to audit `createAutomation`'s failure paths for
+        // orphan-action-set leaks.
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                home.addTrigger(trigger) { error in
+                    if let error { continuation.resume(throwing: error) }
+                    else { continuation.resume() }
                 }
+            }
+        } catch {
+            if isInlineActionSet {
                 try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    home.removeTrigger(trigger) { err in
+                    home.removeActionSet(actionSet) { err in
                         if let err { continuation.resume(throwing: err) }
                         else { continuation.resume() }
                     }
                 }
-                throw error
             }
+            throw error
         }
+
+        // Step 1b: Build & apply the combined trigger predicate (weekdays + conditions +
+        // time conditions). Shared with `createTimeAutomation`. On failure, the helper
+        // tears down the orphan trigger and inline action set if applicable.
+        try await applyCombinedPredicate(
+            to: trigger,
+            weekdays: effectiveWeekdays,
+            resolvedConditions: resolvedConditions,
+            timeConditions: timeConditions,
+            isInlineActionSet: isInlineActionSet,
+            actionSet: actionSet,
+            in: home
+        )
 
         // Step 1c: Attach an HMDurationEvent end-event so HomeKit reverts the
         // trigger's actions after N seconds (e.g. motion-triggered light auto-off).
-        // Mirrors the predicate cleanup pattern: on failure, tear down the orphan
-        // trigger (and inline action set if we created one) before rethrowing.
         if let durationSeconds {
             do {
                 try await applyDuration(seconds: durationSeconds, to: trigger)
             } catch {
-                if isInlineActionSet {
-                    try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                        home.removeActionSet(actionSet) { err in
-                            if let err { continuation.resume(throwing: err) }
-                            else { continuation.resume() }
-                        }
-                    }
-                }
-                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    home.removeTrigger(trigger) { err in
-                        if let err { continuation.resume(throwing: err) }
-                        else { continuation.resume() }
-                    }
-                }
+                await cleanupOrphans(trigger: trigger, isInlineActionSet: isInlineActionSet, actionSet: actionSet, in: home)
                 throw error
             }
         }
@@ -1231,21 +1309,7 @@ final class HomeKitManager: NSObject, Observable {
                 }
             }
         } catch {
-            // Cleanup: remove the orphaned trigger (and inline action set if we created one)
-            if isInlineActionSet {
-                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    home.removeActionSet(actionSet) { err in
-                        if let err { continuation.resume(throwing: err) }
-                        else { continuation.resume() }
-                    }
-                }
-            }
-            try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                home.removeTrigger(trigger) { err in
-                    if let err { continuation.resume(throwing: err) }
-                    else { continuation.resume() }
-                }
-            }
+            await cleanupOrphans(trigger: trigger, isInlineActionSet: isInlineActionSet, actionSet: actionSet, in: home)
             throw error
         }
 
@@ -1253,21 +1317,7 @@ final class HomeKitManager: NSObject, Observable {
         do {
             try await homeKitAsync { trigger.enable(true, completionHandler: $0) }
         } catch {
-            // Cleanup on enable failure
-            if isInlineActionSet {
-                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    home.removeActionSet(actionSet) { err in
-                        if let err { continuation.resume(throwing: err) }
-                        else { continuation.resume() }
-                    }
-                }
-            }
-            try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                home.removeTrigger(trigger) { err in
-                    if let err { continuation.resume(throwing: err) }
-                    else { continuation.resume() }
-                }
-            }
+            await cleanupOrphans(trigger: trigger, isInlineActionSet: isInlineActionSet, actionSet: actionSet, in: home)
             throw error
         }
 
@@ -1301,16 +1351,430 @@ final class HomeKitManager: NSObject, Observable {
         return attachPredicateFields(result)
     }
 
+    /// Create a time-of-day automation: `HMCalendarEvent` (HH:MM) or
+    /// `HMSignificantTimeEvent` (sunrise/sunset, optionally offset) as the trigger
+    /// event, with the same predicate-flag vocabulary as `createAutomation`
+    /// (`weekdays` / `conditions` / `timeConditionsAfter` / `timeConditionsBefore` /
+    /// `durationSeconds`) ANDed into the trigger's predicate.
+    ///
+    /// The time-of-day spec is itself the trigger *event*, not a predicate. Adding
+    /// a `--time-after sunset-30` flag to a `06:30` clock automation means "fire at
+    /// 06:30 AND only when it's already past 30 minutes before sunset" — useful for
+    /// e.g. a coffee-maker automation that should skip the wake-up step in summer
+    /// when the user is already up.
+    ///
+    /// Auto-fills `weekdays = [1...7]` (every day) when omitted, since the
+    /// trigger event itself is time-of-day and iOS 15+ marks time-conditional
+    /// automations without weekday gating as "unreliable". This is stricter
+    /// than `createAutomation`, which only auto-fills when explicit time
+    /// conditions (`--time-after`/`--time-before`) are present. See the
+    /// inline rationale near the `effectiveWeekdays` definition.
+    func createTimeAutomation(
+        name: String,
+        time: String,
+        weekdays: [Int] = [],
+        conditions: [[String: String]] = [],
+        timeConditions: [TimeCondition] = [],
+        durationSeconds: Int? = nil,
+        sceneID: String? = nil,
+        actions: [[String: String]]? = nil,
+        homeID: String? = nil,
+        dryRun: Bool = false
+    ) async throws -> [String: Any] {
+        await waitForReady()
+        let home = try resolveHome(homeID: homeID)
+
+        // Parse the trigger time-of-day spec. Maps the strict-string ParseError
+        // surface to ControlError so direct-socket callers get a precise message.
+        let timeSpec: TimeSpec
+        do {
+            timeSpec = try TimeSpec.parse(time)
+        } catch let err as TimeSpec.ParseError {
+            throw ControlError.invalidArgument(err.message)
+        }
+
+        // Resolve conditions up-front (shared with createAutomation).
+        let resolvedConditions = try resolveConditions(conditions, in: home)
+
+        // iOS 15+ marks time-conditional automations without weekday gating as
+        // "unreliable", and that warning applies just as strongly when the
+        // trigger event IS itself a time-of-day fire — the OS treats `endEvent`,
+        // `recurrences`, and predicate-gated time windows the same way. Auto-fill
+        // all 7 days when no `--days` was provided so the trigger actually fires.
+        let weekdaysAutoFilled = weekdays.isEmpty
+        let effectiveWeekdays: [Int] = weekdaysAutoFilled ? [1, 2, 3, 4, 5, 6, 7] : weekdays
+
+        // Echo conditions / time conditions back to the caller, identical shape to createAutomation.
+        let conditionsEcho: [[String: String]] = resolvedConditions.map {
+            [
+                "accessory": $0.accessory.name,
+                "accessory_id": $0.accessory.uniqueIdentifier.uuidString,
+                "property": $0.property,
+                "value": $0.rawValue,
+            ]
+        }
+        let timeAfterEcho: [String] = timeConditions.compactMap {
+            guard $0.relation == .after else { return nil }
+            let ev = $0.event == .sunrise ? "sunrise" : "sunset"
+            if $0.offsetMinutes == 0 { return ev }
+            return $0.offsetMinutes > 0 ? "\(ev)+\($0.offsetMinutes)" : "\(ev)\($0.offsetMinutes)"
+        }
+        let timeBeforeEcho: [String] = timeConditions.compactMap {
+            guard $0.relation == .before else { return nil }
+            let ev = $0.event == .sunrise ? "sunrise" : "sunset"
+            if $0.offsetMinutes == 0 { return ev }
+            return $0.offsetMinutes > 0 ? "\(ev)+\($0.offsetMinutes)" : "\(ev)\($0.offsetMinutes)"
+        }
+
+        // Derive the read-side trigger_type tag to match what
+        // `AccessoryModel.automationSummary` will render on subsequent list/get.
+        let triggerTypeTag: String
+        switch timeSpec {
+        case .calendar: triggerTypeTag = "calendar"
+        case .significantTime: triggerTypeTag = "significant_time"
+        }
+
+        let attachPredicateFields: ([String: Any]) -> [String: Any] = { existing in
+            var r = existing
+            if !effectiveWeekdays.isEmpty { r["weekdays"] = effectiveWeekdays }
+            if weekdaysAutoFilled { r["weekdays_auto_filled"] = true }
+            if !conditionsEcho.isEmpty { r["conditions"] = conditionsEcho }
+            if !timeAfterEcho.isEmpty { r["time_after"] = timeAfterEcho }
+            if !timeBeforeEcho.isEmpty { r["time_before"] = timeBeforeEcho }
+            return r
+        }
+
+        // Resolve the action set: existing scene or inline action set.
+        let actionSet: HMActionSet
+        let isInlineActionSet: Bool
+
+        if let actions, !actions.isEmpty {
+            let resolvedActions = try resolveActions(actions, in: home)
+
+            if dryRun {
+                var result: [String: Any] = [
+                    "dry_run": true,
+                    "inline_actions": true,
+                    "name": name,
+                    "home": home.name,
+                    "trigger_type": triggerTypeTag,
+                    "time": timeSpec.canonicalString,
+                    "action_count": resolvedActions.count,
+                    "actions": resolvedActions.map { action in
+                        [
+                            "accessory": action.accessory.name,
+                            "characteristic": CharacteristicMapper.name(for: action.characteristic.characteristicType),
+                            "value": "\(action.value)",
+                        ] as [String: String]
+                    },
+                ]
+                if let durationSeconds { result["duration_seconds"] = durationSeconds }
+                return attachPredicateFields(result)
+            }
+
+            let inlineSetName = name
+            let newActionSet = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<HMActionSet, Error>) in
+                home.addActionSet(withName: inlineSetName) { actionSet, error in
+                    if let error { continuation.resume(throwing: error) }
+                    else if let actionSet { continuation.resume(returning: actionSet) }
+                    else { continuation.resume(throwing: ControlError.writeFailed("Failed to create action set")) }
+                }
+            }
+
+            for resolved in resolvedActions {
+                let writeAction = HMCharacteristicWriteAction(
+                    characteristic: resolved.characteristic,
+                    targetValue: resolved.value as! NSCopying & NSObjectProtocol
+                )
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    newActionSet.addAction(writeAction) { error in
+                        if let error { continuation.resume(throwing: error) }
+                        else { continuation.resume() }
+                    }
+                }
+            }
+
+            actionSet = newActionSet
+            isInlineActionSet = true
+        } else if let sceneID {
+            guard let existingSet = home.actionSets.first(where: { $0.uniqueIdentifier.uuidString == sceneID })
+                    ?? home.actionSets.first(where: { $0.name.localizedCaseInsensitiveCompare(sceneID) == .orderedSame })
+            else {
+                throw ControlError.sceneNotFound(sceneID)
+            }
+
+            if dryRun {
+                var result: [String: Any] = [
+                    "dry_run": true,
+                    "name": name,
+                    "home": home.name,
+                    "trigger_type": triggerTypeTag,
+                    "time": timeSpec.canonicalString,
+                    "scene": existingSet.name,
+                ]
+                if let durationSeconds { result["duration_seconds"] = durationSeconds }
+                return attachPredicateFields(result)
+            }
+
+            actionSet = existingSet
+            isInlineActionSet = false
+        } else {
+            throw ControlError.writeFailed("Either 'scene_id' or 'actions' must be provided")
+        }
+
+        // Build the trigger from the time spec.
+        let triggerEvent = timeSpec.makeEvent()
+        let trigger = HMEventTrigger(
+            name: name,
+            events: [triggerEvent],
+            end: nil,
+            recurrences: nil,
+            predicate: nil
+        )
+
+        // Step 1: Add trigger to home. On failure, clean up the inline action set
+        // (which already lives in `home.actionSets` from `addActionSet`).
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                home.addTrigger(trigger) { error in
+                    if let error { continuation.resume(throwing: error) }
+                    else { continuation.resume() }
+                }
+            }
+        } catch {
+            if isInlineActionSet {
+                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    home.removeActionSet(actionSet) { err in
+                        if let err { continuation.resume(throwing: err) }
+                        else { continuation.resume() }
+                    }
+                }
+            }
+            throw error
+        }
+
+        // Step 1b: predicate composition + cleanup-on-failure. Shared with createAutomation.
+        try await applyCombinedPredicate(
+            to: trigger,
+            weekdays: effectiveWeekdays,
+            resolvedConditions: resolvedConditions,
+            timeConditions: timeConditions,
+            isInlineActionSet: isInlineActionSet,
+            actionSet: actionSet,
+            in: home
+        )
+
+        // Step 1c: optional HMDurationEvent. Same cleanup pattern as Step 1b.
+        if let durationSeconds {
+            do {
+                try await applyDuration(seconds: durationSeconds, to: trigger)
+            } catch {
+                await cleanupOrphans(trigger: trigger, isInlineActionSet: isInlineActionSet, actionSet: actionSet, in: home)
+                throw error
+            }
+        }
+
+        // Step 2: Link the action set.
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                trigger.addActionSet(actionSet) { error in
+                    if let error { continuation.resume(throwing: error) }
+                    else { continuation.resume() }
+                }
+            }
+        } catch {
+            await cleanupOrphans(trigger: trigger, isInlineActionSet: isInlineActionSet, actionSet: actionSet, in: home)
+            throw error
+        }
+
+        // Step 3: Enable the trigger.
+        do {
+            try await homeKitAsync { trigger.enable(true, completionHandler: $0) }
+        } catch {
+            await cleanupOrphans(trigger: trigger, isInlineActionSet: isInlineActionSet, actionSet: actionSet, in: home)
+            throw error
+        }
+
+        let actionLabel = isInlineActionSet ? "\(actionSet.actions.count) inline action(s)" : actionSet.name
+        AppLogger.homekit.info("[\(home.name)] Created time automation '\(name)': \(timeSpec.canonicalString) → \(actionLabel)")
+        var result: [String: Any] = [
+            "id": trigger.uniqueIdentifier.uuidString,
+            "name": name,
+            "home": home.name,
+            "trigger_type": triggerTypeTag,
+            "time": timeSpec.canonicalString,
+            "enabled": true,
+            "dry_run": false,
+            "action_count": actionSet.actions.count,
+        ]
+        if isInlineActionSet {
+            result["inline_actions"] = true
+        } else {
+            result["scene"] = actionSet.name
+        }
+        if let durationSeconds {
+            result["duration_seconds"] = durationSeconds
+        }
+        return attachPredicateFields(result)
+    }
+
     /// Add an HMDurationEvent to the trigger's `endEvents` so HomeKit reverts
     /// any characteristics turned on by the trigger after the given duration.
-    /// Used by `--duration N` on `automations create` to implement auto-off
-    /// for motion-triggered lights and similar patterns.
+    /// Used by `--duration N` on `automations create` / `create-time` to implement
+    /// auto-off for motion-triggered lights and similar patterns.
     private func applyDuration(seconds: Int, to trigger: HMEventTrigger) async throws {
         let durationEvent = HMDurationEvent(duration: TimeInterval(seconds))
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             trigger.updateEndEvents([durationEvent]) { error in
                 if let error { continuation.resume(throwing: error) }
                 else { continuation.resume() }
+            }
+        }
+    }
+
+    /// Resolve raw `--condition` rows against the home's accessories + characteristics.
+    /// Fails before any HomeKit mutation if any condition is malformed, references an
+    /// unknown accessory/characteristic, or has an unparseable value. Shared by
+    /// `createAutomation` and `createTimeAutomation`.
+    fileprivate func resolveConditions(_ conditions: [[String: String]], in home: HMHome) throws -> [ResolvedCondition] {
+        var resolved: [ResolvedCondition] = []
+        for cond in conditions {
+            guard let condAccessoryID = cond["accessory"],
+                  let condProperty = cond["property"],
+                  let condValueStr = cond["value"],
+                  !condAccessoryID.isEmpty, !condProperty.isEmpty, !condValueStr.isEmpty
+            else {
+                throw ControlError.invalidArgument("Condition must have non-empty 'accessory', 'property', and 'value' keys")
+            }
+            let condAccessory: HMAccessory
+            if let found = home.accessories.first(where: { $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(condAccessoryID) == .orderedSame }) {
+                condAccessory = found
+            } else if let found = findAccessoryByName(condAccessoryID, room: cond["room"], in: home) {
+                condAccessory = found
+            } else {
+                throw ControlError.accessoryNotFound(condAccessoryID)
+            }
+            guard let condChar = findCharacteristicByDescription(on: condAccessory, property: condProperty) else {
+                throw ControlError.invalidArgument("Characteristic '\(condProperty)' not found on '\(condAccessory.name)' for --condition")
+            }
+            guard let parsed = parseActionValue(condValueStr, property: condProperty) else {
+                throw ControlError.invalidArgument("Cannot parse condition value '\(condValueStr)' for '\(condProperty)'")
+            }
+            resolved.append(ResolvedCondition(
+                accessory: condAccessory,
+                characteristic: condChar,
+                property: condProperty,
+                value: parsed,
+                rawValue: condValueStr
+            ))
+        }
+        return resolved
+    }
+
+    /// Build the AND-combined trigger predicate from weekdays + characteristic
+    /// conditions + sun-relative time conditions.
+    ///
+    /// Returns nil if all inputs are empty (no `updatePredicate` call needed).
+    /// Returns the single subpredicate directly if only one is present, or an
+    /// `NSCompoundPredicate(andPredicateWithSubpredicates:)` otherwise. Mirrors
+    /// the structure documented in `createAutomation`'s Step 1b.
+    fileprivate func buildCombinedPredicate(
+        existing: NSPredicate?,
+        weekdays: [Int],
+        resolvedConditions: [ResolvedCondition],
+        timeConditions: [TimeCondition]
+    ) -> NSPredicate? {
+        var subpredicates: [NSPredicate] = []
+        if let existing { subpredicates.append(existing) }
+        if !weekdays.isEmpty {
+            let dayPredicates: [NSPredicate] = weekdays.map { weekday in
+                var dc = DateComponents()
+                dc.weekday = weekday
+                return HMEventTrigger.predicateForEvaluatingTrigger(occurringOn: dc)
+            }
+            subpredicates.append(
+                dayPredicates.count == 1
+                    ? dayPredicates[0]
+                    : NSCompoundPredicate(orPredicateWithSubpredicates: dayPredicates)
+            )
+        }
+        for cond in resolvedConditions {
+            subpredicates.append(
+                HMEventTrigger.predicateForEvaluatingTrigger(
+                    cond.characteristic,
+                    relatedBy: .equalTo,
+                    toValue: cond.value
+                )
+            )
+        }
+        for tc in timeConditions {
+            if let p = tc.predicate() { subpredicates.append(p) }
+        }
+        if subpredicates.isEmpty { return nil }
+        if subpredicates.count == 1 { return subpredicates[0] }
+        return NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
+    }
+
+    /// Compose + apply the combined predicate to the trigger. On failure, clean
+    /// up the orphan trigger and inline action set (if applicable) before rethrowing.
+    /// Shared with `createTimeAutomation` so both call sites use the same Step 1b shape.
+    fileprivate func applyCombinedPredicate(
+        to trigger: HMEventTrigger,
+        weekdays: [Int],
+        resolvedConditions: [ResolvedCondition],
+        timeConditions: [TimeCondition],
+        isInlineActionSet: Bool,
+        actionSet: HMActionSet,
+        in home: HMHome
+    ) async throws {
+        let combinedPredicate = buildCombinedPredicate(
+            existing: trigger.predicate,
+            weekdays: weekdays,
+            resolvedConditions: resolvedConditions,
+            timeConditions: timeConditions
+        )
+        guard let combinedPredicate else { return }
+        do {
+            try await homeKitAsync { trigger.updatePredicate(combinedPredicate, completionHandler: $0) }
+        } catch {
+            await cleanupOrphans(trigger: trigger, isInlineActionSet: isInlineActionSet, actionSet: actionSet, in: home)
+            throw error
+        }
+    }
+
+    /// Tear down an orphan trigger (and inline action set if we created one)
+    /// after a failed step in `createAutomation` / `createTimeAutomation`.
+    /// Swallows individual removal errors with `try?` so the caller's original
+    /// error is the one that surfaces. Mirrors the cleanup pattern from the
+    /// `e6ffa1b` Step 1b hardening (PR #59) — the action set exists in
+    /// `home.actionSets` from `addActionSet` regardless of whether it's been
+    /// linked to the trigger.
+    ///
+    /// Order matters: remove the trigger FIRST, then the action set. In Step 2/3
+    /// failure paths the action set is already linked to the trigger when cleanup
+    /// runs; HomeKit may reject `removeActionSet` on a linked action set, and
+    /// because the error is swallowed by `try?` the action set would silently
+    /// persist in `home.actionSets`. Removing the trigger first unlinks any
+    /// referenced action sets, so the subsequent `removeActionSet` operates on
+    /// a true orphan and succeeds.
+    fileprivate func cleanupOrphans(
+        trigger: HMEventTrigger,
+        isInlineActionSet: Bool,
+        actionSet: HMActionSet,
+        in home: HMHome
+    ) async {
+        try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            home.removeTrigger(trigger) { err in
+                if let err { continuation.resume(throwing: err) }
+                else { continuation.resume() }
+            }
+        }
+        if isInlineActionSet {
+            try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                home.removeActionSet(actionSet) { err in
+                    if let err { continuation.resume(throwing: err) }
+                    else { continuation.resume() }
+                }
             }
         }
     }

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -1189,17 +1189,31 @@ final class HomeKitManager: NSObject, Observable {
                 }
             }
 
-            for resolved in resolvedActions {
-                let writeAction = HMCharacteristicWriteAction(
-                    characteristic: resolved.characteristic,
-                    targetValue: resolved.value as! NSCopying & NSObjectProtocol
-                )
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    newActionSet.addAction(writeAction) { error in
-                        if let error { continuation.resume(throwing: error) }
+            do {
+                for resolved in resolvedActions {
+                    let writeAction = HMCharacteristicWriteAction(
+                        characteristic: resolved.characteristic,
+                        targetValue: resolved.value as! NSCopying & NSObjectProtocol
+                    )
+                    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                        newActionSet.addAction(writeAction) { error in
+                            if let error { continuation.resume(throwing: error) }
+                            else { continuation.resume() }
+                        }
+                    }
+                }
+            } catch {
+                // Cleanup on partial-add failure: the action set already lives in
+                // `home.actionSets` from `addActionSet`, but the trigger hasn't been
+                // created yet, so a leaked orphan scene tile would persist in the
+                // Home app. Remove it before rethrowing.
+                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    home.removeActionSet(newActionSet) { err in
+                        if let err { continuation.resume(throwing: err) }
                         else { continuation.resume() }
                     }
                 }
+                throw error
             }
 
             actionSet = newActionSet
@@ -1481,17 +1495,31 @@ final class HomeKitManager: NSObject, Observable {
                 }
             }
 
-            for resolved in resolvedActions {
-                let writeAction = HMCharacteristicWriteAction(
-                    characteristic: resolved.characteristic,
-                    targetValue: resolved.value as! NSCopying & NSObjectProtocol
-                )
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    newActionSet.addAction(writeAction) { error in
-                        if let error { continuation.resume(throwing: error) }
+            do {
+                for resolved in resolvedActions {
+                    let writeAction = HMCharacteristicWriteAction(
+                        characteristic: resolved.characteristic,
+                        targetValue: resolved.value as! NSCopying & NSObjectProtocol
+                    )
+                    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                        newActionSet.addAction(writeAction) { error in
+                            if let error { continuation.resume(throwing: error) }
+                            else { continuation.resume() }
+                        }
+                    }
+                }
+            } catch {
+                // Cleanup on partial-add failure: the action set already lives in
+                // `home.actionSets` from `addActionSet`, but the trigger hasn't been
+                // created yet, so a leaked orphan scene tile would persist in the
+                // Home app. Remove it before rethrowing.
+                try? await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    home.removeActionSet(newActionSet) { err in
+                        if let err { continuation.resume(throwing: err) }
                         else { continuation.resume() }
                     }
                 }
+                throw error
             }
 
             actionSet = newActionSet

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -16,6 +16,119 @@ final class SocketServer: @unchecked Sendable {
         (args[key] as? Bool) ?? (args[key] as? String).map { $0 == "true" } ?? defaultValue
     }
 
+    /// Thrown by `parseWeekdaysArg` when `weekdays` is present but malformed.
+    /// Caller maps the `.message` to `encodeResponse(success: false, error:)`.
+    /// Absent → returns `[]` (does not throw), matching the existing default-empty
+    /// behavior for the optional `--days` flag.
+    fileprivate struct WeekdaysArgError: Error {
+        let message: String
+    }
+
+    /// Thrown by `parseAccessoryRowsArg` when an `actions` / `conditions` arg is
+    /// present but malformed. Caller maps the `.message` to `encodeResponse(success: false, error:)`.
+    /// Absent → returns `nil` (does not throw); empty array → returns `[]`.
+    fileprivate struct AccessoryRowsArgError: Error {
+        let message: String
+    }
+
+    /// Strict parser for `actions` / `conditions` socket args (both have the same
+    /// `accessory:property:value` row shape, with optional `room`). Mirrors the
+    /// `e6ffa1b` `duration_seconds` validation pattern: distinguish absent from
+    /// unparseable, reject `__NSCFBoolean` explicitly so JSON `true`/`false` don't
+    /// silently coerce, and validate every required field is a non-empty `String`.
+    ///
+    /// - Parameters:
+    ///   - raw: the raw arg value (typically `args["actions"]` or `args["conditions"]`).
+    ///   - fieldName: the JSON key name (`"actions"` or `"conditions"`), used in error messages.
+    /// - Returns: parsed `[[String: String]]`, or `nil` if the arg is absent. An
+    ///   explicit empty array round-trips as `[]` so callers can distinguish absent
+    ///   from explicit-empty.
+    /// - Throws: `AccessoryRowsArgError` if the arg is present but not an array,
+    ///   contains a non-dict element, or contains an element missing/empty/non-string
+    ///   `accessory`/`property`/`value` fields, or with non-string field values.
+    fileprivate static func parseAccessoryRowsArg(_ raw: Any?, fieldName: String) throws -> [[String: String]]? {
+        guard let raw else { return nil }
+        guard let array = raw as? [Any] else {
+            throw AccessoryRowsArgError(message: "'\(fieldName)' must be an array of {accessory, property, value} dicts")
+        }
+        var result: [[String: String]] = []
+        result.reserveCapacity(array.count)
+        for (index, element) in array.enumerated() {
+            guard let dict = element as? [String: Any] else {
+                throw AccessoryRowsArgError(message: "'\(fieldName)'[\(index)] must be a dict with string 'accessory', 'property', 'value' fields")
+            }
+            var row: [String: String] = [:]
+            for key in ["accessory", "property", "value"] {
+                guard let raw = dict[key] else {
+                    throw AccessoryRowsArgError(message: "'\(fieldName)'[\(index)] missing required string field '\(key)'")
+                }
+                // Reject NSNumber-bools and NSNumbers: JSON booleans bridge as
+                // __NSCFBoolean and would silently cast in surprising ways.
+                if let nsNum = raw as? NSNumber, CFGetTypeID(nsNum) == CFBooleanGetTypeID() {
+                    throw AccessoryRowsArgError(message: "'\(fieldName)'[\(index)].\(key) is a boolean; expected a non-empty string")
+                }
+                guard let strVal = raw as? String else {
+                    throw AccessoryRowsArgError(message: "'\(fieldName)'[\(index)].\(key) must be a string")
+                }
+                guard !strVal.isEmpty else {
+                    throw AccessoryRowsArgError(message: "'\(fieldName)'[\(index)].\(key) must be a non-empty string")
+                }
+                row[key] = strVal
+            }
+            // Optional `room` field — preserve if present and string-valued.
+            if let roomRaw = dict["room"] {
+                if let roomStr = roomRaw as? String, !roomStr.isEmpty {
+                    row["room"] = roomStr
+                } else {
+                    throw AccessoryRowsArgError(message: "'\(fieldName)'[\(index)].room must be a non-empty string when provided")
+                }
+            }
+            result.append(row)
+        }
+        return result
+    }
+
+    /// Strict parser for the `weekdays` socket arg. Mirrors the `e6ffa1b`
+    /// `duration_seconds` validation pattern: distinguish absent from unparseable, reject
+    /// `__NSCFBoolean` explicitly so JSON `true`/`false` don't coerce to `1`/`0`,
+    /// and validate each element is an `Int` (or `String` parseable to `Int`)
+    /// in the HomeKit weekday range `1...7` (1=Sunday, 7=Saturday).
+    ///
+    /// - Returns: parsed `[Int]` (empty if the arg is absent).
+    /// - Throws: `WeekdaysArgError` if the arg is present but not an array,
+    ///   contains a non-Int / non-Int-parseable-String element, contains an
+    ///   `NSNumber`-bool, or contains an element outside `1...7`.
+    fileprivate static func parseWeekdaysArg(_ raw: Any?) throws -> [Int] {
+        guard let raw else { return [] }
+        guard let array = raw as? [Any] else {
+            throw WeekdaysArgError(message: "'weekdays' must be an array of integers in 1...7 (1=Sunday, 7=Saturday)")
+        }
+        var result: [Int] = []
+        result.reserveCapacity(array.count)
+        for element in array {
+            // Reject JSON booleans (bridged as __NSCFBoolean, which casts to Int 0/1).
+            if let nsNum = element as? NSNumber, CFGetTypeID(nsNum) == CFBooleanGetTypeID() {
+                throw WeekdaysArgError(message: "'weekdays' contains a boolean; expected integers in 1...7")
+            }
+            let parsed: Int?
+            if let intVal = element as? Int {
+                parsed = intVal
+            } else if let strVal = element as? String, let intFromStr = Int(strVal) {
+                parsed = intFromStr
+            } else {
+                parsed = nil
+            }
+            guard let day = parsed else {
+                throw WeekdaysArgError(message: "'weekdays' contains a non-integer value; expected integers in 1...7")
+            }
+            guard (1...7).contains(day) else {
+                throw WeekdaysArgError(message: "'weekdays' value \(day) is out of range; expected integers in 1...7 (1=Sunday, 7=Saturday)")
+            }
+            result.append(day)
+        }
+        return result
+    }
+
     /// Start the socket server synchronously (non-blocking — sets up GCD dispatch sources).
     func start() {
         let path = AppConfig.socketPath
@@ -687,14 +800,23 @@ final class SocketServer: @unchecked Sendable {
                 )
 
             case "create_automation":
-                guard let name = args["name"] as? String else {
-                    return encodeResponse(success: false, error: "Missing 'name' argument")
+                guard let name = args["name"] as? String, !name.trimmingCharacters(in: .whitespaces).isEmpty else {
+                    return encodeResponse(success: false, error: "Missing or empty 'name' argument")
                 }
                 guard let accessoryID = args["accessory_id"] as? String else {
                     return encodeResponse(success: false, error: "Missing 'accessory_id' argument")
                 }
                 let sceneID = args["scene_id"] as? String
-                let actions = args["actions"] as? [[String: String]]
+                // Strict parse: distinguish absent (nil) from present-but-malformed
+                // (throws) so a misshapen `actions` arg returns a precise error
+                // instead of silently coercing to nil and surfacing the misleading
+                // "Either 'scene_id' or 'actions' array is required".
+                let actions: [[String: String]]?
+                do {
+                    actions = try Self.parseAccessoryRowsArg(args["actions"], fieldName: "actions")
+                } catch let err as AccessoryRowsArgError {
+                    return encodeResponse(success: false, error: err.message)
+                }
                 guard sceneID != nil || (actions != nil && !actions!.isEmpty) else {
                     return encodeResponse(success: false, error: "Either 'scene_id' or 'actions' array is required")
                 }
@@ -705,10 +827,18 @@ final class SocketServer: @unchecked Sendable {
                     ?? 0
                 let serviceIndex = (args["service_index"] as? Int)
                     ?? (args["service_index"] as? String).flatMap(Int.init)
-                let weekdays = (args["weekdays"] as? [Int])
-                    ?? (args["weekdays"] as? [String])?.compactMap(Int.init)
-                    ?? []
-                let conditions = (args["conditions"] as? [[String: String]]) ?? []
+                let weekdays: [Int]
+                do {
+                    weekdays = try Self.parseWeekdaysArg(args["weekdays"])
+                } catch let err as WeekdaysArgError {
+                    return encodeResponse(success: false, error: err.message)
+                }
+                let conditions: [[String: String]]
+                do {
+                    conditions = try Self.parseAccessoryRowsArg(args["conditions"], fieldName: "conditions") ?? []
+                } catch let err as AccessoryRowsArgError {
+                    return encodeResponse(success: false, error: err.message)
+                }
                 // Parse sun-relative time predicates. The CLI/MCP layer pre-validates format,
                 // but defensively re-validate here so direct socket clients can't bypass it.
                 let timeAfterRaw = (args["time_after"] as? [String]) ?? []
@@ -765,6 +895,102 @@ final class SocketServer: @unchecked Sendable {
                     conditions: conditions,
                     timeConditions: timeConditions,
                     durationSeconds: durationSeconds,
+                    homeID: args["home_id"] as? String,
+                    dryRun: parseBool(args, key: "dry_run")
+                )
+
+            case "create_time_automation":
+                guard let name = args["name"] as? String, !name.isEmpty else {
+                    return encodeResponse(success: false, error: "Missing or empty 'name' argument")
+                }
+                guard let time = args["time"] as? String, !time.trimmingCharacters(in: .whitespaces).isEmpty else {
+                    return encodeResponse(success: false,
+                        error: "Missing or empty 'time' argument. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30').")
+                }
+                // Defense-in-depth: re-validate format here so direct-socket clients
+                // can't bypass the CLI's `validateTimeOfDaySpec` pre-check. The
+                // manager re-runs `TimeSpec.parse` at HomeKit-mutation time (it's the
+                // canonical source of truth); this layer just shortens the round-trip
+                // for bad input. Errors surface the underlying `ParseError.message`
+                // text the manager would have returned, prefixed with `Invalid 'time'
+                // argument:` so socket clients know which arg failed.
+                do {
+                    _ = try TimeSpec.parse(time)
+                } catch let err as TimeSpec.ParseError {
+                    return encodeResponse(success: false, error: "Invalid 'time' argument: \(err.message)")
+                }
+                let sceneID = args["scene_id"] as? String
+                // Strict parse: see `create_automation` for the rationale (distinguish
+                // absent from present-but-malformed so the "Either 'scene_id' or 'actions'…"
+                // error is reserved for the genuinely-missing case).
+                let actions: [[String: String]]?
+                do {
+                    actions = try Self.parseAccessoryRowsArg(args["actions"], fieldName: "actions")
+                } catch let err as AccessoryRowsArgError {
+                    return encodeResponse(success: false, error: err.message)
+                }
+                guard sceneID != nil || (actions != nil && !actions!.isEmpty) else {
+                    return encodeResponse(success: false, error: "Either 'scene_id' or 'actions' array is required")
+                }
+                let weekdays: [Int]
+                do {
+                    weekdays = try Self.parseWeekdaysArg(args["weekdays"])
+                } catch let err as WeekdaysArgError {
+                    return encodeResponse(success: false, error: err.message)
+                }
+                let conditions: [[String: String]]
+                do {
+                    conditions = try Self.parseAccessoryRowsArg(args["conditions"], fieldName: "conditions") ?? []
+                } catch let err as AccessoryRowsArgError {
+                    return encodeResponse(success: false, error: err.message)
+                }
+                let timeAfterRaw = (args["time_after"] as? [String]) ?? []
+                let timeBeforeRaw = (args["time_before"] as? [String]) ?? []
+                var timeConditions: [TimeCondition] = []
+                for raw in timeAfterRaw {
+                    guard let tc = TimeCondition.parse(raw, relation: .after) else {
+                        return encodeResponse(success: false,
+                            error: "Invalid 'time_after' value '\(raw)'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunset-30').")
+                    }
+                    timeConditions.append(tc)
+                }
+                for raw in timeBeforeRaw {
+                    guard let tc = TimeCondition.parse(raw, relation: .before) else {
+                        return encodeResponse(success: false,
+                            error: "Invalid 'time_before' value '\(raw)'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunrise+15').")
+                    }
+                    timeConditions.append(tc)
+                }
+                // Mirror the e6ffa1b validation pattern: distinguish absent from unparseable,
+                // and reject NSNumber-bool (`true`/`false` in JSON would otherwise become 1/0).
+                let durationSeconds: Int?
+                if let raw = args["duration_seconds"] {
+                    let isBool: Bool = {
+                        guard let nsNum = raw as? NSNumber else { return false }
+                        return CFGetTypeID(nsNum) == CFBooleanGetTypeID()
+                    }()
+                    let parsed: Int? = isBool
+                        ? nil
+                        : ((raw as? Int) ?? (raw as? String).flatMap(Int.init))
+                    guard let parsed, (1...86400).contains(parsed) else {
+                        return encodeResponse(
+                            success: false,
+                            error: "'duration_seconds' must be a positive integer between 1 and 86400 (24 hours)"
+                        )
+                    }
+                    durationSeconds = parsed
+                } else {
+                    durationSeconds = nil
+                }
+                result = try await hk.createTimeAutomation(
+                    name: name,
+                    time: time,
+                    weekdays: weekdays,
+                    conditions: conditions,
+                    timeConditions: timeConditions,
+                    durationSeconds: durationSeconds,
+                    sceneID: sceneID,
+                    actions: actions,
                     homeID: args["home_id"] as? String,
                     dryRun: parseBool(args, key: "dry_run")
                 )

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -129,6 +129,48 @@ final class SocketServer: @unchecked Sendable {
         return result
     }
 
+    /// Thrown by `parseStringArrayArg` when a `time_after` / `time_before` arg is
+    /// present but malformed. Caller maps the `.message` to `encodeResponse(success: false, error:)`.
+    /// Absent → returns `[]` (does not throw), matching the existing default-empty
+    /// behavior for the optional time-predicate flags.
+    fileprivate struct StringArrayArgError: Error {
+        let message: String
+    }
+
+    /// Strict parser for the `time_after` / `time_before` socket args. Mirrors the
+    /// `e6ffa1b` pattern: distinguish absent (returns `[]`) from present-but-malformed
+    /// (throws) so a misshapen value returns a precise error instead of silently
+    /// dropping the predicate and creating an automation without the requested gate.
+    ///
+    /// - Parameters:
+    ///   - raw: the raw arg value (typically `args["time_after"]` or `args["time_before"]`).
+    ///   - fieldName: the JSON key name, used in error messages.
+    /// - Returns: parsed `[String]`, or `[]` if the arg is absent.
+    /// - Throws: `StringArrayArgError` if the arg is present but not an array of strings.
+    fileprivate static func parseStringArrayArg(_ raw: Any?, fieldName: String) throws -> [String] {
+        guard let raw else { return [] }
+        guard let array = raw as? [Any] else {
+            throw StringArrayArgError(message: "'\(fieldName)' must be an array of strings (e.g. 'sunset-30', 'sunrise+15').")
+        }
+        var result: [String] = []
+        result.reserveCapacity(array.count)
+        for (index, element) in array.enumerated() {
+            // Reject JSON booleans explicitly (bridged as __NSCFBoolean which would
+            // otherwise cast to neither String nor a useful type).
+            if let nsNum = element as? NSNumber, CFGetTypeID(nsNum) == CFBooleanGetTypeID() {
+                throw StringArrayArgError(message: "'\(fieldName)'[\(index)] is a boolean; expected a non-empty string")
+            }
+            guard let strVal = element as? String else {
+                throw StringArrayArgError(message: "'\(fieldName)'[\(index)] must be a string")
+            }
+            guard !strVal.isEmpty else {
+                throw StringArrayArgError(message: "'\(fieldName)'[\(index)] must be a non-empty string")
+            }
+            result.append(strVal)
+        }
+        return result
+    }
+
     /// Start the socket server synchronously (non-blocking — sets up GCD dispatch sources).
     func start() {
         let path = AppConfig.socketPath
@@ -841,8 +883,14 @@ final class SocketServer: @unchecked Sendable {
                 }
                 // Parse sun-relative time predicates. The CLI/MCP layer pre-validates format,
                 // but defensively re-validate here so direct socket clients can't bypass it.
-                let timeAfterRaw = (args["time_after"] as? [String]) ?? []
-                let timeBeforeRaw = (args["time_before"] as? [String]) ?? []
+                let timeAfterRaw: [String]
+                let timeBeforeRaw: [String]
+                do {
+                    timeAfterRaw = try Self.parseStringArrayArg(args["time_after"], fieldName: "time_after")
+                    timeBeforeRaw = try Self.parseStringArrayArg(args["time_before"], fieldName: "time_before")
+                } catch let err as StringArrayArgError {
+                    return encodeResponse(success: false, error: err.message)
+                }
                 var timeConditions: [TimeCondition] = []
                 for raw in timeAfterRaw {
                     guard let tc = TimeCondition.parse(raw, relation: .after) else {
@@ -900,7 +948,7 @@ final class SocketServer: @unchecked Sendable {
                 )
 
             case "create_time_automation":
-                guard let name = args["name"] as? String, !name.isEmpty else {
+                guard let name = args["name"] as? String, !name.trimmingCharacters(in: .whitespaces).isEmpty else {
                     return encodeResponse(success: false, error: "Missing or empty 'name' argument")
                 }
                 guard let time = args["time"] as? String, !time.trimmingCharacters(in: .whitespaces).isEmpty else {
@@ -944,8 +992,14 @@ final class SocketServer: @unchecked Sendable {
                 } catch let err as AccessoryRowsArgError {
                     return encodeResponse(success: false, error: err.message)
                 }
-                let timeAfterRaw = (args["time_after"] as? [String]) ?? []
-                let timeBeforeRaw = (args["time_before"] as? [String]) ?? []
+                let timeAfterRaw: [String]
+                let timeBeforeRaw: [String]
+                do {
+                    timeAfterRaw = try Self.parseStringArrayArg(args["time_after"], fieldName: "time_after")
+                    timeBeforeRaw = try Self.parseStringArrayArg(args["time_before"], fieldName: "time_before")
+                } catch let err as StringArrayArgError {
+                    return encodeResponse(success: false, error: err.message)
+                }
                 var timeConditions: [TimeCondition] = []
                 for raw in timeAfterRaw {
                     guard let tc = TimeCondition.parse(raw, relation: .after) else {

--- a/Tests/homeclaw-cliTests/CreateTimeTests.swift
+++ b/Tests/homeclaw-cliTests/CreateTimeTests.swift
@@ -1,0 +1,331 @@
+import Testing
+@testable import homeclaw_cli
+
+// MARK: - validateTimeOfDaySpec (the --time parser for `create-time`)
+//
+// These exercise the CLI-layer parser specifically. The HomeKit-side `TimeSpec.parse`
+// in HomeKitManager is the source of truth and re-validates whatever the socket
+// receives, but the CLI parser owns the user-facing error messages — keeping it
+// strict prevents ambiguous values like `12:5` from reaching the socket layer.
+
+@Suite("CreateTimeAutomation.validateTimeOfDaySpec — HH:MM")
+struct ValidateTimeOfDaySpecHHMMTests {
+    @Test("valid clock times round-trip with two-digit canonical form")
+    func validClockTimes() throws {
+        #expect(try CreateAutomation.validateTimeOfDaySpec("00:00") == "00:00")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("06:30") == "06:30")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("12:34") == "12:34")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("23:59") == "23:59")
+    }
+
+    @Test("whitespace around input is tolerated, but the canonical form is trimmed")
+    func whitespaceTolerated() throws {
+        #expect(try CreateAutomation.validateTimeOfDaySpec("  09:15  ") == "09:15")
+    }
+
+    @Test("hour > 23 rejected")
+    func badHour() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("25:00")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("24:00")
+        }
+    }
+
+    @Test("minute > 59 rejected")
+    func badMinute() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("12:60")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("12:99")
+        }
+    }
+
+    @Test("single-digit hour rejected — '6:30' could be 6 or 60 to a casual reader")
+    func singleDigitHour() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("6:30")
+        }
+    }
+
+    @Test("single-digit minute rejected — '12:5' must not silently become '12:50'")
+    func singleDigitMinute() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("12:5")
+        }
+    }
+
+    @Test("three-digit minute rejected")
+    func threeDigitMinute() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("12:345")
+        }
+    }
+
+    @Test("missing colon rejected — '1234' must not be interpreted as HH:MM")
+    func missingColon() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("1234")
+        }
+    }
+
+    @Test("non-numeric components rejected")
+    func nonNumeric() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("ab:cd")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("12:ab")
+        }
+    }
+
+    @Test("empty hour or minute rejected")
+    func emptyComponent() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec(":30")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("12:")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec(":")
+        }
+    }
+}
+
+@Suite("CreateTimeAutomation.validateTimeOfDaySpec — sunrise/sunset")
+struct ValidateTimeOfDaySpecSunTests {
+    @Test("bare sunrise/sunset accepted and lowercased")
+    func bareSunEvents() throws {
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunrise") == "sunrise")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunset") == "sunset")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("Sunrise") == "sunrise")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("SUNSET") == "sunset")
+    }
+
+    @Test("positive offsets accepted")
+    func positiveOffsets() throws {
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunrise+15") == "sunrise+15")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunset+60") == "sunset+60")
+    }
+
+    @Test("negative offsets accepted")
+    func negativeOffsets() throws {
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunset-30") == "sunset-30")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunrise-45") == "sunrise-45")
+    }
+
+    @Test("zero-minute offset accepted")
+    func zeroOffset() throws {
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunrise+0") == "sunrise+0")
+    }
+
+    @Test("offset exactly at the 1440-minute cap accepted")
+    func maxOffsetAccepted() throws {
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunrise+1440") == "sunrise+1440")
+        #expect(try CreateAutomation.validateTimeOfDaySpec("sunset-1440") == "sunset-1440")
+    }
+
+    @Test("offset > 1440 rejected — almost certainly a typo, user probably wanted --days")
+    func offsetOutOfRange() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("sunrise+1500")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("sunset-9999")
+        }
+    }
+
+    @Test("offset missing sign rejected — must start with + or -")
+    func missingSign() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("sunset30")
+        }
+    }
+
+    @Test("offset present but missing numeric magnitude rejected")
+    func missingMagnitude() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("sunrise+")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("sunset-")
+        }
+    }
+
+    @Test("unknown sun event rejected — 'noon' and 'midnight' are not HomeKit primitives")
+    func unknownSunEvent() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("noon")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("midnight")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("dawn")
+        }
+    }
+
+    @Test("empty input rejected")
+    func emptyInput() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.validateTimeOfDaySpec("   ")
+        }
+    }
+}
+
+// MARK: - parseWeekdays (the --days parser shared by create and create-time)
+
+@Suite("CreateAutomation.parseWeekdays")
+struct ParseWeekdaysTests {
+    @Test("named days accepted in any case")
+    func namedDays() throws {
+        #expect(try CreateAutomation.parseWeekdays("mon,tue,wed,thu,fri") == [2, 3, 4, 5, 6])
+        #expect(try CreateAutomation.parseWeekdays("Sun,Sat") == [1, 7])
+        #expect(try CreateAutomation.parseWeekdays("MONDAY,FRIDAY") == [2, 6])
+    }
+
+    @Test("numeric days accepted")
+    func numericDays() throws {
+        #expect(try CreateAutomation.parseWeekdays("1,2,3") == [1, 2, 3])
+        #expect(try CreateAutomation.parseWeekdays("7,5,3,1") == [1, 3, 5, 7])
+    }
+
+    @Test("mixed named + numeric accepted")
+    func mixedDays() throws {
+        #expect(try CreateAutomation.parseWeekdays("mon,5,fri") == [2, 5, 6])
+    }
+
+    @Test("duplicates collapse and result is sorted")
+    func duplicatesAndOrder() throws {
+        #expect(try CreateAutomation.parseWeekdays("fri,mon,fri,2") == [2, 6])
+        #expect(try CreateAutomation.parseWeekdays("3,3,3") == [3])
+    }
+
+    @Test("whitespace around tokens tolerated")
+    func whitespaceTolerated() throws {
+        #expect(try CreateAutomation.parseWeekdays(" mon , tue , wed ") == [2, 3, 4])
+    }
+
+    @Test("invalid token rejected")
+    func invalidToken() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseWeekdays("mon,xxx,fri")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseWeekdays("mon,8,fri")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseWeekdays("0")
+        }
+    }
+}
+
+// MARK: - parseConditionRow (the --condition parser shared by create and create-time)
+
+@Suite("CreateAutomation.parseConditionRow")
+struct ParseConditionRowTests {
+    @Test("three colon-separated parts accepted")
+    func validRow() throws {
+        let parsed = try CreateAutomation.parseConditionRow("Front Door:contact_state:0")
+        #expect(parsed["accessory"] == "Front Door")
+        #expect(parsed["property"] == "contact_state")
+        #expect(parsed["value"] == "0")
+    }
+
+    @Test("whitespace trimmed inside parts")
+    func whitespaceTrimmed() throws {
+        let parsed = try CreateAutomation.parseConditionRow("  Foo  :  bar  :  baz  ")
+        #expect(parsed["accessory"] == "Foo")
+        #expect(parsed["property"] == "bar")
+        #expect(parsed["value"] == "baz")
+    }
+
+    @Test("value containing colons preserved via maxSplits=2")
+    func valueWithColons() throws {
+        let parsed = try CreateAutomation.parseConditionRow("Sensor:rgb:255:128:0")
+        #expect(parsed["accessory"] == "Sensor")
+        #expect(parsed["property"] == "rgb")
+        #expect(parsed["value"] == "255:128:0")
+    }
+
+    @Test("fewer than 3 parts rejected")
+    func tooFewParts() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseConditionRow("Foo:bar")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseConditionRow("Foo")
+        }
+    }
+
+    @Test("empty parts rejected")
+    func emptyParts() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseConditionRow(":bar:baz")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseConditionRow("foo::baz")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseConditionRow("foo:bar:")
+        }
+    }
+}
+
+// MARK: - parseActionRow (the --action parser shared by create and create-time)
+
+@Suite("CreateAutomation.parseActionRow")
+struct ParseActionRowTests {
+    @Test("three colon-separated parts accepted")
+    func validRow() throws {
+        let parsed = try CreateAutomation.parseActionRow("Light:power:1")
+        #expect(parsed["accessory"] == "Light")
+        #expect(parsed["property"] == "power")
+        #expect(parsed["value"] == "1")
+    }
+
+    @Test("whitespace trimmed inside parts")
+    func whitespaceTrimmed() throws {
+        let parsed = try CreateAutomation.parseActionRow("  Light  :  power  :  1  ")
+        #expect(parsed["accessory"] == "Light")
+        #expect(parsed["property"] == "power")
+        #expect(parsed["value"] == "1")
+    }
+
+    @Test("value containing colons preserved via maxSplits=2")
+    func valueWithColons() throws {
+        let parsed = try CreateAutomation.parseActionRow("Sensor:rgb:255:128:0")
+        #expect(parsed["accessory"] == "Sensor")
+        #expect(parsed["property"] == "rgb")
+        #expect(parsed["value"] == "255:128:0")
+    }
+
+    @Test("fewer than 3 parts rejected")
+    func tooFewParts() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseActionRow("Light:power")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseActionRow("Light")
+        }
+    }
+
+    @Test("empty parts rejected")
+    func emptyParts() {
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseActionRow(":power:1")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseActionRow("Light::1")
+        }
+        #expect(throws: (any Error).self) {
+            _ = try CreateAutomation.parseActionRow("Light:power:")
+        }
+    }
+}

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -111,6 +111,44 @@ export async function handleAutomations(args) {
       return sendCommand('get_automation', socketArgs);
     }
 
+    case 'create_time': {
+      if (!args.name) throw new Error('name is required for create_time action');
+      if (!args.time || typeof args.time !== 'string' || args.time.trim() === '') {
+        throw new Error("time is required for create_time action. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30').");
+      }
+      if (!args.scene_id && (!args.actions || args.actions.length === 0)) {
+        throw new Error('Either scene_id or actions array is required for create_time action');
+      }
+      const socketArgs = {
+        name: args.name,
+        time: args.time,
+      };
+      if (args.scene_id) socketArgs.scene_id = args.scene_id;
+      if (args.actions) socketArgs.actions = args.actions;
+      if (Array.isArray(args.weekdays) && args.weekdays.length > 0) {
+        socketArgs.weekdays = args.weekdays;
+      }
+      if (Array.isArray(args.conditions) && args.conditions.length > 0) {
+        socketArgs.conditions = args.conditions;
+      }
+      if (Array.isArray(args.time_after) && args.time_after.length > 0) {
+        socketArgs.time_after = args.time_after;
+      }
+      if (Array.isArray(args.time_before) && args.time_before.length > 0) {
+        socketArgs.time_before = args.time_before;
+      }
+      if (args.duration_seconds != null) {
+        const d = args.duration_seconds;
+        if (!Number.isInteger(d) || d < 1 || d > 86400) {
+          throw new Error('duration_seconds must be an integer between 1 and 86400 (24 hours)');
+        }
+        socketArgs.duration_seconds = String(d);
+      }
+      if (args.home_id) socketArgs.home_id = args.home_id;
+      if (args.dry_run) socketArgs.dry_run = 'true';
+      return sendCommand('create_time_automation', socketArgs);
+    }
+
     case 'create': {
       if (!args.name) throw new Error('name is required for create action');
       if (!args.accessory_id) throw new Error('accessory_id is required for create action');

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -203,13 +203,13 @@ export const tools = [
   },
   {
     name: 'homekit_automations',
-    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value. Use duration_seconds at create time to auto-revert actions after N seconds (e.g. motion-triggered lights that turn off again after a delay). List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
+    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) or by a time of day (clock or sunrise/sunset), delete automations, or enable/disable them. For characteristic-change triggers use action=create with press_type (buttons) or characteristic+trigger_value (sensors). For time-of-day triggers use action=create_time with the `time` field (HH:MM, sunrise, sunset, or <sun-event>±N). Both create actions accept the same predicate vocabulary: weekdays, conditions, time_after, time_before, duration_seconds. Use duration_seconds to auto-revert actions after N seconds (e.g. motion-triggered lights or sunset porch lights that turn off after a delay). List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
     inputSchema: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
-          enum: ['list', 'get', 'create', 'delete', 'enable', 'disable'],
+          enum: ['list', 'get', 'create', 'create_time', 'delete', 'enable', 'disable'],
           description: 'Action to perform. Default: list',
         },
         home_id: {
@@ -222,15 +222,19 @@ export const tools = [
         },
         name: {
           type: 'string',
-          description: 'Automation name (create action)',
+          description: 'Automation name (create / create_time actions)',
         },
         accessory_id: {
           type: 'string',
           description: 'Trigger accessory UUID or name (create action)',
         },
+        time: {
+          type: 'string',
+          description: 'Time of day the automation fires (create_time action, required). Format: "HH:MM" for a wall-clock time (e.g. "06:30", "17:45"; both fields must be zero-padded two digits — "6:30" is rejected), "sunrise"/"sunset" for sun-relative events, or "<sun-event>±N" where N is minutes (e.g. "sunset-30", "sunrise+15"). Offsets larger than 1440 minutes (24h) are rejected. Implemented as HMCalendarEvent for HH:MM and HMSignificantTimeEvent for sunrise/sunset. All other predicate flags (weekdays, conditions, time_after, time_before, duration_seconds) compose with `time` the same way they do on the create action — `time` is the trigger event, those are the gating predicates.',
+        },
         scene_id: {
           type: 'string',
-          description: 'Scene UUID or name to trigger (create action). Alternative to actions.',
+          description: 'Scene UUID or name to trigger (create / create_time actions). Alternative to actions.',
         },
         actions: {
           type: 'array',
@@ -244,7 +248,7 @@ export const tools = [
             },
             required: ['accessory', 'property', 'value'],
           },
-          description: 'Inline actions for the automation (create action). Alternative to scene_id. Creates a scene named after the automation. Each action sets one characteristic on one accessory.',
+          description: 'Inline actions for the automation (create / create_time actions). Alternative to scene_id. Creates a scene named after the automation. Each action sets one characteristic on one accessory.',
         },
         press_type: {
           type: 'number',
@@ -266,7 +270,7 @@ export const tools = [
         weekdays: {
           type: 'array',
           items: { type: 'number', enum: [1, 2, 3, 4, 5, 6, 7] },
-          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, the automation fires every day. iOS 15+ marks time-conditional automations without weekday gating as "unreliable", so pass weekdays explicitly when combining with time-of-day conditions. If you set time_after/time_before but omit weekdays, HomeClaw auto-fills all 7 days and sets `weekdays_auto_filled: true` in the response. (create action)',
+          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, characteristic-trigger automations (create) fire every day; time-of-day automations (create_time) auto-fill all 7 days since iOS 15+ marks time-conditional automations without weekday gating as "unreliable". Setting time_after/time_before on create with no weekdays also auto-fills all 7 days and sets `weekdays_auto_filled: true` in the response. (create / create_time actions)',
         },
         conditions: {
           type: 'array',
@@ -280,27 +284,27 @@ export const tools = [
             },
             required: ['accessory', 'property', 'value'],
           },
-          description: 'Extra characteristic predicates ANDed into the trigger predicate (create action). The trigger fires only when the trigger event happens AND every condition holds. Example: porch motion that only triggers when the front door is closed AND nobody is home. Each condition is a (characteristic == value) match against any accessory in the home. (create action)',
+          description: 'Extra characteristic predicates ANDed into the trigger predicate. The trigger fires only when the trigger event happens AND every condition holds. Example: porch motion (or sunset, on create_time) that only triggers when the front door is closed AND nobody is home. Each condition is a (characteristic == value) match against any accessory in the home. (create / create_time actions)',
         },
         time_after: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Sun-relative time predicates ANDed into the trigger so it only fires after the given event (create action). Format: "<sunrise|sunset>[±N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create action)',
+          description: 'Sun-relative time predicates ANDed into the trigger so it only fires after the given event. Format: "<sunrise|sunset>[±N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). On create_time these are gating predicates on top of the `time` trigger event, not the trigger itself. When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create / create_time actions)',
         },
         time_before: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Sun-relative time predicates ANDed into the trigger so it only fires before the given event (create action). Same format and offset rules as time_after. (create action)',
+          description: 'Sun-relative time predicates ANDed into the trigger so it only fires before the given event. Same format and offset rules as time_after. (create / create_time actions)',
         },
         duration_seconds: {
           type: 'integer',
           minimum: 1,
           maximum: 86400,
-          description: 'Auto-revert the trigger\'s actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger\'s endEvents — HomeKit handles the revert natively, no follow-up automation required. Common use case: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold). (create action)',
+          description: 'Auto-revert the trigger\'s actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger\'s endEvents — HomeKit handles the revert natively, no follow-up automation required. Common use cases: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold), or sunset porch lights that should turn off after an hour. (create / create_time actions)',
         },
         dry_run: {
           type: 'boolean',
-          description: 'Preview changes without applying (create/delete actions)',
+          description: 'Preview changes without applying (create/create_time/delete actions)',
         },
       },
       required: ['action'],

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21015,13 +21015,13 @@ var tools = [
   },
   {
     name: "homekit_automations",
-    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) with either a scene reference or inline actions, delete automations, or enable/disable them. For button triggers use press_type; for other triggers use characteristic + trigger_value. Use duration_seconds at create time to auto-revert actions after N seconds (e.g. motion-triggered lights that turn off again after a delay). List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
+    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) or by a time of day (clock or sunrise/sunset), delete automations, or enable/disable them. For characteristic-change triggers use action=create with press_type (buttons) or characteristic+trigger_value (sensors). For time-of-day triggers use action=create_time with the `time` field (HH:MM, sunrise, sunset, or <sun-event>\xB1N). Both create actions accept the same predicate vocabulary: weekdays, conditions, time_after, time_before, duration_seconds. Use duration_seconds to auto-revert actions after N seconds (e.g. motion-triggered lights or sunset porch lights that turn off after a delay). List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
     inputSchema: {
       type: "object",
       properties: {
         action: {
           type: "string",
-          enum: ["list", "get", "create", "delete", "enable", "disable"],
+          enum: ["list", "get", "create", "create_time", "delete", "enable", "disable"],
           description: "Action to perform. Default: list"
         },
         home_id: {
@@ -21034,15 +21034,19 @@ var tools = [
         },
         name: {
           type: "string",
-          description: "Automation name (create action)"
+          description: "Automation name (create / create_time actions)"
         },
         accessory_id: {
           type: "string",
           description: "Trigger accessory UUID or name (create action)"
         },
+        time: {
+          type: "string",
+          description: 'Time of day the automation fires (create_time action, required). Format: "HH:MM" for a wall-clock time (e.g. "06:30", "17:45"; both fields must be zero-padded two digits \u2014 "6:30" is rejected), "sunrise"/"sunset" for sun-relative events, or "<sun-event>\xB1N" where N is minutes (e.g. "sunset-30", "sunrise+15"). Offsets larger than 1440 minutes (24h) are rejected. Implemented as HMCalendarEvent for HH:MM and HMSignificantTimeEvent for sunrise/sunset. All other predicate flags (weekdays, conditions, time_after, time_before, duration_seconds) compose with `time` the same way they do on the create action \u2014 `time` is the trigger event, those are the gating predicates.'
+        },
         scene_id: {
           type: "string",
-          description: "Scene UUID or name to trigger (create action). Alternative to actions."
+          description: "Scene UUID or name to trigger (create / create_time actions). Alternative to actions."
         },
         actions: {
           type: "array",
@@ -21056,7 +21060,7 @@ var tools = [
             },
             required: ["accessory", "property", "value"]
           },
-          description: "Inline actions for the automation (create action). Alternative to scene_id. Creates a scene named after the automation. Each action sets one characteristic on one accessory."
+          description: "Inline actions for the automation (create / create_time actions). Alternative to scene_id. Creates a scene named after the automation. Each action sets one characteristic on one accessory."
         },
         press_type: {
           type: "number",
@@ -21078,7 +21082,7 @@ var tools = [
         weekdays: {
           type: "array",
           items: { type: "number", enum: [1, 2, 3, 4, 5, 6, 7] },
-          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, the automation fires every day. iOS 15+ marks time-conditional automations without weekday gating as "unreliable", so pass weekdays explicitly when combining with time-of-day conditions. If you set time_after/time_before but omit weekdays, HomeClaw auto-fills all 7 days and sets `weekdays_auto_filled: true` in the response. (create action)'
+          description: 'Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, characteristic-trigger automations (create) fire every day; time-of-day automations (create_time) auto-fill all 7 days since iOS 15+ marks time-conditional automations without weekday gating as "unreliable". Setting time_after/time_before on create with no weekdays also auto-fills all 7 days and sets `weekdays_auto_filled: true` in the response. (create / create_time actions)'
         },
         conditions: {
           type: "array",
@@ -21092,27 +21096,27 @@ var tools = [
             },
             required: ["accessory", "property", "value"]
           },
-          description: "Extra characteristic predicates ANDed into the trigger predicate (create action). The trigger fires only when the trigger event happens AND every condition holds. Example: porch motion that only triggers when the front door is closed AND nobody is home. Each condition is a (characteristic == value) match against any accessory in the home. (create action)"
+          description: "Extra characteristic predicates ANDed into the trigger predicate. The trigger fires only when the trigger event happens AND every condition holds. Example: porch motion (or sunset, on create_time) that only triggers when the front door is closed AND nobody is home. Each condition is a (characteristic == value) match against any accessory in the home. (create / create_time actions)"
         },
         time_after: {
           type: "array",
           items: { type: "string" },
-          description: 'Sun-relative time predicates ANDed into the trigger so it only fires after the given event (create action). Format: "<sunrise|sunset>[\xB1N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create action)'
+          description: 'Sun-relative time predicates ANDed into the trigger so it only fires after the given event. Format: "<sunrise|sunset>[\xB1N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). On create_time these are gating predicates on top of the `time` trigger event, not the trigger itself. When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create / create_time actions)'
         },
         time_before: {
           type: "array",
           items: { type: "string" },
-          description: "Sun-relative time predicates ANDed into the trigger so it only fires before the given event (create action). Same format and offset rules as time_after. (create action)"
+          description: "Sun-relative time predicates ANDed into the trigger so it only fires before the given event. Same format and offset rules as time_after. (create / create_time actions)"
         },
         duration_seconds: {
           type: "integer",
           minimum: 1,
           maximum: 86400,
-          description: "Auto-revert the trigger's actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger's endEvents \u2014 HomeKit handles the revert natively, no follow-up automation required. Common use case: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold). (create action)"
+          description: "Auto-revert the trigger's actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger's endEvents \u2014 HomeKit handles the revert natively, no follow-up automation required. Common use cases: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold), or sunset porch lights that should turn off after an hour. (create / create_time actions)"
         },
         dry_run: {
           type: "boolean",
-          description: "Preview changes without applying (create/delete actions)"
+          description: "Preview changes without applying (create/create_time/delete actions)"
         }
       },
       required: ["action"]
@@ -21314,6 +21318,43 @@ async function handleAutomations(args) {
       const socketArgs = { id: args.id };
       if (args.home_id) socketArgs.home_id = args.home_id;
       return sendCommand("get_automation", socketArgs);
+    }
+    case "create_time": {
+      if (!args.name) throw new Error("name is required for create_time action");
+      if (!args.time || typeof args.time !== "string" || args.time.trim() === "") {
+        throw new Error("time is required for create_time action. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>\xB1<minutes>' (e.g. 'sunset-30').");
+      }
+      if (!args.scene_id && (!args.actions || args.actions.length === 0)) {
+        throw new Error("Either scene_id or actions array is required for create_time action");
+      }
+      const socketArgs = {
+        name: args.name,
+        time: args.time
+      };
+      if (args.scene_id) socketArgs.scene_id = args.scene_id;
+      if (args.actions) socketArgs.actions = args.actions;
+      if (Array.isArray(args.weekdays) && args.weekdays.length > 0) {
+        socketArgs.weekdays = args.weekdays;
+      }
+      if (Array.isArray(args.conditions) && args.conditions.length > 0) {
+        socketArgs.conditions = args.conditions;
+      }
+      if (Array.isArray(args.time_after) && args.time_after.length > 0) {
+        socketArgs.time_after = args.time_after;
+      }
+      if (Array.isArray(args.time_before) && args.time_before.length > 0) {
+        socketArgs.time_before = args.time_before;
+      }
+      if (args.duration_seconds != null) {
+        const d = args.duration_seconds;
+        if (!Number.isInteger(d) || d < 1 || d > 86400) {
+          throw new Error("duration_seconds must be an integer between 1 and 86400 (24 hours)");
+        }
+        socketArgs.duration_seconds = String(d);
+      }
+      if (args.home_id) socketArgs.home_id = args.home_id;
+      if (args.dry_run) socketArgs.dry_run = "true";
+      return sendCommand("create_time_automation", socketArgs);
     }
     case "create": {
       if (!args.name) throw new Error("name is required for create action");


### PR DESCRIPTION
## What this adds

`automations create-time` — a new top-level subcommand parallel to `automations create`, for automations that fire on calendar/significant-time events rather than characteristic changes. All predicate flags from #49/#56/#59 (`--days`, `--condition`, `--time-after`, `--time-before`, `--duration`) compose with `--time` the same way they do on `create`, fulfilling the "predicates are orthogonal to trigger type" design from #48.

```bash
# Weekday-morning coffee
homeclaw-cli automations create-time \
  --name "Coffee Maker" --time "06:30" \
  --days mon,tue,wed,thu,fri \
  --action "Coffee Maker:power:1"

# Sunset porch lights, auto-off after an hour
homeclaw-cli automations create-time \
  --name "Porch Lights" --time "sunset-30" \
  --duration 3600 \
  --scene "Porch On"

# Sunset trigger only when someone's home, weekdays
homeclaw-cli automations create-time \
  --name "Welcome Home Glow" --time "sunset" \
  --condition "Front Door:occupancy_detected:true" \
  --days mon,tue,wed,thu,fri \
  --scene "Welcome"
```

`--time` accepts five forms, validated at all three layers (CLI + SocketServer + Manager):

| Form | Example | Maps to |
|---|---|---|
| `HH:MM` | `06:30` | HMCalendarEvent |
| `sunrise` / `sunset` | `sunrise` | HMSignificantTimeEvent |
| `sunrise±N` / `sunset±N` | `sunset-30` | HMSignificantTimeEvent with offset (|N| ≤ 1440) |

A new `TimeSpec` enum (alongside `TimeCondition` from #56) is the manager-side source of truth and constructs the right HMEvent subtype.

## Refactor: Step 1b/1c extracted into shared helpers

`createAutomation`'s inline Step 1b (combined predicate) and Step 1c (`applyDuration`) are extracted into `fileprivate` helpers on `HomeKitManager`. Both `createAutomation` and `createTimeAutomation` call the same machinery, so the entire predicate-composition + duration + cleanup logic lives in one place.

```swift
resolveConditions(_:in:) -> [ResolvedCondition]
buildCombinedPredicate(existing:weekdays:resolvedConditions:timeConditions:) -> NSPredicate?
applyCombinedPredicate(to:weekdays:resolvedConditions:timeConditions:isInlineActionSet:actionSet:in:)
cleanupOrphans(trigger:isInlineActionSet:actionSet:in:)
```

External behavior of `create` is unchanged. The single-element-fast-path semantics from #49 are preserved; the post-`addTrigger` ordering established by #59 is preserved.

`cleanupOrphans` now removes the trigger before the action set (instead of the other way around) so HomeKit's link between them is broken before the action set is removed — avoids the linked-action-set rejection case in Step 2/3 failure paths.

Also closes a latent leak: `createAutomation`'s Step 1 (the `addTrigger` call) previously had no cleanup, so a failure there left the inline action set orphaned. Now wrapped in a `do/catch` that mirrors `createTimeAutomation`'s Step 1 — fulfills the audit pledge in my #59 thanks comment.

## SocketServer validation, e6ffa1b-style across the board

The hardening pattern from `e6ffa1b` (distinguish absent from unparseable, reject `__NSCFBoolean`, validate ranges) is now applied uniformly:

- **`time`**: rejected if absent / empty / non-string. Re-validated via `TimeSpec.parse` for non-CLI callers — the third validation layer the CLI comment had been promising.
- **`weekdays`**: new `parseWeekdaysArg` helper rejects `__NSCFBoolean` via `CFGetTypeID == CFBooleanGetTypeID`, distinguishes absent from unparseable, validates each element is in `1...7`. Applied to both `create_automation` (closing the pre-existing gap I committed to fix in the #59 thanks comment) and `create_time_automation`.
- **`actions` and `conditions`**: new `parseAccessoryRowsArg` helper distinguishes absent from present-but-malformed, requires `accessory`/`property`/`value` as non-empty strings, validates optional `room`, rejects `__NSCFBoolean` values inside rows.
- **`duration_seconds`**: reuses the e6ffa1b range-check pattern.
- **`name`**: rejected if absent or empty/whitespace-only — schema-contract symmetry across `create` and `create_time`.

## CLI parsers consolidated

- `parseActionRow` and `parseConditionRow` are now static helpers on `CreateAutomation`, both trim whitespace per part and reject empty parts. Shared by `create` and `create-time` so the surfaces stay aligned.
- `validateTimeOfDaySpec` inline-handles the unknown-prefix case (`--time noon`) with a tailored error listing all four valid forms, instead of forwarding to the sun-event-only error message.

## Tests

Test target Omar set up in `d648b3c` is now exercised more:

- **43 tests pass** (7 existing `FormatDuration` + 36 new in `CreateTimeTests.swift`)
- Coverage: `TimeSpec` parsing via the CLI mirror (HH:MM range edges, sun-event offsets, malformed input, offset cap at 1440), weekday parser (dedup/sort, mixed names+numerics), `parseConditionRow` and `parseActionRow` (whitespace trim, empty parts, value-with-colons)
- Manager-side `TimeSpec.parse` itself has no direct tests due to the test-target boundary (test target depends on `homeclaw-cli`, not the Catalyst app target). Cross-reference doc comments link the two parsers so future drift is easier to catch. Documented as a follow-up.

## Read-side: already in place

PR #50 + your `34fd00f` flattenTopAnd fix already surface `HMCalendarEvent` (`"at HH:MM"`, `trigger_type: "calendar"`) and `HMSignificantTimeEvent` (`"at sunrise+15"`, `trigger_type: "significant_time"`) in `automations list` / `get`. This PR produces exactly those structures, so the round-trip lights up automatically — no read-side work needed.

## MCP/lib parity

- `lib/schemas.js`: `create_time` added to the `homekit_automations` action enum; new `time` property with rich description showing all valid forms; predicate-flag descriptions updated to read "(create / create_time actions)" so MCP callers see the orthogonality.
- `lib/handlers/homekit.js`: new `case 'create_time':` mirrors `case 'create':` validation.
- `mcp-server/dist/server.js` rebuilt.

## Testing status

- ✅ `swift build --product homeclaw-cli` — clean
- ✅ `swift test` — 43/43 pass
- ✅ `npm install && npm run build:mcp` — clean
- ✅ `xcodebuild ... Catalyst CODE_SIGNING_ALLOWED=NO build` — `** BUILD SUCCEEDED **`, zero warnings on changed files
- ⚠️ Runtime end-to-end against real HomeKit — same provisioning caveat as #49/#50/#56/#59 (`com.shahine.*` not in my provisioning). The Step 1b/1c helpers preserve the existing behavior `create` has been running with on your end since #59; the new `createTimeAutomation` uses the same machinery plus the HMCalendarEvent / HMSignificantTimeEvent construction. Standing by for your spot-check.

## Notes

- Diff is large (~1284 inserts, 250 deletes) but the bulk is the HomeKitManager refactor extracting Step 1b/1c, plus the SocketServer validation helpers. Net-new feature code is closer to ~500 lines; the rest is refactor + consolidation.
- A few items I consciously didn't change in this PR but flagged for follow-up: extracting the SocketServer arg-parser helpers into a CLI-target-accessible module so `parseWeekdaysArg` / `parseAccessoryRowsArg` can be unit-tested; lifting `TimeSpec.parse` to a shared module for the same reason. Both would simplify future SocketServer hardening.
- No build-number / version-manifest changes (per the `chore(release):` separation pattern).

## Sequence

Per #48: PR 5 of 6. Builds on #49, #50, #56, #59. Next:

- **PR6** — `add-condition` modify-in-place verb. With `extractConditions` + your `flattenTopAnd` fix already in place from #56, PR6 becomes a focused single-purpose change.

Refs #48.
