### PR TITLE
fix: self-heal wedged control socket + stale menu on headless Macs

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,8 +26,6 @@
 	<string>26.0</string>
 	<key>LSUIElement</key>
 	<true/>
-	<key>NSAppSleepDisabled</key>
-	<true/>
 	<key>NSHomeKitUsageDescription</key>
 	<string>HomeClaw needs access to your HomeKit accessories to expose them via MCP and CLI.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,6 +26,8 @@
 	<string>26.0</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSAppSleepDisabled</key>
+	<true/>
 	<key>NSHomeKitUsageDescription</key>
 	<string>HomeClaw needs access to your HomeKit accessories to expose them via MCP and CLI.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/Sources/homeclaw/App/HomeClawApp.swift
+++ b/Sources/homeclaw/App/HomeClawApp.swift
@@ -18,6 +18,15 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
     private var menuDataObserver: NSObjectProtocol?
     private var webhookCircuitObserver: NSObjectProtocol?
 
+    /// Held for the app's lifetime to opt out of App Nap. HomeClaw is an
+    /// `LSUIElement` background agent: on a headless Mac (no display/UI activity)
+    /// macOS aggressively App-Naps it, which suspends the socket accept loop and
+    /// the menu-data push task — the app stays alive but its control socket starts
+    /// refusing connections and the menu freezes until a manual restart. The
+    /// assertion uses `.allowing` idle system sleep so the Mac can still sleep
+    /// normally; it only prevents our process from being napped while awake.
+    private var appNapActivity: NSObjectProtocol?
+
     /// Set to true only by openSettings() — used to distinguish explicit
     /// settings requests from UIKit scene session restoration on launch.
     static var settingsRequested = false
@@ -57,6 +66,10 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
         Task { @MainActor in
             _ = await HomeKitManager.shared.refreshCache()
         }
+    }
+
+    @objc func currentMenuData() -> [String: Any] {
+        HomeKitManager.shared.buildMenuData()
     }
 
     @objc func controlAccessory(id: String, characteristic: String, value: String) {
@@ -134,6 +147,13 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         AppLogger.app.info("HomeClaw starting (unified Catalyst)...")
+
+        // Opt out of App Nap for the lifetime of the process so the control socket
+        // and menu-data pipeline keep running on headless/idle Macs. `.allowing`
+        // idle system sleep keeps normal Mac sleep behavior intact.
+        appNapActivity = ProcessInfo.processInfo.beginActivity(
+            options: .userInitiatedAllowingIdleSystemSleep,
+            reason: "HomeKit bridge and control socket")
 
         // Hide from dock — menu bar only
         #if targetEnvironment(macCatalyst)

--- a/Sources/homeclaw/Bridge/BridgeProtocols.swift
+++ b/Sources/homeclaw/Bridge/BridgeProtocols.swift
@@ -7,6 +7,10 @@ import Foundation
     var isLaunchAtLoginEnabled: Bool { get }
     func setLaunchAtLogin(_ enabled: Bool)
     func refreshData()
+    /// Synchronously returns the current menu snapshot from the in-memory cache
+    /// (no async I/O). Lets the bridge pull fresh data when the menu opens, so a
+    /// stale menu self-heals on the next click instead of waiting for a push.
+    func currentMenuData() -> [String: Any]
     func openSettings()
     func quitApp()
     func controlAccessory(id: String, characteristic: String, value: String)

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -281,6 +281,7 @@ final class HomeKitManager: NSObject, Observable {
     private let cache = CharacteristicCache.shared
     private var isWarmingCache = false
     private var menuPushTask: Task<Void, Never>?
+    private var hydrationRetryTask: Task<Void, Never>?
 
     private(set) var homes: [HMHome] = []
 
@@ -2978,6 +2979,26 @@ final class HomeKitManager: NSObject, Observable {
         }
     }
 
+    /// Safety net for late accessory hydration. `HMHomeManager` reports homes (and
+    /// their action sets) before `home.accessories` fully populates, and it does not
+    /// always re-fire `homeManagerDidUpdateHomes` once they do — leaving the menu
+    /// showing scenes but no devices. When we become ready with zero accessories,
+    /// re-check and re-push a few times so the menu fills in on its own. No-ops (and
+    /// stops) as soon as accessories appear, so a genuinely empty home costs nothing.
+    private func scheduleAccessoryHydrationRetry() {
+        hydrationRetryTask?.cancel()
+        hydrationRetryTask = Task { @MainActor in
+            for delaySeconds in [2, 4, 8] {
+                try? await Task.sleep(for: .seconds(delaySeconds))
+                if Task.isCancelled { return }
+                guard totalAccessoryCount == 0 else { return }  // hydrated — done
+                AppLogger.homekit.info("Accessory hydration retry: still 0 accessories, re-warming + re-pushing menu")
+                await warmCache()
+                scheduleMenuDataPush()
+            }
+        }
+    }
+
     // MARK: - Cache
 
     /// Warms the cache by reading interesting values from all filtered accessories.
@@ -3260,6 +3281,12 @@ extension HomeKitManager: HMHomeManagerDelegate {
                 userInfo: ["ready": self.homesReady, "homeNames": homeNames]
             )
             scheduleMenuDataPush()
+
+            // If homes are present but accessories haven't hydrated yet, keep
+            // re-checking so the menu fills in without needing a restart.
+            if self.totalAccessoryCount == 0 {
+                scheduleAccessoryHydrationRetry()
+            }
         }
     }
 }

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -2983,18 +2983,21 @@ final class HomeKitManager: NSObject, Observable {
     /// their action sets) before `home.accessories` fully populates, and it does not
     /// always re-fire `homeManagerDidUpdateHomes` once they do — leaving the menu
     /// showing scenes but no devices. When we become ready with zero accessories,
-    /// re-check and re-push a few times so the menu fills in on its own. No-ops (and
-    /// stops) as soon as accessories appear, so a genuinely empty home costs nothing.
+    /// re-warm and re-push a few times so the menu fills in on its own, then stop
+    /// once accessories appear. The push happens BEFORE the hydrated check so the
+    /// tick that observes hydration also refreshes the menu — otherwise the menu
+    /// would stay on the empty snapshot until some other refresh path ran. A
+    /// genuinely empty home just pushes the same empty snapshot a few times and stops.
     private func scheduleAccessoryHydrationRetry() {
         hydrationRetryTask?.cancel()
         hydrationRetryTask = Task { @MainActor in
             for delaySeconds in [2, 4, 8] {
                 try? await Task.sleep(for: .seconds(delaySeconds))
                 if Task.isCancelled { return }
-                guard totalAccessoryCount == 0 else { return }  // hydrated — done
-                AppLogger.homekit.info("Accessory hydration retry: still 0 accessories, re-warming + re-pushing menu")
+                AppLogger.homekit.info("Accessory hydration retry: re-warming + re-pushing menu (\(self.totalAccessoryCount) accessory(ies))")
                 await warmCache()
                 scheduleMenuDataPush()
+                if totalAccessoryCount > 0 { return }  // hydrated and pushed — done
             }
         }
     }
@@ -3283,8 +3286,10 @@ extension HomeKitManager: HMHomeManagerDelegate {
             scheduleMenuDataPush()
 
             // If homes are present but accessories haven't hydrated yet, keep
-            // re-checking so the menu fills in without needing a restart.
-            if self.totalAccessoryCount == 0 {
+            // re-checking so the menu fills in without needing a restart. Guard on
+            // !homes.isEmpty so an early "no homes yet" callback doesn't spin the
+            // retry for 14s against an empty cache.
+            if !self.homes.isEmpty && self.totalAccessoryCount == 0 {
                 scheduleAccessoryHydrationRetry()
             }
         }

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -12,6 +12,15 @@ final class SocketServer: @unchecked Sendable {
     private var acceptSource: DispatchSourceRead?
     private let queue = DispatchQueue(label: "com.shahine.homeclaw.socket", qos: .userInitiated)
 
+    /// Watchdog: a wedged or torn-down listener (App Nap, an unexpected dispatch
+    /// source cancel, an orphaned socket file) leaves the app alive but the socket
+    /// refusing connections. A periodic self-connect probe detects this and rebinds.
+    private let watchdogQueue = DispatchQueue(label: "com.shahine.homeclaw.socket.watchdog", qos: .utility)
+    private var watchdogTimer: DispatchSourceTimer?
+    /// Set by `stop()` so the watchdog doesn't fight an intentional shutdown.
+    private var intentionallyStopped = false
+    private let watchdogInterval: TimeInterval = 30
+
     /// Parse a boolean wire arg, distinguishing absent from present-but-unparseable.
     ///
     /// Accepts:
@@ -207,8 +216,18 @@ final class SocketServer: @unchecked Sendable {
         return result
     }
 
-    /// Start the socket server synchronously (non-blocking — sets up GCD dispatch sources).
+    /// Start the socket server synchronously (non-blocking — sets up GCD dispatch sources)
+    /// and arm the watchdog that keeps it alive.
     func start() {
+        intentionallyStopped = false
+        bringUpListener()
+        startWatchdog()
+    }
+
+    /// Bind, listen, and arm the accept dispatch source. Idempotent: unlinks any
+    /// stale socket file first, so it is safe to call repeatedly (e.g. from the
+    /// watchdog after a wedge).
+    private func bringUpListener() {
         let path = AppConfig.socketPath
 
         // Remove stale socket
@@ -265,11 +284,12 @@ final class SocketServer: @unchecked Sendable {
         source.setEventHandler { [weak self] in
             self?.acceptConnection()
         }
-        source.setCancelHandler { [weak self] in
-            if let fd = self?.serverFD, fd >= 0 {
-                close(fd)
-            }
-            unlink(AppConfig.socketPath)
+        // Close the listening fd on cancel. We deliberately do NOT unlink the path
+        // here: `bringUpListener` already unlinks-before-bind, so unlinking on cancel
+        // would race a concurrent restart and delete the freshly-bound socket file.
+        let cancelFD = serverFD
+        source.setCancelHandler {
+            if cancelFD >= 0 { close(cancelFD) }
         }
         source.resume()
         acceptSource = source
@@ -278,9 +298,61 @@ final class SocketServer: @unchecked Sendable {
     }
 
     func stop() {
+        intentionallyStopped = true
+        watchdogTimer?.cancel()
+        watchdogTimer = nil
         acceptSource?.cancel()
         acceptSource = nil
         serverFD = -1
+        unlink(AppConfig.socketPath)
+    }
+
+    // MARK: - Watchdog
+
+    private func startWatchdog() {
+        watchdogTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: watchdogQueue)
+        timer.schedule(deadline: .now() + watchdogInterval, repeating: watchdogInterval)
+        timer.setEventHandler { [weak self] in self?.checkListenerHealth() }
+        timer.resume()
+        watchdogTimer = timer
+    }
+
+    /// Probe the socket with a real connect(). A live listener accepts it (and our
+    /// empty request is discarded cleanly); a wedged/absent listener fails, which
+    /// triggers a rebind. Runs on the watchdog queue, independent of the accept queue.
+    private func checkListenerHealth() {
+        guard !intentionallyStopped else { return }
+        guard !canConnectToSocket() else { return }
+        AppLogger.socket.error("Socket listener unhealthy (connect failed) — rebinding")
+        queue.async { [weak self] in
+            guard let self, !self.intentionallyStopped else { return }
+            self.acceptSource?.cancel()
+            self.acceptSource = nil
+            self.serverFD = -1
+            self.bringUpListener()
+        }
+    }
+
+    private func canConnectToSocket() -> Bool {
+        let path = AppConfig.socketPath
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            path.withCString { cstr in
+                _ = memcpy(ptr, cstr, min(path.utf8.count, MemoryLayout.size(ofValue: ptr.pointee) - 1))
+            }
+        }
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        return result == 0
     }
 
     // MARK: - Connection Handling

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -257,6 +257,7 @@ final class SocketServer: @unchecked Sendable {
         guard bindResult == 0 else {
             AppLogger.socket.error("Failed to bind socket (errno: \(errno))")
             close(serverFD)
+            serverFD = -1
             return
         }
 
@@ -264,6 +265,7 @@ final class SocketServer: @unchecked Sendable {
         guard listen(serverFD, 16) == 0 else {
             AppLogger.socket.error("Failed to listen on socket (errno: \(errno))")
             close(serverFD)
+            serverFD = -1
             return
         }
 

--- a/Sources/macOSBridge/MacOSController.swift
+++ b/Sources/macOSBridge/MacOSController.swift
@@ -81,6 +81,13 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
 
     public func menuWillOpen(_ menu: NSMenu) {
         menuIsOpen = true
+        // Pull the freshest snapshot synchronously so the menu that's about to show
+        // reflects current HomeKit state — heals a stale/empty menu (e.g. after the
+        // app was App-Napped or a push was missed) without waiting for a restart.
+        if let fresh = iOSBridge?.currentMenuData(), fresh["ready"] as? Bool == true {
+            menuData = fresh
+            rebuildMenu()
+        }
         iOSBridge?.refreshData()
     }
 
@@ -284,6 +291,28 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
                 addSceneItem(scene, to: menu)
             }
         }
+
+        // Empty-state affordance: HomeKit is ready but no accessory produced a row
+        // (e.g. accessories hadn't hydrated when this snapshot was built). Offer an
+        // explicit refresh instead of silently showing only scenes.
+        let anyAccessoryShown = rooms.contains { room in
+            (room["accessories"] as? [[String: Any]] ?? []).contains(where: { isAccessoryVisible($0) })
+        }
+        if !anyAccessoryShown {
+            menu.addItem(.separator())
+            let item = NSMenuItem(
+                title: "No accessories loaded \u{2014} Refresh",
+                action: #selector(refreshTapped),
+                keyEquivalent: "")
+            item.target = self
+            item.image = NSImage(
+                systemSymbolName: "arrow.clockwise", accessibilityDescription: "Refresh")
+            menu.addItem(item)
+        }
+    }
+
+    @objc private func refreshTapped() {
+        iOSBridge?.refreshData()
     }
 
     private func addSceneItem(_ scene: [String: Any], to menu: NSMenu) {

--- a/Sources/macOSBridge/MacOSController.swift
+++ b/Sources/macOSBridge/MacOSController.swift
@@ -299,7 +299,11 @@ public class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
             (room["accessories"] as? [[String: Any]] ?? []).contains(where: { isAccessoryVisible($0) })
         }
         if !anyAccessoryShown {
-            menu.addItem(.separator())
+            // Avoid a double rule: the scenes section may already have added a trailing
+            // separator (this is the exact late-hydration case — scenes present, no rooms).
+            if !(menu.items.last?.isSeparatorItem ?? false) {
+                menu.addItem(.separator())
+            }
             let item = NSMenuItem(
                 title: "No accessories loaded \u{2014} Refresh",
                 action: #selector(refreshTapped),


### PR DESCRIPTION
## Problem

On a headless Mac (a remote/SSH host like `lobster`), the menu bar showed only scenes — **0 of 110 accessories** — and the CLI reported `HomeClaw is not running` even though the app process was alive. A manual restart fixed it.

Root cause: **App Nap.** HomeClaw is an `LSUIElement` background agent (`Resources/Info.plist`). With no display/UI activity, macOS aggressively App-Naps the process, which:
- suspends the socket accept loop (`SocketServer.acceptConnection`) → the control socket refuses connections (the "not running" CLI error), and
- stalls the debounced menu-data push (`scheduleMenuDataPush`).

Compounding it, `HMHomeManager` reports homes + their `actionSets` (scenes) **before** `home.accessories` hydrate, and doesn't always re-fire `homeManagerDidUpdateHomes` once they do — so the menu froze at "scenes only."

> The `accessoryFilterMode:"allowlist"` config on the affected machine was a **red herring** — `filterAccessories()` returns all accessories when the allowlist is empty, which is why the CLI showed all 110.

## Fix

**Prevention**
- **#1 App Nap opt-out** — hold `ProcessInfo.beginActivity(.userInitiatedAllowingIdleSystemSleep)` for the app's lifetime (`HomeClawApp`) + `NSAppSleepDisabled` in Info.plist. System idle sleep still works; only our process is exempt from napping while the Mac is awake.
- **#2 Socket watchdog** — a 30s self-`connect()` probe (`SocketServer`) rebinds a dead listener. `start()` split into `bringUpListener()`; the accept source's cancel handler **no longer unlinks** the socket path (it raced a concurrent rebind and could delete a freshly-bound socket); `stop()` halts the watchdog and unlinks.

**Self-repair**
- **#3 Pull-on-open** — new `Mac2iOS.currentMenuData()` lets `menuWillOpen` rebuild from a fresh in-memory snapshot synchronously, so a stale/empty menu heals on the next click.
- **#4 Late-hydration safety net + empty state** — `HomeKitManager` re-checks/re-pushes the menu at 2/4/8s when it becomes ready with 0 accessories, and the menu now shows an explicit **"No accessories loaded — Refresh"** row instead of silently showing scenes only.

## Testing

- ✅ Mac Catalyst build **SUCCEEDED** (`xcodebuild -scheme HomeClaw -destination 'platform=macOS,variant=Mac Catalyst'`), no new warnings.
- ⚠️ Not yet runtime-verified on `lobster` — that needs a dev-signed install + HomeKit TCC re-grant. The fixes are grounded in the observed failure modes (wedged socket + un-refreshed partial snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)