### PR TITLE
refactor: use non-deprecated HMSignificantTimeEvent trigger predicates

### DIFF
--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -3,18 +3,14 @@ import HomeKit
 // MARK: - Time Condition
 
 /// A before/after sun-relative time predicate for automation triggers.
-/// Composes via `HMEventTrigger.predicateForEvaluatingTrigger(occurringBefore/After:applyingOffset:)`.
+/// Composes via `HMEventTrigger.predicateForEvaluatingTrigger(occurringBefore/After:)` with an
+/// `HMSignificantTimeEvent` carrying the optional offset.
 ///
 /// Format: `<sun-event>[±<minutes>]` where sun-event is `sunrise` or `sunset` and the offset
 /// is signed minutes (e.g. `sunset-30`, `sunrise+15`, `sunset`).
 struct TimeCondition {
     enum Relation { case after, before }
-    enum Event {
-        case sunrise, sunset
-        var significantEvent: String {
-            self == .sunrise ? HMSignificantEvent.sunrise.rawValue : HMSignificantEvent.sunset.rawValue
-        }
-    }
+    enum Event { case sunrise, sunset }
 
     let relation: Relation
     let event: Event
@@ -32,21 +28,16 @@ struct TimeCondition {
             dc.minute = offsetMinutes
             offset = dc
         }
-        // The string-form predicate APIs are marked deprecated in Catalyst 13.1+, but the
-        // replacement (HMSignificantTimeEvent-taking variant) is not exposed to Swift —
-        // only the DateComponents and HMPresenceEvent overloads bridge. Mirror the existing
-        // weekday predicate construction (`occurringOn:`) which is in the same boat.
+        // The non-deprecated predicate APIs take an HMSignificantTimeEvent (which carries
+        // the offset) rather than a significant-event string + separate offset. Both are
+        // available on macCatalyst 14.0+.
+        let sigEvent = event == .sunrise ? HMSignificantEvent.sunrise : HMSignificantEvent.sunset
+        let significantEvent = HMSignificantTimeEvent(significantEvent: sigEvent, offset: offset)
         switch relation {
         case .after:
-            return HMEventTrigger.predicateForEvaluatingTrigger(
-                occurringAfter: event.significantEvent,
-                applyingOffset: offset
-            )
+            return HMEventTrigger.predicateForEvaluatingTriggerOccurring(afterSignificantEvent: significantEvent)
         case .before:
-            return HMEventTrigger.predicateForEvaluatingTrigger(
-                occurringBefore: event.significantEvent,
-                applyingOffset: offset
-            )
+            return HMEventTrigger.predicateForEvaluatingTriggerOccurring(beforeSignificantEvent: significantEvent)
         }
     }
 


### PR DESCRIPTION
## What

`TimeCondition.predicate()` built sun-relative automation predicates with `predicateForEvaluatingTrigger(occurringAfter:applyingOffset:)` / `(occurringBefore:applyingOffset:)` — the significant-event **string + offset** overloads, deprecated in Mac Catalyst 13.1. These emitted 4 deprecation warnings on every build.

A comment in the code claimed the replacement "is not exposed to Swift." That was wrong — the SDK header and apinotes confirm `predicateForEvaluatingTriggerOccurring(afterSignificantEvent:)` / `(beforeSignificantEvent:)` are available on `macCatalyst(14.0)`. They take an `HMSignificantTimeEvent` that carries the offset, instead of a string + separate `applyingOffset`.

## Change

- Construct an `HMSignificantTimeEvent` (same pattern as `TimeSpec.makeEvent()` already uses) and call the non-deprecated predicate factories.
- Remove the now-unused `Event.significantEvent` string property and the stale comment.

No behavior change — same predicate semantics, just the current API. Clears all 4 deprecation warnings.

## Testing

- ✅ Mac Catalyst build **SUCCEEDED**, and the `predicateForEvaluatingTrigger` deprecation warnings no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)