### PR TITLE
Fix #66: hard timeout on HomeKit reads + `get --no-refresh`

### DIFF
--- a/Sources/homeclaw-cli/Commands/GetCommand.swift
+++ b/Sources/homeclaw-cli/Commands/GetCommand.swift
@@ -12,9 +12,14 @@ struct Get: ParsableCommand {
     @Flag(name: .long, help: "Output raw JSON")
     var json = false
 
+    @Flag(name: .long, help: "Skip live characteristic reads; return last-known + static values only (fast — ideal for serial number / model / firmware sweeps)")
+    var noRefresh = false
+
     func run() throws {
         if let err = validateInput(accessory, label: "accessory") { throw ValidationError(err) }
-        let response = try SocketClient.send(command: "get_accessory", args: ["id": accessory])
+        var args: [String: String] = ["id": accessory]
+        if noRefresh { args["refresh"] = "false" }
+        let response = try SocketClient.send(command: "get_accessory", args: args)
 
         guard response.success else {
             throw ValidationError(response.error ?? "Unknown error")

--- a/Sources/homeclaw-cli/Commands/GetCommand.swift
+++ b/Sources/homeclaw-cli/Commands/GetCommand.swift
@@ -44,6 +44,9 @@ struct Get: ParsableCommand {
         print("  Category:  \(category)")
         print("  Room:      \(room)")
         print("  Reachable: \(reachable)")
+        if detail["refreshed"] as? Bool == false {
+            print("  Note:      --no-refresh — static + last-known values only (dynamic state not live-read)")
+        }
 
         if let services = detail["services"] as? [[String: Any]] {
             for service in services {

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -3141,18 +3141,23 @@ final class HomeKitManager: NSObject, Observable {
         // first resumes the continuation; the loser is a no-op.
         let guardBox = ReadResumeGuard()
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            // Cancellable timer leg: when HomeKit responds before the deadline we
+            // cancel it, so a large readAllValues loop (50–100+ characteristics)
+            // doesn't leave a burst of no-op main-thread wakeups draining 6s later.
+            let timerWork = DispatchWorkItem {
+                guard guardBox.claim() else { return }
+                logger.warning("readValue timed out after \(timeout, format: .fixed(precision: 0))s; serving last-known value")
+                continuation.resume()
+            }
             characteristic.readValue { error in
+                timerWork.cancel()
                 guard guardBox.claim() else { return }
                 if let error {
                     logger.debug("readValue failed: \(error.localizedDescription, privacy: .public)")
                 }
                 continuation.resume()
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
-                guard guardBox.claim() else { return }
-                logger.warning("readValue timed out after \(timeout, format: .fixed(precision: 0))s; serving last-known value")
-                continuation.resume()
-            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: timerWork)
         }
     }
 

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -1,4 +1,5 @@
 import HomeKit
+import os
 
 // MARK: - Time Condition
 
@@ -257,6 +258,22 @@ fileprivate struct ResolvedCondition {
     let rawValue: String
 }
 
+/// One-shot resume guard for `HomeKitManager.readValueWithTimeout`. The HomeKit
+/// completion handler and the timeout timer race to resume the continuation; only
+/// the first `claim()` returns true, so the continuation resumes exactly once.
+/// `@unchecked Sendable` is sound because all mutable state is guarded by the lock.
+fileprivate final class ReadResumeGuard: @unchecked Sendable {
+    private let lock = NSLock()
+    private var claimed = false
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if claimed { return false }
+        claimed = true
+        return true
+    }
+}
+
 /// Central HomeKit interface. Must run on @MainActor because HMHomeManager
 /// requires main-thread delegate callbacks.
 @MainActor
@@ -427,13 +444,21 @@ final class HomeKitManager: NSObject, Observable {
         return result
     }
 
-    func getAccessory(id: String, homeID: String? = nil) async -> [String: Any]? {
+    /// - Parameter refresh: when `true` (default) live-reads dynamic
+    ///   characteristics before serializing. Pass `false` to skip all live reads
+    ///   and return last-known + static values only. Static metadata (serial
+    ///   number, model, firmware, manufacturer) never needs a live read, so a
+    ///   non-refreshing get is instant — the right choice for whole-home metadata
+    ///   sweeps that otherwise trigger the per-call ballooning in issue #66.
+    func getAccessory(id: String, homeID: String? = nil, refresh: Bool = true) async -> [String: Any]? {
         await waitForReady()
         if Self.isDemoMode { return DemoFixtures.accessoryDetail(id: id) }
         guard let accessory = findAccessory(id: id, homeID: homeID) else { return nil }
         guard isAccessoryAllowed(accessory) else { return nil }
-        await readAllValues(for: accessory)
-        updateCacheFromAccessory(accessory)
+        if refresh {
+            await readAllValues(for: accessory)
+            updateCacheFromAccessory(accessory)
+        }
         return AccessoryModel.accessoryDetail(accessory)
     }
 
@@ -3008,7 +3033,7 @@ final class HomeKitManager: NSObject, Observable {
                 for characteristic in service.characteristics {
                     let name = CharacteristicMapper.name(for: characteristic.characteristicType)
                     if AccessoryModel.isInterestingState(name) {
-                        try? await characteristic.readValue()
+                        await readValueWithTimeout(characteristic)
                         state[name] = CharacteristicMapper.formatValue(
                             characteristic.value, for: characteristic.characteristicType
                         )
@@ -3076,7 +3101,7 @@ final class HomeKitManager: NSObject, Observable {
             for characteristic in service.characteristics {
                 let name = CharacteristicMapper.name(for: characteristic.characteristicType)
                 if AccessoryModel.isInterestingState(name) {
-                    try? await characteristic.readValue()
+                    await readValueWithTimeout(characteristic)
                 }
             }
         }
@@ -3089,8 +3114,44 @@ final class HomeKitManager: NSObject, Observable {
         for service in accessory.services {
             for characteristic in service.characteristics {
                 if characteristic.properties.contains(HMCharacteristicPropertyReadable) {
-                    try? await characteristic.readValue()
+                    await readValueWithTimeout(characteristic)
                 }
+            }
+        }
+    }
+
+    /// Hard ceiling for a single HomeKit characteristic read.
+    private static let readTimeout: TimeInterval = 6
+
+    /// Best-effort refresh of `characteristic.value` with a hard timeout.
+    ///
+    /// HomeKit's `readValue` can leave its completion handler pending
+    /// indefinitely under load (large bridges, many accessories — issue #66).
+    /// The async `readValue()` is an auto-imported completion-handler API and
+    /// does NOT honor Swift task cancellation, so a structured timeout can't
+    /// unblock it — we must use the completion form and race it against a timer.
+    /// Because the socket dispatcher serializes on the main actor, one stuck
+    /// read otherwise stalls every later request: the "first call fast, later
+    /// calls balloon to ~95s / hang" signature in the bug report. A timed-out
+    /// read simply leaves the previously cached `characteristic.value` in place.
+    private func readValueWithTimeout(_ characteristic: HMCharacteristic) async {
+        let timeout = Self.readTimeout
+        let logger = AppLogger.homekit
+        // One-shot guard: whichever of the HomeKit completion or the timer fires
+        // first resumes the continuation; the loser is a no-op.
+        let guardBox = ReadResumeGuard()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            characteristic.readValue { error in
+                guard guardBox.claim() else { return }
+                if let error {
+                    logger.debug("readValue failed: \(error.localizedDescription, privacy: .public)")
+                }
+                continuation.resume()
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+                guard guardBox.claim() else { return }
+                logger.warning("readValue timed out after \(timeout, format: .fixed(precision: 0))s; serving last-known value")
+                continuation.resume()
             }
         }
     }

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -459,7 +459,17 @@ final class HomeKitManager: NSObject, Observable {
             await readAllValues(for: accessory)
             updateCacheFromAccessory(accessory)
         }
-        return AccessoryModel.accessoryDetail(accessory)
+        var detail = AccessoryModel.accessoryDetail(accessory)
+        if !refresh {
+            // Signal that dynamic characteristic values were NOT live-read this
+            // call. Without a refresh, never-read characteristics serialize as
+            // null/last-known, so callers must not mistake a stale/unread value
+            // for a fresh one. Static metadata (serial/model/firmware) is always
+            // accurate. Only emitted on the opt-in path, so default output is
+            // unchanged.
+            detail["refreshed"] = false
+        }
+        return detail
     }
 
     // MARK: - Control

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -425,7 +425,11 @@ final class SocketServer: @unchecked Sendable {
                 guard let id = args["id"] as? String else {
                     return encodeResponse(success: false, error: "Missing 'id' argument")
                 }
-                guard let accessory = await hk.getAccessory(id: id, homeID: args["home_id"] as? String) else {
+                // `refresh: false` skips live characteristic reads — instant, and
+                // all that's needed for serial-number / model / firmware sweeps.
+                // Defaults to true to preserve prior behavior.
+                let refresh = parseBool(args, key: "refresh", default: true)
+                guard let accessory = await hk.getAccessory(id: id, homeID: args["home_id"] as? String, refresh: refresh) else {
                     return encodeResponse(success: false, error: "Accessory not found: \(id)")
                 }
                 result = accessory

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -23,6 +23,8 @@ export async function handleAccessories(args) {
       if (!args.accessory_id) throw new Error('accessory_id is required for get action');
       const socketArgs = { id: args.accessory_id };
       if (args.home_id) socketArgs.home_id = args.home_id;
+      // Skip live characteristic reads when only static metadata is needed.
+      if (args.no_refresh) socketArgs.refresh = false;
       return sendCommand('get_accessory', socketArgs);
     }
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -55,6 +55,10 @@ export const tools = [
           type: 'string',
           description: 'Service UUID to target when the characteristic exists on multiple services (control action). Required when an ambiguity error is returned.',
         },
+        no_refresh: {
+          type: 'boolean',
+          description: 'Skip live characteristic reads and return last-known + static values only (get action). Much faster and avoids per-call slowdowns when reading many accessories in sequence; safe for static metadata like serial number, model, and firmware.',
+        },
       },
     },
   },

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -20866,6 +20866,10 @@ var tools = [
         service_type: {
           type: "string",
           description: "Service UUID to target when the characteristic exists on multiple services (control action). Required when an ambiguity error is returned."
+        },
+        no_refresh: {
+          type: "boolean",
+          description: "Skip live characteristic reads and return last-known + static values only (get action). Much faster and avoids per-call slowdowns when reading many accessories in sequence; safe for static metadata like serial number, model, and firmware."
         }
       }
     }
@@ -21256,6 +21260,7 @@ async function handleAccessories(args) {
       if (!args.accessory_id) throw new Error("accessory_id is required for get action");
       const socketArgs = { id: args.accessory_id };
       if (args.home_id) socketArgs.home_id = args.home_id;
+      if (args.no_refresh) socketArgs.refresh = false;
       return sendCommand("get_accessory", socketArgs);
     }
     case "search": {


### PR DESCRIPTION
## Problem

`homeclaw-cli get <uuid>` is fast in isolation but per-call time balloons under sequential load (first call ~2s, third ~95s, parallel calls hang). Fixes #66.

## Root cause

`getAccessory` -> `readAllValues` did serial `try? await characteristic.readValue()` per characteristic with **no timeout**. The async `readValue()` is an auto-imported completion-handler API that does **not** honor Swift task cancellation, so a stuck HomeKit read leaves its continuation suspended forever. Because the socket dispatcher serializes on `@MainActor`, one hung read stalls every later request -> the ballooning signature. Same unsignaled-wait class as #65.

## Fix

**1. Hard read timeout (core).** New `readValueWithTimeout(_:)` uses the completion-handler form of `readValue` raced against a 6s `DispatchQueue.main.asyncAfter` timer, with a one-shot `NSLock`-backed `ReadResumeGuard` so the continuation always resumes exactly once. Applied to all three read loops (`readAllValues`, `readInterestingValues`, `warmCache`). Lives in shared `HomeKitManager`, so every client (CLI, MCP, socket, app UI) benefits — bounds worst case from infinite/95s to 6s per read.

**2. `--no-refresh` fast path (reporter's request).** `getAccessory(refresh:)` — `refresh: false` skips all live reads and returns static + last-known values only. Serial number / model / firmware are static Accessory-Information characteristics already present without a live read, so whole-home metadata sweeps are now instant. Wired through:
- socket `get_accessory` (`refresh` arg)
- CLI `homeclaw-cli get <id> --no-refresh`
- MCP `homekit_accessories` action=get (`no_refresh`), with regenerated `mcp-server/dist` bundle

## Verification

- Catalyst app build: PASS (Swift 6 strict concurrency, no warnings)
- SPM CLI build: PASS
- MCP bundle rebuilt via esbuild; `node --check` on sources: PASS
- Smoke-tested against the live app: plain `get` and `get --no-refresh` both exit 0 and return valid JSON (wire-compatible; defaults preserve prior behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
