### PR TITLE
chore: release HomeClaw plugin 1.0.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,16 @@
       "name": "homeclaw",
       "source": "./",
       "description": "HomeKit smart home control via MCP - control lights, locks, thermostats, and scenes",
-      "version": "1.0.3",
-      "keywords": ["homekit", "smart-home", "lights", "locks", "thermostats", "scenes", "automation"],
+      "version": "1.0.4",
+      "keywords": [
+        "homekit",
+        "smart-home",
+        "lights",
+        "locks",
+        "thermostats",
+        "scenes",
+        "automation"
+      ],
       "category": "iot"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,17 +1,27 @@
 {
   "name": "homeclaw",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "HomeKit smart home control via MCP - control lights, locks, thermostats, and scenes",
   "author": {
     "name": "Omar Shahine"
   },
   "license": "MIT",
-  "keywords": ["homekit", "smart-home", "lights", "locks", "thermostats", "scenes", "automation"],
+  "keywords": [
+    "homekit",
+    "smart-home",
+    "lights",
+    "locks",
+    "thermostats",
+    "scenes",
+    "automation"
+  ],
   "mcpServers": {
     "homekit": {
       "type": "stdio",
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/dist/server.js"]
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/mcp-server/dist/server.js"
+      ]
     }
   }
 }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@homeclaw/mcp-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "MCP server for HomeClaw",
   "type": "module",

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "homeclaw",
   "name": "HomeClaw",
   "description": "HomeKit smart home control and monitoring",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeclaw",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "OpenClaw plugin for HomeKit smart home control — lights, locks, thermostats, and scenes",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homeclaw",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homeclaw",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "workspaces": [
         "openclaw",
         "mcp-server"
@@ -17,7 +17,7 @@
     },
     "mcp-server": {
       "name": "@homeclaw/mcp-server",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       }
@@ -5137,7 +5137,7 @@
     },
     "openclaw": {
       "name": "homeclaw",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homeclaw",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "HomeClaw — MCP server and CLI for HomeKit smart home control",
   "type": "module",


### PR DESCRIPTION
Version bump for the OpenClaw SDK refresh. Version consistency was checked locally before pushing.