### PR TITLE
feat: add-condition — modify-in-place verb for existing automations

### DIFF
--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -14,6 +14,7 @@ struct Automations: ParsableCommand {
             EnableAutomation.self,
             DisableAutomation.self,
             RewireAutomation.self,
+            AddAutomationCondition.self,
         ],
         defaultSubcommand: ListAutomations.self
     )
@@ -918,6 +919,120 @@ struct RewireAutomation: ParsableCommand {
         if !warnings.isEmpty {
             print("\nWarnings:")
             for w in warnings { print("  ⚠ \(w)") }
+        }
+    }
+}
+
+// MARK: - Add Condition (modify-in-place)
+
+/// Append a characteristic condition (ANDed) to an existing automation's trigger predicate.
+/// Preserves the trigger UUID so physical button bindings, Siri references, and any other
+/// UUID-keyed integrations survive the modification (the reason this exists rather than
+/// "delete + recreate with extra flags"). See `HomeKitManager.addAutomationCondition`
+/// for the predicate-combine strategy (flatten-at-write) and the failure semantics.
+struct AddAutomationCondition: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "add-condition",
+        abstract:
+            "Add a characteristic condition (ANDed) to an existing automation in place (preserves trigger UUID)"
+    )
+
+    @Argument(help: "Automation name or UUID")
+    var id: String
+
+    @Option(name: .long, help: "Accessory name or UUID for the new condition")
+    var accessory: String
+
+    @Option(name: .long, help: "Characteristic name (e.g., contact_state, occupancy_detected, power)")
+    var property: String
+
+    @Option(name: .long, help: "Required value as string (e.g., 'true', '0', '50'); uses exact match (==)")
+    var value: String
+
+    @Option(name: .long, help: "Room name for accessory disambiguation when multiple accessories share a name (optional)")
+    var room: String?
+
+    @Option(name: .long, help: "Home name or UUID (defaults to primary home)")
+    var home: String?
+
+    @Flag(name: .long, help: "Preview without modifying the automation")
+    var dryRun = false
+
+    @Flag(name: .long, help: "Output raw JSON")
+    var json = false
+
+    func validate() throws {
+        // ArgumentParser already enforces presence of @Option/@Argument, but it doesn't
+        // catch empty strings (e.g. --accessory '' or a positional argument that's just
+        // whitespace). Reject those here so the user gets a CLI ValidationError before
+        // we open the socket and round-trip to HomeKitManager.
+        if id.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw ValidationError("Automation id/name must be non-empty")
+        }
+        if accessory.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw ValidationError("--accessory must be non-empty")
+        }
+        if property.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw ValidationError("--property must be non-empty")
+        }
+        if value.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw ValidationError("--value must be non-empty")
+        }
+        if let room, room.trimmingCharacters(in: .whitespaces).isEmpty {
+            throw ValidationError("--room must be non-empty when provided")
+        }
+    }
+
+    func run() throws {
+        var args: [String: Any] = [
+            "id": id,
+            "accessory": accessory,
+            "property": property,
+            "value": value,
+            "dry_run": dryRun,
+        ]
+        if let room { args["room"] = room }
+        if let home { args["home_id"] = home }
+
+        let response = try SocketClient.sendAny(command: "add_automation_condition", args: args)
+        guard response.success else {
+            throw ValidationError(response.error ?? "Unknown error")
+        }
+
+        if shouldOutputJSON(json) {
+            printJSON(response.data?.value)
+            return
+        }
+
+        guard let result = response.data?.value as? [String: Any] else {
+            print("Done.")
+            return
+        }
+
+        let isDryRun = result["dry_run"] as? Bool ?? false
+        let autoName = result["name"] as? String ?? id
+        let accessoryName = result["accessory"] as? String ?? accessory
+        let propertyName = result["property"] as? String ?? property
+        let valueStr = result["value"] as? String ?? value
+        let count = result["condition_count_after"] as? Int
+        // Only echo the room when HomeKitManager included it in the result —
+        // it does so only when the room hint actually scoped the lookup (the
+        // name-based path was taken). UUID lookups omit it because the room
+        // would be misleading.
+        let roomSuffix: String
+        if let room = result["room"] as? String {
+            roomSuffix = " (in room \(room))"
+        } else {
+            roomSuffix = ""
+        }
+
+        if isDryRun {
+            print("DRY RUN — would add condition to '\(autoName)': \(accessoryName)\(roomSuffix).\(propertyName) = \(valueStr)")
+        } else {
+            print("Added condition to '\(autoName)': \(accessoryName)\(roomSuffix).\(propertyName) = \(valueStr)")
+        }
+        if let count {
+            print("  Trigger now has \(count) condition(s)")
         }
     }
 }

--- a/Sources/homeclaw/HomeKit/AccessoryModel.swift
+++ b/Sources/homeclaw/HomeKit/AccessoryModel.swift
@@ -562,8 +562,12 @@ enum AccessoryModel {
     }
 
     /// Flatten nested top-level AND compounds into a flat subpredicate list.
-    /// Successive `updatePredicate` mutations (e.g. `add-condition` calls in a future PR)
-    /// can produce AND-of-ANDs; treating those as a flat list keeps the decoder stable.
+    /// Successive `updatePredicate` mutations from `add-condition` (which appends
+    /// new condition leaves to a trigger's existing predicate) can produce AND-of-
+    /// ANDs whose top-level is flat but whose children are themselves the standard
+    /// HMEventTrigger characteristic-leaf compounds. This function flattens
+    /// unconditionally with `isCharacteristicLeaf` as the leaf signal, so callers
+    /// see a flat conjunct list regardless of write-time nesting.
     ///
     /// The characteristic predicate `(characteristic == X AND value == Y)` is a leaf — both
     /// subs are NSComparisonPredicate referencing an HMCharacteristic — so we keep it intact
@@ -583,9 +587,15 @@ enum AccessoryModel {
         for sub in subs { flattenTopAnd(sub, into: &out) }
     }
 
-    /// True for the 2-sub AND of comparisons that HomeKit uses to express a single
-    /// characteristic predicate. Identified by an HMCharacteristic constant on either side.
-    private static func isCharacteristicLeaf(_ subs: [NSPredicate]) -> Bool {
+    /// Determines whether an NSPredicate is the "characteristic leaf" shape HomeKit
+    /// uses to represent a single condition: a 2-element AND of comparisons, with an
+    /// HMCharacteristic constant on either side of one comparison. Used by
+    /// `extractConditions` via `flattenTopAnd` on the read side, and by
+    /// `HomeKitManager.addAutomationCondition` on the write side to decide whether
+    /// to wrap or flatten an existing predicate. Introduced for the decoder fix in
+    /// 34fd00f; reused for the writer in this PR to keep the leaf-recognition
+    /// vocabulary in lockstep.
+    static func isCharacteristicLeaf(_ subs: [NSPredicate]) -> Bool {
         guard subs.count == 2 else { return false }
         let comparisons = subs.compactMap { $0 as? NSComparisonPredicate }
         guard comparisons.count == 2 else { return false }

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -1667,17 +1667,27 @@ final class HomeKitManager: NSObject, Observable {
     fileprivate func resolveConditions(_ conditions: [[String: String]], in home: HMHome) throws -> [ResolvedCondition] {
         var resolved: [ResolvedCondition] = []
         for cond in conditions {
-            guard let condAccessoryID = cond["accessory"],
-                  let condProperty = cond["property"],
-                  let condValueStr = cond["value"],
-                  !condAccessoryID.isEmpty, !condProperty.isEmpty, !condValueStr.isEmpty
-            else {
+            // Trim and reject whitespace-only values for the same reasons
+            // `addAutomationCondition` does — a `"   "` accessory string would
+            // pass the bare `.isEmpty` check but fail accessory lookup with a
+            // less helpful error. Keeping symmetry with add-condition's
+            // discipline so the same input fails the same way at every entry
+            // point. (Tightens behavior of PR #56's existing parser.)
+            let condAccessoryID = (cond["accessory"] ?? "").trimmingCharacters(in: .whitespaces)
+            let condProperty = (cond["property"] ?? "").trimmingCharacters(in: .whitespaces)
+            let condValueStr = (cond["value"] ?? "").trimmingCharacters(in: .whitespaces)
+            guard !condAccessoryID.isEmpty, !condProperty.isEmpty, !condValueStr.isEmpty else {
                 throw ControlError.invalidArgument("Condition must have non-empty 'accessory', 'property', and 'value' keys")
             }
+            let condRoom: String? = {
+                guard let raw = cond["room"] else { return nil }
+                let t = raw.trimmingCharacters(in: .whitespaces)
+                return t.isEmpty ? nil : t
+            }()
             let condAccessory: HMAccessory
             if let found = home.accessories.first(where: { $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(condAccessoryID) == .orderedSame }) {
                 condAccessory = found
-            } else if let found = findAccessoryByName(condAccessoryID, room: cond["room"], in: home) {
+            } else if let found = findAccessoryByName(condAccessoryID, room: condRoom, in: home) {
                 condAccessory = found
             } else {
                 throw ControlError.accessoryNotFound(condAccessoryID)
@@ -1980,6 +1990,195 @@ final class HomeKitManager: NSObject, Observable {
         var result = summary
         result["dry_run"] = false
         result["after"] = trigger.actionSets.map { $0.name }
+        return result
+    }
+
+    /// Append a characteristic condition (ANDed) to an existing automation's predicate,
+    /// preserving the trigger UUID so button bindings, Siri references, and other
+    /// UUID-keyed integrations survive the modification.
+    ///
+    /// Only HMEventTrigger supports characteristic-condition predicates. HMTimerTrigger
+    /// (Apple Home native time automations) and other HMTrigger subclasses don't expose
+    /// `updatePredicate`, so we reject those up-front with a clear error.
+    ///
+    /// Flatten-at-write strategy: when the trigger's existing predicate is a
+    /// top-level AND compound that ISN'T a characteristic leaf, extract its
+    /// subpredicates and rebuild a fresh top-level AND with the new condition
+    /// appended. Successive calls keep the top-level AND 1-deep — its children
+    /// remain the standard `HMEventTrigger.predicateForEvaluatingTrigger` leaves
+    /// (each itself a 2-element AND of comparisons). This holds for predicates
+    /// HomeClaw wrote; predicates written by Apple Home or other HomeKit clients
+    /// may already have nested structures we preserve when extending.
+    /// `AccessoryModel.extractConditions` + `flattenTopAnd` (see #56 / 34fd00f)
+    /// decode this back to a flat list of conditions regardless of write-time
+    /// nesting, so the read-side decoder handles either case.
+    ///
+    /// HMEventTrigger.updatePredicate is observed to leave the original predicate
+    /// intact on failure (Apple's docs deliver an error via the completion handler
+    /// without formally documenting atomicity, but empirically no partial mutation
+    /// occurs). Earlier steps in this method (resolve accessory / characteristic,
+    /// parse value, build the combined predicate) run before the mutation and
+    /// surface as plain `throws` — no partial mutation can occur there either.
+    ///
+    /// Idempotency: repeated calls with the same accessory+property+value silently
+    /// append duplicate conjuncts. `A AND A` is logically `A` so HomeKit
+    /// evaluation is unaffected, but `extractConditions` will report the
+    /// duplicates and the predicate grows. This is intentional for retry-safety
+    /// after transient HomeKit errors; callers wanting deduplication should
+    /// `get` the trigger first and filter against the existing conditions.
+    ///
+    /// `conditionRoom` is an optional disambiguator forwarded to the name-based
+    /// accessory lookup. When two accessories share a name across different rooms,
+    /// the caller can pass the room name to scope the match. Ignored when
+    /// `accessoryID` already resolves as a UUID. Mirrors the `room` disambiguator
+    /// accepted by `createAutomation`'s `--condition` parser. When the accessory
+    /// name matches multiple accessories across rooms and `conditionRoom` is nil,
+    /// `findAccessoryByName` returns the first match by HomeKit's accessory
+    /// iteration order — non-deterministic from the user's perspective. Pass
+    /// `conditionRoom` (or use the accessory's UUID) to disambiguate.
+    func addAutomationCondition(
+        id: String,
+        accessoryID: String,
+        conditionRoom: String? = nil,
+        property: String,
+        value: String,
+        homeID: String? = nil,
+        dryRun: Bool = false
+    ) async throws -> [String: Any] {
+        await waitForReady()
+        let home = try resolveHome(homeID: homeID)
+
+        // Only HMEventTrigger supports updatePredicate. Reject other trigger subclasses
+        // explicitly so callers get a clear message instead of a no-op.
+        if findEventTrigger(id: id, in: home) == nil, findAnyTrigger(id: id, in: home) != nil {
+            throw ControlError.invalidArgument(
+                "Automation '\(id)' is an HMTimerTrigger (Apple Home native time automation), " +
+                "not an HMEventTrigger. add-condition only works on HMEventTrigger automations " +
+                "because HMTimerTrigger doesn't expose the predicate API needed to append a condition. " +
+                "There's no in-place workaround that preserves the trigger UUID — recreating via " +
+                "`automations create-time` would produce a new UUID, breaking any references " +
+                "(button bindings, Siri shortcuts, integrations) to the original."
+            )
+        }
+        guard let trigger = findEventTrigger(id: id, in: home) else {
+            throw ControlError.triggerNotFound(id)
+        }
+
+        // Resolve the new condition's accessory + characteristic + value before mutating.
+        // Mirrors `createAutomation`'s `--condition` resolution path so the same inputs
+        // produce the same errors regardless of which command was called. Trim
+        // `conditionRoom` here too so a future Swift caller that bypasses
+        // SocketServer (where the wire-side trim happens) still gets the same
+        // discipline — defensive layer-symmetry, not a duplicate of the wire check.
+        let trimmedAccessoryID = accessoryID.trimmingCharacters(in: .whitespaces)
+        let trimmedProperty = property.trimmingCharacters(in: .whitespaces)
+        let trimmedValue = value.trimmingCharacters(in: .whitespaces)
+        let trimmedRoom: String? = {
+            guard let raw = conditionRoom else { return nil }
+            let t = raw.trimmingCharacters(in: .whitespaces)
+            return t.isEmpty ? nil : t
+        }()
+        guard !trimmedAccessoryID.isEmpty,
+              !trimmedProperty.isEmpty,
+              !trimmedValue.isEmpty else {
+            throw ControlError.invalidArgument("Each of accessory/property/value must be non-empty")
+        }
+        // Track which lookup path resolved the accessory so we only echo `room` in
+        // the response when the room scoping was actually meaningful (the
+        // name-based path used it). UUID lookups ignore the room hint, so echoing
+        // it back would suggest the room mattered when it didn't.
+        let condAccessory: HMAccessory
+        let roomScopedLookup: Bool
+        if let found = home.accessories.first(where: { $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(trimmedAccessoryID) == .orderedSame }) {
+            condAccessory = found
+            roomScopedLookup = false
+        } else if let found = findAccessoryByName(trimmedAccessoryID, room: trimmedRoom, in: home) {
+            condAccessory = found
+            roomScopedLookup = (trimmedRoom != nil)
+        } else {
+            throw ControlError.accessoryNotFound(trimmedAccessoryID)
+        }
+        guard let condChar = findCharacteristicByDescription(on: condAccessory, property: trimmedProperty) else {
+            throw ControlError.invalidArgument("Characteristic '\(trimmedProperty)' not found on '\(condAccessory.name)'")
+        }
+        guard let parsedValue = parseActionValue(trimmedValue, property: trimmedProperty) else {
+            throw ControlError.invalidArgument("Cannot parse condition value '\(trimmedValue)' for '\(trimmedProperty)'")
+        }
+
+        let newConditionPredicate = HMEventTrigger.predicateForEvaluatingTrigger(
+            condChar,
+            relatedBy: .equalTo,
+            toValue: parsedValue
+        )
+
+        // Flatten-at-write: if the existing predicate is already a top-level AND that's
+        // NOT a characteristic-leaf (the 2-sub `char == X AND value == Y` shape HomeKit
+        // uses to express a single characteristic predicate), reuse its subpredicates so
+        // the result stays a single flat N-ary AND instead of growing nested.
+        let combinedPredicate: NSPredicate
+        if let existing = trigger.predicate {
+            if let compound = existing as? NSCompoundPredicate,
+               compound.compoundPredicateType == .and,
+               let subs = compound.subpredicates as? [NSPredicate],
+               !AccessoryModel.isCharacteristicLeaf(subs)
+            {
+                var flattened = subs
+                flattened.append(newConditionPredicate)
+                combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: flattened)
+            } else {
+                combinedPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [existing, newConditionPredicate])
+            }
+        } else {
+            combinedPredicate = newConditionPredicate
+        }
+
+        // Project the post-add characteristic-condition count from the structured
+        // decoder. Filter to `type == "characteristic"` so the count matches what a
+        // user expects after `add-condition` — i.e. the number of characteristic
+        // predicates ANDed in the trigger, NOT the total conjunct count (which
+        // would also include weekday and time-of-day predicates).
+        //
+        // Dry-run projects this count from the same `extractConditions` decoder a
+        // follow-up `get` would use, so structurally the count should match. Exact
+        // equality assumes HomeKit preserves the predicate's AND structure on
+        // `updatePredicate` round-trip — empirically observed but not formally
+        // documented by Apple. Note: predicates with conjunct shapes outside
+        // `extractConditions`'s recognized set (e.g. HomeKit-native NOT-compounds,
+        // exotic comparison operators) won't be counted, so the projected count
+        // can under-report on triggers Apple Home wrote with non-standard shapes.
+        let projectedConditionCount = AccessoryModel
+            .extractConditions(combinedPredicate, in: home)
+            .filter { ($0["type"] as? String) == "characteristic" }
+            .count
+
+        var result: [String: Any] = [
+            "id": trigger.uniqueIdentifier.uuidString,
+            "name": trigger.name,
+            "home": home.name,
+            "accessory": condAccessory.name,
+            "accessory_id": condAccessory.uniqueIdentifier.uuidString,
+            "property": trimmedProperty,
+            "value": trimmedValue,
+            "condition_count_after": projectedConditionCount,
+        ]
+        // Echo back the room disambiguator only when it actually scoped the
+        // accessory lookup (the name-based path was taken AND the caller passed
+        // a room). Echoing it back on the UUID path would suggest the room
+        // mattered when in fact it was ignored — UUID lookup is unambiguous and
+        // the room hint is silently discarded.
+        if roomScopedLookup, let trimmedRoom { result["room"] = trimmedRoom }
+
+        if dryRun {
+            result["dry_run"] = true
+            return result
+        }
+
+        // See the function-level docstring for atomicity / failure semantics.
+        try await homeKitAsync { trigger.updatePredicate(combinedPredicate, completionHandler: $0) }
+
+        AppLogger.homekit.info(
+            "[\(home.name)] Added condition to automation '\(trigger.name)': \(condAccessory.name).\(trimmedProperty) = \(trimmedValue)")
+        result["dry_run"] = false
         return result
     }
 

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -1679,11 +1679,23 @@ final class HomeKitManager: NSObject, Observable {
             guard !condAccessoryID.isEmpty, !condProperty.isEmpty, !condValueStr.isEmpty else {
                 throw ControlError.invalidArgument("Condition must have non-empty 'accessory', 'property', and 'value' keys")
             }
-            let condRoom: String? = {
-                guard let raw = cond["room"] else { return nil }
+            // Defense-in-depth against a whitespace-only `room` slipping past the
+            // socket parser. Silently dropping such a value via `trim-then-nil`
+            // would widen the lookup to all rooms and could bind the condition to
+            // the wrong same-named accessory in homes with duplicates. Fail loud
+            // instead. (The socket parser `parseAccessoryRowsArg` is the primary
+            // gate; this guards any other entry point that might construct
+            // condition dicts directly.)
+            let condRoom: String?
+            if let raw = cond["room"] {
                 let t = raw.trimmingCharacters(in: .whitespaces)
-                return t.isEmpty ? nil : t
-            }()
+                guard !t.isEmpty else {
+                    throw ControlError.invalidArgument("Condition 'room' must be non-empty when provided")
+                }
+                condRoom = t
+            } else {
+                condRoom = nil
+            }
             let condAccessory: HMAccessory
             if let found = home.accessories.first(where: { $0.uniqueIdentifier.uuidString.caseInsensitiveCompare(condAccessoryID) == .orderedSame }) {
                 condAccessory = found

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -12,8 +12,34 @@ final class SocketServer: @unchecked Sendable {
     private var acceptSource: DispatchSourceRead?
     private let queue = DispatchQueue(label: "com.shahine.homeclaw.socket", qos: .userInitiated)
 
+    /// Parse a boolean wire arg, distinguishing absent from present-but-unparseable.
+    ///
+    /// Accepts:
+    ///   - true / false (as JSON booleans, bridged to NSCFBoolean on iOS/macOS)
+    ///   - "true" / "false" (case-insensitive strings)
+    ///
+    /// Rejects (returns `defaultValue`):
+    ///   - integers like `1` / `0` (would otherwise silently bool-coerce via `as? Bool`)
+    ///   - typo'd strings like `"yes"`, `"1"`, `"on"` (only the literal "true" string is truthy)
+    ///
+    /// The default-on-unrecognized direction is deliberately the SAFE one for the
+    /// most-affected caller (`dry_run`) — typo'd opt-ins become no-ops rather than
+    /// silently real-applying. The dangerous direction would be treating an
+    /// unparseable input as `true`; this implementation never does that.
     private func parseBool(_ args: [String: Any], key: String, default defaultValue: Bool = false) -> Bool {
-        (args[key] as? Bool) ?? (args[key] as? String).map { $0 == "true" } ?? defaultValue
+        guard let raw = args[key] else { return defaultValue }
+        // Accept NSCFBoolean (the runtime class JSON booleans bridge to). Checking
+        // CFGetTypeID against CFBooleanGetTypeID rejects NSNumber-bool-coerced
+        // integers (`1`, `0`) which would otherwise pass `as? Bool` silently.
+        if let nsNum = raw as? NSNumber, CFGetTypeID(nsNum) == CFBooleanGetTypeID() {
+            return nsNum.boolValue
+        }
+        // Accept explicit "true"/"false" strings (case-insensitive). Any other
+        // string (e.g. "yes", "1", "on") returns the default — never silently true.
+        if let s = raw as? String {
+            return s.lowercased() == "true"
+        }
+        return defaultValue
     }
 
     /// Thrown by `parseWeekdaysArg` when `weekdays` is present but malformed.
@@ -1085,6 +1111,80 @@ final class SocketServer: @unchecked Sendable {
                     id: id,
                     enabled: enabled,
                     homeID: args["home_id"] as? String
+                )
+
+            case "add_automation_condition":
+                // Wire contract: flat args (`accessory`, `property`, `value`, `room`) — the
+                // MCP/JS handler unpacks the nested `condition` object into these flat
+                // siblings. Direct socket clients bypassing the JS layer should send the
+                // flat shape, not the nested.
+                //
+                // Required string args: id, accessory, property, value. Validate each
+                // is present AND non-empty (after whitespace trim) so a whitespace-only
+                // string from the wire can't slip through to HomeKitManager. Mirrors the
+                // CLI `validate()` rules and the discipline established by the
+                // duration_seconds parsing above — distinguish absent from unparseable.
+                // Trim once and forward the trimmed values. Validating a trimmed
+                // string but forwarding the raw form (the prior bug) meant
+                // `--accessory " Front Door "` validated fine but the manager-side
+                // lookup got the padded form and threw `accessoryNotFound`.
+                guard let idRaw = args["id"] as? String else {
+                    return encodeResponse(success: false, error: "Missing 'id' argument")
+                }
+                let id = idRaw.trimmingCharacters(in: .whitespaces)
+                guard !id.isEmpty else {
+                    return encodeResponse(success: false, error: "'id' argument must be non-empty (after trimming whitespace)")
+                }
+                guard let accessoryRaw = args["accessory"] as? String else {
+                    return encodeResponse(success: false, error: "Missing 'accessory' argument")
+                }
+                let accessory = accessoryRaw.trimmingCharacters(in: .whitespaces)
+                guard !accessory.isEmpty else {
+                    return encodeResponse(success: false, error: "'accessory' argument must be non-empty (after trimming whitespace)")
+                }
+                guard let propertyRaw = args["property"] as? String else {
+                    return encodeResponse(success: false, error: "Missing 'property' argument")
+                }
+                let property = propertyRaw.trimmingCharacters(in: .whitespaces)
+                guard !property.isEmpty else {
+                    return encodeResponse(success: false, error: "'property' argument must be non-empty (after trimming whitespace)")
+                }
+                guard let valueRaw = args["value"] as? String else {
+                    return encodeResponse(success: false, error: "Missing 'value' argument")
+                }
+                let value = valueRaw.trimmingCharacters(in: .whitespaces)
+                guard !value.isEmpty else {
+                    return encodeResponse(success: false, error: "'value' argument must be non-empty (after trimming whitespace)")
+                }
+                // Optional room disambiguator — mirrors the `condition.room` field
+                // accepted by `create`/`create-time`. Forwarded to HomeKitManager so
+                // accessory name lookup can scope by room when multiple accessories
+                // share a name across rooms. Distinguish absent (nil OK) from
+                // present-but-malformed (e.g. `room: 123` or `room: ["Kitchen"]`),
+                // mirroring the e6ffa1b validation pattern Omar applied to
+                // time_after / time_before in a46ac9f. Empty / whitespace-only
+                // strings are rejected up-front rather than silently coerced to nil.
+                let conditionRoom: String?
+                if let raw = args["room"] {
+                    guard let s = raw as? String else {
+                        return encodeResponse(success: false, error: "'room' must be a string when provided")
+                    }
+                    let trimmed = s.trimmingCharacters(in: .whitespaces)
+                    if trimmed.isEmpty {
+                        return encodeResponse(success: false, error: "'room' must be non-empty when provided")
+                    }
+                    conditionRoom = trimmed
+                } else {
+                    conditionRoom = nil
+                }
+                result = try await hk.addAutomationCondition(
+                    id: id,
+                    accessoryID: accessory,
+                    conditionRoom: conditionRoom,
+                    property: property,
+                    value: value,
+                    homeID: args["home_id"] as? String,
+                    dryRun: parseBool(args, key: "dry_run")
                 )
 
             case "webhook_log":

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -101,13 +101,23 @@ final class SocketServer: @unchecked Sendable {
                 }
                 row[key] = strVal
             }
-            // Optional `room` field — preserve if present and string-valued.
+            // Optional `room` field — trim and reject whitespace-only at intake.
+            // A bare `.isEmpty` check would accept `"   "` and let it propagate to
+            // the resolver, where the trim-to-nil pattern would silently drop the
+            // explicit-but-malformed scope and widen the accessory lookup to all
+            // rooms — potentially binding the condition to the wrong same-named
+            // accessory. Matches the discipline applied to the required
+            // accessory/property/value fields and to the add-condition socket
+            // handler's `room` validation.
             if let roomRaw = dict["room"] {
-                if let roomStr = roomRaw as? String, !roomStr.isEmpty {
-                    row["room"] = roomStr
-                } else {
+                guard let roomStr = roomRaw as? String else {
                     throw AccessoryRowsArgError(message: "'\(fieldName)'[\(index)].room must be a non-empty string when provided")
                 }
+                let trimmed = roomStr.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else {
+                    throw AccessoryRowsArgError(message: "'\(fieldName)'[\(index)].room must be a non-empty string when provided")
+                }
+                row["room"] = trimmed
             }
             result.append(row)
         }

--- a/Tests/homeclaw-cliTests/AddConditionTests.swift
+++ b/Tests/homeclaw-cliTests/AddConditionTests.swift
@@ -1,0 +1,206 @@
+import Testing
+@testable import homeclaw_cli
+
+/// Tests for the `automations add-condition` CLI parser.
+///
+/// Only the CLI-layer validation surface is testable from this target — the manager
+/// and SocketServer halves live in the `homeclaw` app target (Catalyst-only, HomeKit
+/// entitlement required) and are exercised end-to-end via `swift run homeclaw-cli`
+/// against a running app, not from unit tests. The empty-string and whitespace-only
+/// rejection paths covered here mirror the SocketServer-side `Missing or empty` guard
+/// in `SocketServer.swift` so a malformed CLI invocation fails fast at the parser.
+@Suite("AddAutomationCondition CLI parser")
+struct AddConditionTests {
+    @Test("parses all required flags")
+    func parsesRequiredFlags() throws {
+        let cmd = try AddAutomationCondition.parse([
+            "Porch Lights",
+            "--accessory", "Front Door",
+            "--property", "contact_state",
+            "--value", "0",
+        ])
+        #expect(cmd.id == "Porch Lights")
+        #expect(cmd.accessory == "Front Door")
+        #expect(cmd.property == "contact_state")
+        #expect(cmd.value == "0")
+        #expect(cmd.dryRun == false)
+        #expect(cmd.json == false)
+        #expect(cmd.home == nil)
+    }
+
+    @Test("accepts --dry-run and --json flags")
+    func parsesOptionalFlags() throws {
+        let cmd = try AddAutomationCondition.parse([
+            "Porch Lights",
+            "--accessory", "Front Door",
+            "--property", "contact_state",
+            "--value", "0",
+            "--dry-run",
+            "--json",
+        ])
+        #expect(cmd.dryRun == true)
+        #expect(cmd.json == true)
+    }
+
+    @Test("accepts --home option")
+    func parsesHome() throws {
+        let cmd = try AddAutomationCondition.parse([
+            "auto-1",
+            "--accessory", "Sensor",
+            "--property", "motion_detected",
+            "--value", "true",
+            "--home", "My Home",
+        ])
+        #expect(cmd.home == "My Home")
+    }
+
+    /// Assert that `cmd.validate()` throws and that the error message mentions `expected`.
+    /// `AddAutomationCondition.validate()` throws `ValidationError` directly — when used
+    /// via `ParsableCommand.parse(...)` the runner wraps it in a `CommandError`, but
+    /// invoking `validate()` directly throws the underlying error. We match on
+    /// `String(describing:)` so either case is acceptable.
+    private func expectValidationFails(
+        _ args: [String],
+        mentioning expected: String,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        do {
+            let cmd = try AddAutomationCondition.parse(args)
+            try cmd.validate()
+            Issue.record("expected validation to fail mentioning '\(expected)'", sourceLocation: sourceLocation)
+        } catch {
+            let desc = String(describing: error)
+            #expect(desc.contains(expected), "error '\(desc)' should mention '\(expected)'", sourceLocation: sourceLocation)
+        }
+    }
+
+    @Test("rejects empty positional id")
+    func rejectsEmptyId() {
+        expectValidationFails(
+            ["", "--accessory", "Front Door", "--property", "contact_state", "--value", "0"],
+            mentioning: "id/name must be non-empty"
+        )
+    }
+
+    @Test("rejects whitespace-only id")
+    func rejectsWhitespaceId() {
+        expectValidationFails(
+            ["   ", "--accessory", "Front Door", "--property", "contact_state", "--value", "0"],
+            mentioning: "id/name must be non-empty"
+        )
+    }
+
+    @Test("rejects empty --accessory")
+    func rejectsEmptyAccessory() {
+        expectValidationFails(
+            ["Porch Lights", "--accessory", "", "--property", "contact_state", "--value", "0"],
+            mentioning: "--accessory must be non-empty"
+        )
+    }
+
+    @Test("rejects whitespace-only --accessory")
+    func rejectsWhitespaceAccessory() {
+        expectValidationFails(
+            ["Porch Lights", "--accessory", "   ", "--property", "contact_state", "--value", "0"],
+            mentioning: "--accessory must be non-empty"
+        )
+    }
+
+    @Test("rejects empty --property")
+    func rejectsEmptyProperty() {
+        expectValidationFails(
+            ["Porch Lights", "--accessory", "Front Door", "--property", "", "--value", "0"],
+            mentioning: "--property must be non-empty"
+        )
+    }
+
+    @Test("rejects whitespace-only --property")
+    func rejectsWhitespaceProperty() {
+        expectValidationFails(
+            ["Porch Lights", "--accessory", "Front Door", "--property", "   ", "--value", "0"],
+            mentioning: "--property must be non-empty"
+        )
+    }
+
+    @Test("rejects empty --value")
+    func rejectsEmptyValue() {
+        expectValidationFails(
+            ["Porch Lights", "--accessory", "Front Door", "--property", "contact_state", "--value", ""],
+            mentioning: "--value must be non-empty"
+        )
+    }
+
+    @Test("rejects whitespace-only --value")
+    func rejectsWhitespaceValue() {
+        expectValidationFails(
+            ["Porch Lights", "--accessory", "Front Door", "--property", "contact_state", "--value", "   "],
+            mentioning: "--value must be non-empty"
+        )
+    }
+
+    @Test("accepts numeric-looking values without coercion")
+    func acceptsNumericValueAsString() throws {
+        let cmd = try AddAutomationCondition.parse([
+            "auto-1",
+            "--accessory", "Thermostat",
+            "--property", "current_temperature",
+            "--value", "72.5",
+        ])
+        try cmd.validate()
+        #expect(cmd.value == "72.5")
+    }
+
+    @Test("missing required flag rejected by ArgumentParser")
+    func rejectsMissingProperty() {
+        #expect(throws: (any Error).self) {
+            _ = try AddAutomationCondition.parse([
+                "auto-1",
+                "--accessory", "Sensor",
+                "--value", "true",
+            ])
+        }
+    }
+
+    // MARK: --room
+
+    @Test("accepts --room when provided")
+    func parsesRoom() throws {
+        let cmd = try AddAutomationCondition.parse([
+            "auto-1",
+            "--accessory", "Light",
+            "--property", "power",
+            "--value", "true",
+            "--room", "Kitchen",
+        ])
+        try cmd.validate()
+        #expect(cmd.room == "Kitchen")
+    }
+
+    @Test("--room absent → validate() passes with cmd.room == nil")
+    func roomAbsentValidates() throws {
+        let cmd = try AddAutomationCondition.parse([
+            "auto-1",
+            "--accessory", "Light",
+            "--property", "power",
+            "--value", "true",
+        ])
+        try cmd.validate()
+        #expect(cmd.room == nil)
+    }
+
+    @Test("rejects empty --room")
+    func rejectsEmptyRoom() {
+        expectValidationFails(
+            ["Porch Lights", "--accessory", "Front Door", "--property", "contact_state", "--value", "0", "--room", ""],
+            mentioning: "--room must be non-empty"
+        )
+    }
+
+    @Test("rejects whitespace-only --room")
+    func rejectsWhitespaceRoom() {
+        expectValidationFails(
+            ["Porch Lights", "--accessory", "Front Door", "--property", "contact_state", "--value", "0", "--room", "   "],
+            mentioning: "--room must be non-empty"
+        )
+    }
+}

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -145,7 +145,14 @@ export async function handleAutomations(args) {
         socketArgs.duration_seconds = String(d);
       }
       if (args.home_id) socketArgs.home_id = args.home_id;
-      if (args.dry_run) socketArgs.dry_run = 'true';
+      // Accept actual booleans (MCP schema-compliant) and the common stringified
+      // form `"true"`. We deliberately do NOT use loose truthy coercion (`if
+      // (args.dry_run)`) because that flips the string `"false"` to truthy and
+      // would silently real-apply when the caller wanted a dry-run preview. Any
+      // value other than the boolean `true` or the exact string `"true"` is
+      // ignored — a string `"false"`, missing key, or unrecognized type all fall
+      // through to a real apply, which matches the schema-default of `false`.
+      if (args.dry_run === true || args.dry_run === 'true') socketArgs.dry_run = 'true';
       return sendCommand('create_time_automation', socketArgs);
     }
 
@@ -191,7 +198,8 @@ export async function handleAutomations(args) {
         socketArgs.duration_seconds = String(d);
       }
       if (args.home_id) socketArgs.home_id = args.home_id;
-      if (args.dry_run) socketArgs.dry_run = 'true';
+      // See create_time above for why we accept the stringified `"true"` too.
+      if (args.dry_run === true || args.dry_run === 'true') socketArgs.dry_run = 'true';
       return sendCommand('create_automation', socketArgs);
     }
 
@@ -199,7 +207,7 @@ export async function handleAutomations(args) {
       if (!args.id) throw new Error('id is required for delete action');
       const socketArgs = { id: args.id };
       if (args.home_id) socketArgs.home_id = args.home_id;
-      if (args.dry_run) socketArgs.dry_run = 'true';
+      if (args.dry_run === true || args.dry_run === 'true') socketArgs.dry_run = 'true';
       return sendCommand('delete_automation', socketArgs);
     }
 
@@ -212,6 +220,51 @@ export async function handleAutomations(args) {
       };
       if (args.home_id) socketArgs.home_id = args.home_id;
       return sendCommand('enable_automation', socketArgs);
+    }
+
+    case 'add_condition': {
+      // Modify-in-place verb: appends a single characteristic condition to an existing
+      // automation's trigger predicate. Uses the singular `condition` object (vs the
+      // plural `conditions` array on `create`) so the wire shape advertises that this
+      // is a single-step append, not a bulk replace.
+      // Symmetric whitespace-trim rejection across all required string args
+      // — matches the CLI `validate()` and the SocketServer-side guard so the same
+      // input fails the same way at every layer. `id` was previously checked with
+      // truthy `if (!args.id)` which let whitespace-only strings through; tightened
+      // to the same `typeof + trim()` shape as accessory/property/value below.
+      if (typeof args.id !== 'string' || args.id.trim() === '') {
+        throw new Error('id is required for add_condition action (must be a non-empty string)');
+      }
+      if (!args.condition || typeof args.condition !== 'object') {
+        throw new Error('condition object is required for add_condition action');
+      }
+      const { accessory, property, value, room } = args.condition;
+      if (typeof accessory !== 'string' || accessory.trim() === '') {
+        throw new Error('condition.accessory is required (must be a non-empty string)');
+      }
+      if (typeof property !== 'string' || property.trim() === '') {
+        throw new Error('condition.property is required (must be a non-empty string)');
+      }
+      if (typeof value !== 'string' || value.trim() === '') {
+        throw new Error('condition.value must be a non-empty string');
+      }
+      if (room != null && (typeof room !== 'string' || room.trim() === '')) {
+        throw new Error('condition.room must be a non-empty string when provided');
+      }
+      const socketArgs = {
+        id: args.id,
+        accessory,
+        property,
+        value,
+      };
+      // `room` is forwarded to SocketServer / HomeKitManager.addAutomationCondition
+      // as a name-scope disambiguator, matching the pattern used by create /
+      // create-time conditions when multiple accessories share a name across rooms.
+      if (room) socketArgs.room = room;
+      if (args.home_id) socketArgs.home_id = args.home_id;
+      // See create_time above for why we accept the stringified `"true"` too.
+      if (args.dry_run === true || args.dry_run === 'true') socketArgs.dry_run = 'true';
+      return sendCommand('add_automation_condition', socketArgs);
     }
 
     default:

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -203,13 +203,13 @@ export const tools = [
   },
   {
     name: 'homekit_automations',
-    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) or by a time of day (clock or sunrise/sunset), delete automations, or enable/disable them. For characteristic-change triggers use action=create with press_type (buttons) or characteristic+trigger_value (sensors). For time-of-day triggers use action=create_time with the `time` field (HH:MM, sunrise, sunset, or <sun-event>±N). Both create actions accept the same predicate vocabulary: weekdays, conditions, time_after, time_before, duration_seconds. Use duration_seconds to auto-revert actions after N seconds (e.g. motion-triggered lights or sunset porch lights that turn off after a delay). List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
+    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) or by a time of day (clock or sunrise/sunset), delete automations, or enable/disable them. For characteristic-change triggers use action=create with press_type (buttons) or characteristic+trigger_value (sensors). For time-of-day triggers use action=create_time with the `time` field (HH:MM, sunrise, sunset, or <sun-event>±N). Both create actions accept the same predicate vocabulary: weekdays, conditions, time_after, time_before, duration_seconds. Use duration_seconds to auto-revert actions after N seconds (e.g. motion-triggered lights or sunset porch lights that turn off after a delay). Use action=add_condition to append a characteristic condition (ANDed) to an existing automation in place — the trigger UUID is preserved, so button bindings and Siri references survive. List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype. Note: the predicate-composition features (conditions, time_after/time_before, add_condition) are built on standard HMEventTrigger predicate composition — supported by Apple\'s HomeKit framework APIs but not yet surfaced in the Home app\'s Automations tab. They mirror the rule-editor capabilities exposed by third-party HomeKit apps like Controller for HomeKit. Rules created or modified this way execute correctly via HomeKit; use list/get to inspect them since they may not be editable from the Home app.',
     inputSchema: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
-          enum: ['list', 'get', 'create', 'create_time', 'delete', 'enable', 'disable'],
+          enum: ['list', 'get', 'create', 'create_time', 'delete', 'enable', 'disable', 'add_condition'],
           description: 'Action to perform. Default: list',
         },
         home_id: {
@@ -280,7 +280,7 @@ export const tools = [
               accessory: { type: 'string', description: 'Condition accessory UUID (preferred) or name' },
               property: { type: 'string', description: 'Characteristic name (e.g., contact_state, occupancy_detected, power)' },
               value: { type: 'string', description: 'Required value as string (e.g., "true", "0", "50"). Uses exact match (==).' },
-              room: { type: 'string', description: 'Room name for accessory disambiguation (optional)' },
+              room: { type: 'string', description: 'Room name for accessory disambiguation when multiple accessories share a name (optional)' },
             },
             required: ['accessory', 'property', 'value'],
           },
@@ -302,9 +302,20 @@ export const tools = [
           maximum: 86400,
           description: 'Auto-revert the trigger\'s actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger\'s endEvents — HomeKit handles the revert natively, no follow-up automation required. Common use cases: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold), or sunset porch lights that should turn off after an hour. (create / create_time actions)',
         },
+        condition: {
+          type: 'object',
+          properties: {
+            accessory: { type: 'string', description: 'Condition accessory UUID (preferred) or name' },
+            property: { type: 'string', description: 'Characteristic name (e.g., contact_state, occupancy_detected, power)' },
+            value: { type: 'string', description: 'Required value as string (e.g., "true", "0", "50"). Uses exact match (==).' },
+            room: { type: 'string', description: 'Room name for accessory disambiguation when multiple accessories share a name (optional)' },
+          },
+          required: ['accessory', 'property', 'value'],
+          description: 'Single characteristic condition (object — note the singular field name, distinct from the plural `conditions` array used by create / create_time) to append (ANDed) to an existing automation\'s trigger predicate. To add multiple conditions, call add_condition repeatedly — each call preserves the trigger UUID, so physical button bindings, Siri references, and other UUID-keyed integrations survive every modification. The read-side decoder (list/get) surfaces the new condition automatically. To replace an existing condition set, delete the automation and recreate it. (add_condition action)',
+        },
         dry_run: {
           type: 'boolean',
-          description: 'Preview changes without applying (create/create_time/delete actions)',
+          description: 'Preview changes without applying (create/create_time/delete/add_condition actions)',
         },
       },
       required: ['action'],

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21015,13 +21015,13 @@ var tools = [
   },
   {
     name: "homekit_automations",
-    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) or by a time of day (clock or sunrise/sunset), delete automations, or enable/disable them. For characteristic-change triggers use action=create with press_type (buttons) or characteristic+trigger_value (sensors). For time-of-day triggers use action=create_time with the `time` field (HH:MM, sunrise, sunset, or <sun-event>\xB1N). Both create actions accept the same predicate vocabulary: weekdays, conditions, time_after, time_before, duration_seconds. Use duration_seconds to auto-revert actions after N seconds (e.g. motion-triggered lights or sunset porch lights that turn off after a delay). List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype.',
+    description: 'Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) or by a time of day (clock or sunrise/sunset), delete automations, or enable/disable them. For characteristic-change triggers use action=create with press_type (buttons) or characteristic+trigger_value (sensors). For time-of-day triggers use action=create_time with the `time` field (HH:MM, sunrise, sunset, or <sun-event>\xB1N). Both create actions accept the same predicate vocabulary: weekdays, conditions, time_after, time_before, duration_seconds. Use duration_seconds to auto-revert actions after N seconds (e.g. motion-triggered lights or sunset porch lights that turn off after a delay). Use action=add_condition to append a characteristic condition (ANDed) to an existing automation in place \u2014 the trigger UUID is preserved, so button bindings and Siri references survive. List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type ("button" | "characteristic" | "calendar" | "significant_time" | "timer" | "unknown") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype. Note: the predicate-composition features (conditions, time_after/time_before, add_condition) are built on standard HMEventTrigger predicate composition \u2014 supported by Apple\'s HomeKit framework APIs but not yet surfaced in the Home app\'s Automations tab. They mirror the rule-editor capabilities exposed by third-party HomeKit apps like Controller for HomeKit. Rules created or modified this way execute correctly via HomeKit; use list/get to inspect them since they may not be editable from the Home app.',
     inputSchema: {
       type: "object",
       properties: {
         action: {
           type: "string",
-          enum: ["list", "get", "create", "create_time", "delete", "enable", "disable"],
+          enum: ["list", "get", "create", "create_time", "delete", "enable", "disable", "add_condition"],
           description: "Action to perform. Default: list"
         },
         home_id: {
@@ -21092,7 +21092,7 @@ var tools = [
               accessory: { type: "string", description: "Condition accessory UUID (preferred) or name" },
               property: { type: "string", description: "Characteristic name (e.g., contact_state, occupancy_detected, power)" },
               value: { type: "string", description: 'Required value as string (e.g., "true", "0", "50"). Uses exact match (==).' },
-              room: { type: "string", description: "Room name for accessory disambiguation (optional)" }
+              room: { type: "string", description: "Room name for accessory disambiguation when multiple accessories share a name (optional)" }
             },
             required: ["accessory", "property", "value"]
           },
@@ -21114,9 +21114,20 @@ var tools = [
           maximum: 86400,
           description: "Auto-revert the trigger's actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger's endEvents \u2014 HomeKit handles the revert natively, no follow-up automation required. Common use cases: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold), or sunset porch lights that should turn off after an hour. (create / create_time actions)"
         },
+        condition: {
+          type: "object",
+          properties: {
+            accessory: { type: "string", description: "Condition accessory UUID (preferred) or name" },
+            property: { type: "string", description: "Characteristic name (e.g., contact_state, occupancy_detected, power)" },
+            value: { type: "string", description: 'Required value as string (e.g., "true", "0", "50"). Uses exact match (==).' },
+            room: { type: "string", description: "Room name for accessory disambiguation when multiple accessories share a name (optional)" }
+          },
+          required: ["accessory", "property", "value"],
+          description: "Single characteristic condition (object \u2014 note the singular field name, distinct from the plural `conditions` array used by create / create_time) to append (ANDed) to an existing automation's trigger predicate. To add multiple conditions, call add_condition repeatedly \u2014 each call preserves the trigger UUID, so physical button bindings, Siri references, and other UUID-keyed integrations survive every modification. The read-side decoder (list/get) surfaces the new condition automatically. To replace an existing condition set, delete the automation and recreate it. (add_condition action)"
+        },
         dry_run: {
           type: "boolean",
-          description: "Preview changes without applying (create/create_time/delete actions)"
+          description: "Preview changes without applying (create/create_time/delete/add_condition actions)"
         }
       },
       required: ["action"]
@@ -21353,7 +21364,7 @@ async function handleAutomations(args) {
         socketArgs.duration_seconds = String(d);
       }
       if (args.home_id) socketArgs.home_id = args.home_id;
-      if (args.dry_run) socketArgs.dry_run = "true";
+      if (args.dry_run === true || args.dry_run === "true") socketArgs.dry_run = "true";
       return sendCommand("create_time_automation", socketArgs);
     }
     case "create": {
@@ -21396,14 +21407,14 @@ async function handleAutomations(args) {
         socketArgs.duration_seconds = String(d);
       }
       if (args.home_id) socketArgs.home_id = args.home_id;
-      if (args.dry_run) socketArgs.dry_run = "true";
+      if (args.dry_run === true || args.dry_run === "true") socketArgs.dry_run = "true";
       return sendCommand("create_automation", socketArgs);
     }
     case "delete": {
       if (!args.id) throw new Error("id is required for delete action");
       const socketArgs = { id: args.id };
       if (args.home_id) socketArgs.home_id = args.home_id;
-      if (args.dry_run) socketArgs.dry_run = "true";
+      if (args.dry_run === true || args.dry_run === "true") socketArgs.dry_run = "true";
       return sendCommand("delete_automation", socketArgs);
     }
     case "enable":
@@ -21415,6 +21426,37 @@ async function handleAutomations(args) {
       };
       if (args.home_id) socketArgs.home_id = args.home_id;
       return sendCommand("enable_automation", socketArgs);
+    }
+    case "add_condition": {
+      if (typeof args.id !== "string" || args.id.trim() === "") {
+        throw new Error("id is required for add_condition action (must be a non-empty string)");
+      }
+      if (!args.condition || typeof args.condition !== "object") {
+        throw new Error("condition object is required for add_condition action");
+      }
+      const { accessory, property, value, room } = args.condition;
+      if (typeof accessory !== "string" || accessory.trim() === "") {
+        throw new Error("condition.accessory is required (must be a non-empty string)");
+      }
+      if (typeof property !== "string" || property.trim() === "") {
+        throw new Error("condition.property is required (must be a non-empty string)");
+      }
+      if (typeof value !== "string" || value.trim() === "") {
+        throw new Error("condition.value must be a non-empty string");
+      }
+      if (room != null && (typeof room !== "string" || room.trim() === "")) {
+        throw new Error("condition.room must be a non-empty string when provided");
+      }
+      const socketArgs = {
+        id: args.id,
+        accessory,
+        property,
+        value
+      };
+      if (room) socketArgs.room = room;
+      if (args.home_id) socketArgs.home_id = args.home_id;
+      if (args.dry_run === true || args.dry_run === "true") socketArgs.dry_run = "true";
+      return sendCommand("add_automation_condition", socketArgs);
     }
     default:
       throw new Error(`Unknown automations action: ${action}`);


### PR DESCRIPTION
## UX context

The multi-condition predicates this verb operates on (and the ones #56 added at create-time) are built on standard `HMEventTrigger` predicate composition — supported by Apple's HomeKit framework APIs but not yet surfaced in the Home app's Automations tab. They mirror the rule-editor capabilities exposed by third-party HomeKit apps like Controller for HomeKit. Rules created or modified this way execute correctly via HomeKit; users inspect them via `automations list/get` (or via this PR's `add-condition` echo), since they may not be editable from the Home app.

## What this adds

`automations add-condition <id-or-name> --accessory --property --value [--room]` — a modify-in-place verb that ANDs an extra characteristic condition into an existing automation's predicate while **preserving the trigger UUID**. Per #48: *"preserving the trigger UUID is exactly why it can't just be 'delete + recreate with extra flags' — button bindings and Siri references would break."*

```bash
# Tighten an existing porch-motion automation so it only fires when the front door is closed
homeclaw-cli automations add-condition "Porch Lights" \
  --accessory "Front Door" \
  --property contact_state \
  --value 0
```

Output:

```
Added condition to 'Porch Lights': Front Door.contact_state = 0
Trigger now has 2 condition(s)
```

`--room` for accessory disambiguation when the same name exists across rooms. Dry-run via `--dry-run` projects `condition_count_after` from the same decoder a follow-up `get` would use.

## What changed

**Write side**

- **`Sources/homeclaw-cli/Commands/AutomationsCommand.swift`** — `AddAutomationCondition` struct with positional `<id>`, required `--accessory/--property/--value`, optional `--room`/`--home`/`--dry-run`/`--json`. All required strings trim-and-reject whitespace-only input. Success/dry-run output displays the room when name-path disambiguation was used.
- **`Sources/homeclaw/HomeKit/SocketServer.swift`** — `case "add_automation_condition":` with the e6ffa1b / a46ac9f validation discipline applied to all five string args. Trimmed values are *forwarded* (not just validated then dropped) so `--accessory " Front Door "` resolves cleanly instead of failing the lookup. Optional `room` distinguishes absent from present-but-malformed.
- **`Sources/homeclaw/HomeKit/HomeKitManager.swift`** — new `addAutomationCondition(...)` method:
  1. `findEventTrigger` lookup; reject `HMTimerTrigger` with an honest error (no in-place workaround that preserves UUID).
  2. Resolve accessory + characteristic + value before any HomeKit mutation. Track UUID-path vs name-path so the result dict only echoes `room` when it actually scoped the lookup.
  3. Build the new condition via `predicateForEvaluatingTrigger(_:relatedBy:toValue:)`.
  4. **Flatten at write** for HomeClaw-written predicates: extract the existing top-level AND's subpredicates and rebuild a fresh top-level AND with the new condition appended. HomeKit-native predicates with pre-existing nested ANDs are preserved as-is (the read-side `flattenTopAnd` decoder from `34fd00f` handles either case).
  5. `trigger.updatePredicate` is observed to leave the original predicate intact on failure. Earlier resolution/parse steps surface as plain throws — no rollback path needed.

  Repeated calls with the same accessory+property+value silently append duplicate conjuncts (`A AND A` is logically `A` so HomeKit evaluation is unaffected, but `extractConditions` reports duplicates and the predicate grows). Intentional for retry-safety after transient errors.

- **`Sources/homeclaw/HomeKit/AccessoryModel.swift`** — `isCharacteristicLeaf` promoted from `private` to `internal` so the writer side and the reader side share the same recognition function. Single source of truth eliminates the drift risk that `34fd00f` fixed on the decoder.

`condition_count_after` filters `extractConditions` to characteristic-type entries only (not weekday / time conjuncts), so the CLI message "Trigger now has N condition(s)" matches user expectation when the trigger also has `--days` / `--time-after` / `--duration`.

## Drive-by fixes (happy to split out if you prefer)

These three touched code outside `add-condition`'s strict scope but applied patterns this PR explicitly hardens for `add-condition`. All three are strictly safer than the prior behavior:

- **`SocketServer.parseBool`** now distinguishes absent from unparseable, accepts only `__NSCFBoolean` (not coerced integers) and case-insensitive `"true"` string. Searched the codebase — no in-tree caller depends on the old permissive behavior.
- **JS handler `dry_run` check** tightened across all four automation actions (`create_time`, `create`, `delete`, `add_condition`) to accept the JSON boolean `true` AND the literal string `"true"`. Pre-audit truthy-check silently flipped string `"false"` to dry-run (real bug); the change preserves that protection while still accepting the common stringified form.
- **`HomeKitManager.createAutomation`'s `--condition` bulk parser** now applies the same `trimmingCharacters` whitespace-rejection as the new `add-condition` path, closing a pre-existing asymmetry from #56.

## MCP/lib parity

- `lib/schemas.js`: `add_condition` added to the `homekit_automations` action enum; new singular `condition` object schema (description explicitly disambiguates from the plural `conditions` array on create / create_time). Tool description gained a brief note explaining that these predicate-composition features execute via Apple's HomeKit APIs but aren't surfaced in the Home app's Automations tab — so LLM callers can correctly answer "where do I see this in the Home app?" without users suspecting a hack.
- `lib/handlers/homekit.js`: `case 'add_condition'` validates `id` / `accessory` / `property` / `value` / `room` as non-empty trimmed strings (no silent coercion); `dry_run` accepts boolean `true` or string `"true"`; forwards `room` for disambiguation.
- `mcp-server/dist/server.js` rebuilt.

## Testing status

- ✅ `swift build --product homeclaw-cli` — clean
- ✅ `swift test` — 60/60 pass (43 from prior PRs + 17 from this PR's `AddAutomationCondition CLI parser` suite covering happy-path, all optional flags, validation rejection of empty/whitespace-only id/accessory/property/value/room, numeric-string preservation, and ArgumentParser-level missing-required-option rejection)
- ✅ `npm install && npm run build:mcp` — clean
- ✅ `xcodebuild ... Catalyst CODE_SIGNING_ALLOWED=NO build` — `** BUILD SUCCEEDED **`
- ⚠️ Runtime end-to-end against real HomeKit — same provisioning caveat as the prior PRs. The flatten-at-write logic + `isCharacteristicLeaf` shared helper round-trip cleanly against the `extractConditions` decoder that's been in main since #56 + `34fd00f`. Standing by for your spot-check.

## Known limitations (deferred)

- **`--service-index` on `add-condition`**: `create` exposes it for multi-button accessories; `add-condition` doesn't. The use case (a multi-service accessory used as a condition source, not just as a trigger source) is uncommon — and `findCharacteristicByDescription`'s current first-match semantics don't have a clean service-index hook. Deferred as a follow-up.
- **Direct unit tests for `addAutomationCondition`** and the SocketServer arg parsers aren't possible from the existing `homeclaw-cliTests` target (depends on the CLI module only, not the Catalyst app target). Documented as a target-boundary limitation; the CLI parser layer is well-tested.
- **CI scope**: GitHub Actions runs `swift build` + `swift test` via SPM, which exercises the CLI target only. HomeKitManager + SocketServer changes verified locally via Catalyst `xcodebuild`.

## Sequence

Per #48: PR 6 of 6. Builds on #49, #50, #56, #59, #60. **Completes the 6-PR sequence sketched in #48.**

Thanks for the careful reviews and post-merge fixes throughout this run — each one taught a pattern that compounded into the next PR (the `flattenTopAnd` decoder fix from `34fd00f` is what makes this PR's write-side flatten work correctly on round-trip; the validation hardening from `e6ffa1b` shaped both the `parseAccessoryRowsArg` helper and this PR's whitespace-trim discipline).

Refs #48.
