### PR TITLE
Expose HomeKit bridge metadata

### DIFF
--- a/Sources/homeclaw-cli/Commands/DeviceMapCommand.swift
+++ b/Sources/homeclaw-cli/Commands/DeviceMapCommand.swift
@@ -94,8 +94,9 @@ struct DeviceMapCmd: ParsableCommand {
                         let summary = dev["state_summary"] as? String ?? ""
                         let reachable = dev["reachable"] as? Bool ?? false
                         let prefix = reachable ? "+" : "-"
+                        let bridgeStr = bridgeDisplayName(in: dev).map { " via \($0)" } ?? ""
                         let stateStr = summary.isEmpty || summary == "unknown" ? "" : " — \(summary)"
-                        lines.append("      \(prefix) \(nameStr) [\(semType)]\(stateStr)")
+                        lines.append("      \(prefix) \(nameStr) [\(semType)]\(bridgeStr)\(stateStr)")
                     }
                 }
             }
@@ -146,6 +147,9 @@ struct DeviceMapCmd: ParsableCommand {
                         ]
                         if let reachable = dev["reachable"] as? Bool, !reachable {
                             entry["unreachable"] = true
+                        }
+                        if let bridge = bridgeDisplayName(in: dev) {
+                            entry["bridge"] = bridge
                         }
                         // Include home/zone only when there are multiple homes
                         if homes.count > 1 {
@@ -227,8 +231,8 @@ struct DeviceMapCmd: ParsableCommand {
                     let devices = room["devices"] as? [[String: Any]] ?? []
                     md.append("#### \(roomName)")
                     md.append("")
-                    md.append("| Device | ID | Type | State | Controls |")
-                    md.append("|--------|----|------|-------|----------|")
+                    md.append("| Device | ID | Type | Bridge | State | Controls |")
+                    md.append("|--------|----|------|--------|-------|----------|")
 
                     for dev in devices {
                         let name = dev["display_name"] as? String ?? dev["name"] as? String ?? "?"
@@ -241,8 +245,9 @@ struct DeviceMapCmd: ParsableCommand {
                             .filter { $0 != "identify" }
                             .joined(separator: ", ")
 
+                        let bridge = bridgeDisplayName(in: dev) ?? ""
                         let stateStr = reachable ? state : "**unreachable**"
-                        md.append("| \(name) | `\(shortID)` | \(semType) | \(stateStr) | \(controls) |")
+                        md.append("| \(name) | `\(shortID)` | \(semType) | \(bridge) | \(stateStr) | \(controls) |")
                     }
                     md.append("")
                 }

--- a/Sources/homeclaw-cli/Commands/GetCommand.swift
+++ b/Sources/homeclaw-cli/Commands/GetCommand.swift
@@ -44,6 +44,12 @@ struct Get: ParsableCommand {
         print("  Category:  \(category)")
         print("  Room:      \(room)")
         print("  Reachable: \(reachable)")
+        if let bridge = bridgeDisplayName(in: detail) {
+            print("  Bridge:    \(bridge)")
+        }
+        if let bridgedAccessoryCount = detail["bridged_accessory_count"] as? Int {
+            print("  Bridged:   \(bridgedAccessoryCount) accessory(ies)")
+        }
         if detail["refreshed"] as? Bool == false {
             print("  Note:      --no-refresh — static + last-known values only (dynamic state not live-read)")
         }

--- a/Sources/homeclaw-cli/Commands/JSONHelper.swift
+++ b/Sources/homeclaw-cli/Commands/JSONHelper.swift
@@ -52,3 +52,11 @@ func printJSON(_ value: Any?) {
     // Fallback
     print("\(value)")
 }
+
+/// Returns a stable display name for an accessory's bridge metadata.
+func bridgeDisplayName(in dict: [String: Any]) -> String? {
+    guard let bridge = dict["bridge"] as? [String: Any] else {
+        return nil
+    }
+    return bridge["name"] as? String ?? bridge["id"] as? String
+}

--- a/Sources/homeclaw-cli/Commands/ListCommand.swift
+++ b/Sources/homeclaw-cli/Commands/ListCommand.swift
@@ -74,8 +74,9 @@ struct List: ParsableCommand {
             if let state = accessory["state"] as? [String: String] {
                 stateStr = state.map { "\($0.key)=\($0.value)" }.joined(separator: ", ")
             }
+            let bridgeStr = bridgeDisplayName(in: accessory).map { " via \($0)" } ?? ""
 
-            print("\(reachable) \(name) [\(category)] in \(room)\(stateStr.isEmpty ? "" : " — \(stateStr)")")
+            print("\(reachable) \(name) [\(category)] in \(room)\(bridgeStr)\(stateStr.isEmpty ? "" : " — \(stateStr)")")
         }
     }
 }

--- a/Sources/homeclaw-cli/Commands/SearchCommand.swift
+++ b/Sources/homeclaw-cli/Commands/SearchCommand.swift
@@ -46,7 +46,8 @@ struct Search: ParsableCommand {
             let name = accessory["name"] as? String ?? "Unknown"
             let category = accessory["category"] as? String ?? "unknown"
             let room = accessory["room"] as? String ?? "No Room"
-            print("  \(name) [\(category)] in \(room)")
+            let bridgeStr = bridgeDisplayName(in: accessory).map { " via \($0)" } ?? ""
+            print("  \(name) [\(category)] in \(room)\(bridgeStr)")
         }
     }
 }

--- a/Sources/homeclaw/HomeKit/AccessoryModel.swift
+++ b/Sources/homeclaw/HomeKit/AccessoryModel.swift
@@ -45,7 +45,9 @@ enum AccessoryModel {
         cachedState: [String: String]? = nil,
         zone: String? = nil,
         displayName: String? = nil,
-        semanticType: String? = nil
+        semanticType: String? = nil,
+        bridge: [String: Any]? = nil,
+        bridgedAccessoryIDs: [String] = []
     ) -> [String: Any] {
         var dict: [String: Any] = [
             "id": accessory.uniqueIdentifier.uuidString,
@@ -68,6 +70,7 @@ enum AccessoryModel {
         if let displayName, displayName != accessory.name { dict["display_name"] = displayName }
         if let semanticType { dict["semantic_type"] = semanticType }
         if let manufacturer = accessory.manufacturer { dict["manufacturer"] = manufacturer }
+        addBridgeMetadata(to: &dict, bridge: bridge, bridgedAccessoryIDs: bridgedAccessoryIDs)
 
         // Use cached state if provided, otherwise read from characteristic objects
         let state: [String: String]
@@ -95,7 +98,11 @@ enum AccessoryModel {
     }
 
     /// Full detail of an accessory (for get views).
-    static func accessoryDetail(_ accessory: HMAccessory) -> [String: Any] {
+    static func accessoryDetail(
+        _ accessory: HMAccessory,
+        bridge: [String: Any]? = nil,
+        bridgedAccessoryIDs: [String] = []
+    ) -> [String: Any] {
         var dict: [String: Any] = [
             "id": accessory.uniqueIdentifier.uuidString,
             "name": accessory.name,
@@ -110,6 +117,12 @@ enum AccessoryModel {
         if let manufacturer = accessory.manufacturer { dict["manufacturer"] = manufacturer }
         if let model = accessory.model { dict["model"] = model }
         if let firmware = accessory.firmwareVersion { dict["firmware"] = firmware }
+        addBridgeMetadata(
+            to: &dict,
+            bridge: bridge,
+            bridgedAccessoryIDs: bridgedAccessoryIDs,
+            includeBridgedAccessoryIDs: true
+        )
 
         // Services and their characteristics
         var services: [[String: Any]] = []
@@ -148,6 +161,24 @@ enum AccessoryModel {
         dict["services"] = services
 
         return dict
+    }
+
+    private static func addBridgeMetadata(
+        to dict: inout [String: Any],
+        bridge: [String: Any]?,
+        bridgedAccessoryIDs: [String],
+        includeBridgedAccessoryIDs: Bool = false
+    ) {
+        if let bridge {
+            dict["bridge"] = bridge
+        }
+
+        guard !bridgedAccessoryIDs.isEmpty else { return }
+        dict["is_bridge"] = true
+        dict["bridged_accessory_count"] = bridgedAccessoryIDs.count
+        if includeBridgedAccessoryIDs {
+            dict["bridged_accessory_ids"] = bridgedAccessoryIDs
+        }
     }
 
     /// Summary of a scene (action set).

--- a/Sources/homeclaw/HomeKit/BridgeMetadata.swift
+++ b/Sources/homeclaw/HomeKit/BridgeMetadata.swift
@@ -1,0 +1,101 @@
+import HomeKit
+
+/// Bridge ownership metadata derived from HomeKit bridge accessories.
+///
+/// HomeKit exposes bridge relationships from the bridge side: a bridge accessory
+/// lists the accessories it vends. This type builds the inverse lookup so child
+/// accessories can report the bridge that owns them.
+///
+/// Respects an optional visibility predicate so a caller-side allowlist (see
+/// `HomeClawConfig.filterMode == "allowlist"`) is not silently bypassed. When
+/// `isAccessoryVisible` returns false for a bridge, that bridge's summary is
+/// never attached to any child. When it returns false for a child, that
+/// child's UUID is dropped from the bridge's `bridged_accessory_ids` list and
+/// the child never receives the bridge summary.
+struct BridgeMetadata {
+    private let bridgeByAccessoryID: [UUID: [String: Any]]
+    private let bridgedAccessoryIDsByBridgeID: [UUID: [String]]
+
+    init(homes: [HMHome], isAccessoryVisible: (HMAccessory) -> Bool = { _ in true }) {
+        var bridgeByAccessoryID: [UUID: [String: Any]] = [:]
+        var bridgedAccessoryIDsByBridgeID: [UUID: [String]] = [:]
+
+        for home in homes {
+            // Index this home's accessories once so we can look up visibility
+            // of each bridged child without an O(n) walk per child.
+            var accessoryByID: [UUID: HMAccessory] = [:]
+            for accessory in home.accessories {
+                accessoryByID[accessory.uniqueIdentifier] = accessory
+            }
+
+            for bridge in home.accessories {
+                guard isAccessoryVisible(bridge) else { continue }
+
+                let allChildIDs = Self.bridgedAccessoryIdentifiers(for: bridge)
+                guard !allChildIDs.isEmpty else { continue }
+
+                // Only surface children that are themselves visible. An unknown
+                // child (present in the identifier list but missing from
+                // home.accessories) is dropped defensively — we can't confirm
+                // it passes the allowlist.
+                let visibleChildIDs = allChildIDs.filter { childID in
+                    guard let child = accessoryByID[childID] else { return false }
+                    return isAccessoryVisible(child)
+                }
+                guard !visibleChildIDs.isEmpty else { continue }
+
+                bridgedAccessoryIDsByBridgeID[bridge.uniqueIdentifier] = visibleChildIDs.map(\.uuidString)
+                let summary = Self.bridgeSummary(for: bridge)
+                for childID in visibleChildIDs {
+                    bridgeByAccessoryID[childID] = summary
+                }
+            }
+        }
+
+        self.bridgeByAccessoryID = bridgeByAccessoryID
+        self.bridgedAccessoryIDsByBridgeID = bridgedAccessoryIDsByBridgeID
+    }
+
+    func bridgeSummary(for accessory: HMAccessory) -> [String: Any]? {
+        bridgeByAccessoryID[accessory.uniqueIdentifier]
+    }
+
+    func bridgedAccessoryIDs(for bridge: HMAccessory) -> [String] {
+        bridgedAccessoryIDsByBridgeID[bridge.uniqueIdentifier] ?? []
+    }
+
+    private static func bridgedAccessoryIdentifiers(for bridge: HMAccessory) -> [UUID] {
+        var ids = Set<UUID>()
+
+        for accessory in bridge.bridgedAccessories {
+            ids.insert(accessory.uniqueIdentifier)
+        }
+
+        for id in bridge.uniqueIdentifiersForBridgedAccessories ?? [] {
+            ids.insert(id)
+        }
+
+        return ids.sorted { lhs, rhs in
+            lhs.uuidString.localizedStandardCompare(rhs.uuidString) == .orderedAscending
+        }
+    }
+
+    private static func bridgeSummary(for bridge: HMAccessory) -> [String: Any] {
+        var dict: [String: Any] = [
+            "id": bridge.uniqueIdentifier.uuidString,
+            "name": bridge.name,
+            "category": CharacteristicMapper.inferredCategoryName(for: bridge),
+            "reachable": bridge.isReachable,
+        ]
+
+        if let room = bridge.room {
+            dict["room"] = room.name
+            dict["room_id"] = room.uniqueIdentifier.uuidString
+        }
+        if let manufacturer = bridge.manufacturer { dict["manufacturer"] = manufacturer }
+        if let model = bridge.model { dict["model"] = model }
+        if let firmware = bridge.firmwareVersion { dict["firmware"] = firmware }
+
+        return dict
+    }
+}

--- a/Sources/homeclaw/HomeKit/DeviceMap.swift
+++ b/Sources/homeclaw/HomeKit/DeviceMap.swift
@@ -277,6 +277,14 @@ enum DeviceMap {
         // Global computations across all filtered accessories
         let allFiltered = homes.flatMap { filter($0.accessories) }
         let displayNames = computeDisplayNames(for: allFiltered)
+        // Bridge metadata must honor the same filter the caller applied — otherwise
+        // a filtered-out bridge would leak its name/model into visible children's
+        // JSON, and a visible bridge would leak the UUIDs of hidden children.
+        let allowedAccessoryIDs = Set(allFiltered.map(\.uniqueIdentifier))
+        let bridgeMetadata = BridgeMetadata(
+            homes: homes,
+            isAccessoryVisible: { allowedAccessoryIDs.contains($0.uniqueIdentifier) }
+        )
 
         // Stats
         var semanticTypeCounts: [String: Int] = [:]
@@ -342,6 +350,15 @@ enum DeviceMap {
                         }
                         if let manufacturer = accessory.manufacturer {
                             device["manufacturer"] = manufacturer
+                        }
+                        if let bridge = bridgeMetadata.bridgeSummary(for: accessory) {
+                            device["bridge"] = bridge
+                        }
+                        let bridgedAccessoryIDs = bridgeMetadata.bridgedAccessoryIDs(for: accessory)
+                        if !bridgedAccessoryIDs.isEmpty {
+                            device["is_bridge"] = true
+                            device["bridged_accessory_count"] = bridgedAccessoryIDs.count
+                            device["bridged_accessory_ids"] = bridgedAccessoryIDs
                         }
 
                         devicesList.append(device)

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -373,6 +373,7 @@ final class HomeKitManager: NSObject, Observable {
         await waitForReady()
         if Self.isDemoMode { return DemoFixtures.roomSummaries() }
         let targetHomes = filteredHomes(homeID: homeID)
+        let bridgeMetadata = BridgeMetadata(homes: targetHomes, isAccessoryVisible: isAccessoryAllowed)
         var result: [[String: Any]] = []
         for home in targetHomes {
             for room in home.rooms {
@@ -381,7 +382,12 @@ final class HomeKitManager: NSObject, Observable {
                 dict["accessory_count"] = filtered.count
                 dict["accessories"] = filtered.map { accessory in
                     let id = accessory.uniqueIdentifier.uuidString
-                    return AccessoryModel.accessorySummary(accessory, cachedState: cache.cachedState(for: id))
+                    return AccessoryModel.accessorySummary(
+                        accessory,
+                        cachedState: cache.cachedState(for: id),
+                        bridge: bridgeMetadata.bridgeSummary(for: accessory),
+                        bridgedAccessoryIDs: bridgeMetadata.bridgedAccessoryIDs(for: accessory)
+                    )
                 }
                 result.append(dict)
             }
@@ -419,6 +425,7 @@ final class HomeKitManager: NSObject, Observable {
         let allFiltered = targetHomes.flatMap { filterAccessories($0.accessories) }
         let displayNames = DeviceMap.computeDisplayNames(for: allFiltered)
         let roomZones = buildRoomZoneLookup(for: targetHomes)
+        let bridgeMetadata = BridgeMetadata(homes: targetHomes, isAccessoryVisible: isAccessoryAllowed)
 
         let result = filtered.map { accessory in
             let id = accessory.uniqueIdentifier
@@ -429,7 +436,9 @@ final class HomeKitManager: NSObject, Observable {
                 cachedState: cache.cachedState(for: id.uuidString),
                 zone: zone,
                 displayName: displayNames[id],
-                semanticType: semanticType.rawValue
+                semanticType: semanticType.rawValue,
+                bridge: bridgeMetadata.bridgeSummary(for: accessory),
+                bridgedAccessoryIDs: bridgeMetadata.bridgedAccessoryIDs(for: accessory)
             )
         }
         if cache.isStale { Task { await warmCache() } }
@@ -451,7 +460,15 @@ final class HomeKitManager: NSObject, Observable {
             await readAllValues(for: accessory)
             updateCacheFromAccessory(accessory)
         }
-        var detail = AccessoryModel.accessoryDetail(accessory)
+        let bridgeMetadata = BridgeMetadata(
+            homes: findHome(for: accessory).map { [$0] } ?? filteredHomes(homeID: homeID),
+            isAccessoryVisible: isAccessoryAllowed
+        )
+        var detail = AccessoryModel.accessoryDetail(
+            accessory,
+            bridge: bridgeMetadata.bridgeSummary(for: accessory),
+            bridgedAccessoryIDs: bridgeMetadata.bridgedAccessoryIDs(for: accessory)
+        )
         if !refresh {
             // Signal that dynamic characteristic values were NOT live-read this
             // call. Without a refresh, never-read characteristics serialize as
@@ -586,7 +603,15 @@ final class HomeKitManager: NSObject, Observable {
         // Read back current values, update cache, and return updated state
         await readInterestingValues(for: accessory)
         updateCacheFromAccessory(accessory)
-        return AccessoryModel.accessorySummary(accessory)
+        let bridgeMetadata = BridgeMetadata(
+            homes: findHome(for: accessory).map { [$0] } ?? filteredHomes(homeID: homeID),
+            isAccessoryVisible: isAccessoryAllowed
+        )
+        return AccessoryModel.accessorySummary(
+            accessory,
+            bridge: bridgeMetadata.bridgeSummary(for: accessory),
+            bridgedAccessoryIDs: bridgeMetadata.bridgedAccessoryIDs(for: accessory)
+        )
     }
 
     // MARK: - Scenes
@@ -3042,6 +3067,7 @@ final class HomeKitManager: NSObject, Observable {
 
         let filtered = filterAccessories(results)
         let roomZones = buildRoomZoneLookup(for: targetHomes)
+        let bridgeMetadata = BridgeMetadata(homes: targetHomes, isAccessoryVisible: isAccessoryAllowed)
 
         let output = filtered.map { accessory in
             let id = accessory.uniqueIdentifier
@@ -3052,7 +3078,9 @@ final class HomeKitManager: NSObject, Observable {
                 cachedState: cache.cachedState(for: id.uuidString),
                 zone: zone,
                 displayName: displayNames[id],
-                semanticType: semanticType.rawValue
+                semanticType: semanticType.rawValue,
+                bridge: bridgeMetadata.bridgeSummary(for: accessory),
+                bridgedAccessoryIDs: bridgeMetadata.bridgedAccessoryIDs(for: accessory)
             )
         }
         if cache.isStale { Task { await warmCache() } }
@@ -3077,6 +3105,7 @@ final class HomeKitManager: NSObject, Observable {
     func listAllAccessories() async -> [[String: Any]] {
         await waitForReady()
         if Self.isDemoMode { return DemoFixtures.allAccessoriesWithHome() }
+        let bridgeMetadata = BridgeMetadata(homes: homes)
         return homes.flatMap { home in
             home.accessories.map { accessory in
                 let id = accessory.uniqueIdentifier.uuidString
@@ -3099,6 +3128,14 @@ final class HomeKitManager: NSObject, Observable {
                 if let cachedState = cache.cachedState(for: id), !cachedState.isEmpty {
                     dict["state"] = cachedState
                 }
+                if let bridge = bridgeMetadata.bridgeSummary(for: accessory) {
+                    dict["bridge"] = bridge
+                }
+                let bridgedAccessoryIDs = bridgeMetadata.bridgedAccessoryIDs(for: accessory)
+                if !bridgedAccessoryIDs.isEmpty {
+                    dict["is_bridge"] = true
+                    dict["bridged_accessory_count"] = bridgedAccessoryIDs.count
+                }
                 return dict
             }
         }
@@ -3116,6 +3153,7 @@ final class HomeKitManager: NSObject, Observable {
         guard let selectedHome = targetHomes.first else {
             return ["ready": true, "selected_home": "", "homes": [], "scenes": [], "rooms": []]
         }
+        let bridgeMetadata = BridgeMetadata(homes: [selectedHome], isAccessoryVisible: isAccessoryAllowed)
 
         let homesList: [[String: Any]] = homes.map { home in
             [
@@ -3145,7 +3183,11 @@ final class HomeKitManager: NSObject, Observable {
                 .map { accessory in
                     let id = accessory.uniqueIdentifier.uuidString
                     return AccessoryModel.accessorySummary(
-                        accessory, cachedState: cache.cachedState(for: id))
+                        accessory,
+                        cachedState: cache.cachedState(for: id),
+                        bridge: bridgeMetadata.bridgeSummary(for: accessory),
+                        bridgedAccessoryIDs: bridgeMetadata.bridgedAccessoryIDs(for: accessory)
+                    )
                 }
                 .sorted { a, b in
                     let catA = a["category"] as? String ?? "other"

--- a/Tests/homeclaw-cliTests/InputHandlingTests.swift
+++ b/Tests/homeclaw-cliTests/InputHandlingTests.swift
@@ -88,6 +88,34 @@ struct ParseAssignmentsTests {
     }
 }
 
+// MARK: - bridgeDisplayName
+
+@Suite("bridgeDisplayName")
+struct BridgeDisplayNameTests {
+    @Test("uses bridge name when present")
+    func name() {
+        let accessory: [String: Any] = [
+            "bridge": ["id": "bridge-id", "name": "Hue Bridge"]
+        ]
+
+        #expect(bridgeDisplayName(in: accessory) == "Hue Bridge")
+    }
+
+    @Test("falls back to bridge id")
+    func idFallback() {
+        let accessory: [String: Any] = [
+            "bridge": ["id": "bridge-id"]
+        ]
+
+        #expect(bridgeDisplayName(in: accessory) == "bridge-id")
+    }
+
+    @Test("returns nil without bridge metadata")
+    func missingBridge() {
+        #expect(bridgeDisplayName(in: [:]) == nil)
+    }
+}
+
 // MARK: - formatSceneReferences (uniform list/get scene rendering)
 
 @Suite("formatSceneReferences")


### PR DESCRIPTION
This PR exposes HomeKit bridge metadata in the API and CLI.

HomeClaw already reported whether an accessory is bridged, but it did not expose which bridge owns a bridged accessory. I want to use my AI agents to index all my smart home devices, including which bridge each device is connected to, so I added the functionality.

## Sample output

### Get accessory with bridge

```sh
homeclaw-cli get '<accessory>' --json --no-refresh | jq '{name, room, category, manufacturer, model, bridge}'
```

```json
{
  "name": "<accessory name>",
  "room": "<room name>",
  "category": "lightbulb",
  "manufacturer": "IKEA of Sweden",
  "model": "TRADFRI bulb GU10 CWS 345lm",
  "bridge": {
    "category": "bridge",
    "firmware": "2.975.2",
    "id": "<bridge uuid>",
    "manufacturer": "IKEA of Sweden",
    "model": "DIRIGERA Hub for smart products",
    "name": "DIRIGERA",
    "reachable": true,
    "room": "<bridge room>"
  }
}
```

### Bridged accessory with children

```sh
homeclaw-cli get 'DIRIGERA' --json --no-refresh | jq '{name, category, is_bridge, bridged_accessory_count, bridged_accessory_ids}'
```

```json
{
  "name": "DIRIGERA",
  "category": "bridge",
  "is_bridge": true,
  "bridged_accessory_count": 11,
  "bridged_accessory_ids": [
    "<accessory uuid 1>",
    "<accessory uuid 2>",
    "<accessory uuid 3>"
  ]
}
```