### PR TITLE
fix(automations): accept HH:MM clock times as trigger conditions (#81)

### DIFF
--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -395,16 +395,23 @@ struct CreateAutomation: ParsableCommand {
             return String(format: "%02d:%02d", hour, minute)
         }
 
-        let rest: String
+        let event: String
+        var rest: String
         if lower.hasPrefix("sunrise") {
+            event = "sunrise"
             rest = String(lower.dropFirst("sunrise".count))
         } else if lower.hasPrefix("sunset") {
+            event = "sunset"
             rest = String(lower.dropFirst("sunset".count))
         } else {
             throw ValidationError("Invalid \(flag) '\(raw)'. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (noon/midnight not supported).")
         }
 
-        if rest.isEmpty { return lower }
+        // Tolerate whitespace anywhere in the offset (`sunset -30`, `sunset - 30`) and
+        // normalize it away, so the value we put on the wire is canonical. Mirrors the
+        // same tolerance in `TimeSpec.parse`; see the note there for why it exists.
+        rest = rest.filter { !$0.isWhitespace }
+        if rest.isEmpty { return event }
 
         guard let sign = rest.first, sign == "+" || sign == "-" else {
             throw ValidationError("Invalid \(flag) '\(raw)'. Offset must start with + or - (e.g. 'sunset-30').")
@@ -419,7 +426,7 @@ struct CreateAutomation: ParsableCommand {
         if magnitude > 1440 {
             throw ValidationError("Invalid \(flag) '\(raw)'. Offsets larger than 1440 minutes (24h) are rejected — that's almost certainly a typo; use --days for weekday gating.")
         }
-        return lower
+        return event + rest
     }
 
     /// Parse `--days mon,tue,...` (or numeric `1-7` where 1=Sun) into the HomeKit

--- a/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
+++ b/Sources/homeclaw-cli/Commands/AutomationsCommand.swift
@@ -195,10 +195,10 @@ struct CreateAutomation: ParsableCommand {
     @Option(name: .long, parsing: .upToNextOption, help: "Extra characteristic predicate ANDed into the trigger as 'accessory:property:value' (repeatable). Example: 'Front Door:contact_state:0'. Note: accessory names containing colons are not supported via --condition; use the MCP conditions array instead.")
     var condition: [String] = []
 
-    @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires after the given event. Format: '<sunrise|sunset>[±N]' where N is minutes (e.g. 'sunset-30'). Offsets >1440 (24h) are rejected. Implies weekday auto-fill if --days is omitted.")
+    @Option(name: .long, parsing: .upToNextOption, help: "Time predicate (repeatable): trigger only fires after the given time. Format: 'HH:MM' (zero-padded, e.g. '07:00') or '<sunrise|sunset>[±N]' where N is minutes (e.g. 'sunset-30'). Offsets >1440 (24h) are rejected. Implies weekday auto-fill if --days is omitted.")
     var timeAfter: [String] = []
 
-    @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires before the given event. Format: '<sunrise|sunset>[±N]' where N is minutes (e.g. 'sunrise+15'). Offsets >1440 (24h) are rejected. Implies weekday auto-fill if --days is omitted.")
+    @Option(name: .long, parsing: .upToNextOption, help: "Time predicate (repeatable): trigger only fires before the given time. Format: 'HH:MM' (zero-padded, e.g. '20:30') or '<sunrise|sunset>[±N]' where N is minutes (e.g. 'sunrise+15'). Offsets >1440 (24h) are rejected. Implies weekday auto-fill if --days is omitted.")
     var timeBefore: [String] = []
 
     @Option(name: .long, help: "Auto-revert the trigger's actions after this many seconds via HMDurationEvent (1-86400). Useful for motion-triggered lights that should turn off again after a delay.")
@@ -356,14 +356,43 @@ struct CreateAutomation: ParsableCommand {
         return weekdays.compactMap { (1...7).contains($0) ? names[$0] : nil }.joined(separator: ",")
     }
 
-    /// Validate a `--time-after` / `--time-before` spec. Format: `<sunrise|sunset>[±N]`.
-    /// Mirrors `TimeCondition.parse` in HomeKitManager but throws CLI-shaped errors
+    /// Validate a time spec: `HH:MM` (zero-padded, 24-hour) or `<sunrise|sunset>[±N]`.
+    /// Mirrors `TimeSpec.parse` in HomeKitManager (the manager-side source of truth,
+    /// which `TimeCondition.parse` also routes through) but throws CLI-shaped errors
     /// pointing at the offending flag. Defence-in-depth: SocketServer re-validates.
+    ///
+    /// Shared by `--time` (the trigger event, via `validateTimeOfDaySpec`) and
+    /// `--time-after` / `--time-before` (gating predicates), which accept the same
+    /// vocabulary — clock times became valid conditions in #81.
     static func validateTimeSpec(_ raw: String, flag: String) throws -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespaces)
         let lower = trimmed.lowercased()
         guard !lower.isEmpty else {
-            throw ValidationError("\(flag) value is empty. Use 'sunrise', 'sunset', or '<sun-event>±<minutes>'.")
+            throw ValidationError("\(flag) value is empty. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30').")
+        }
+
+        // HH:MM clock time
+        if lower.contains(":") {
+            let parts = lower.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else {
+                throw ValidationError("Invalid \(flag) '\(raw)'. Use 'HH:MM' (e.g. '06:30').")
+            }
+            let hourStr = String(parts[0])
+            let minStr = String(parts[1])
+            // Reject ambiguous widths so '12:5' doesn't silently become '12:50'.
+            guard hourStr.count == 2 else {
+                throw ValidationError("Invalid \(flag) '\(raw)'. Hour must be exactly two digits (e.g. '06:30', not '6:30').")
+            }
+            guard minStr.count == 2 else {
+                throw ValidationError("Invalid \(flag) '\(raw)'. Minute must be exactly two digits (e.g. '06:05', not '06:5').")
+            }
+            guard let hour = Int(hourStr), (0...23).contains(hour) else {
+                throw ValidationError("Invalid \(flag) '\(raw)'. Hour must be 0-23.")
+            }
+            guard let minute = Int(minStr), (0...59).contains(minute) else {
+                throw ValidationError("Invalid \(flag) '\(raw)'. Minute must be 0-59.")
+            }
+            return String(format: "%02d:%02d", hour, minute)
         }
 
         let rest: String
@@ -372,7 +401,7 @@ struct CreateAutomation: ParsableCommand {
         } else if lower.hasPrefix("sunset") {
             rest = String(lower.dropFirst("sunset".count))
         } else {
-            throw ValidationError("Invalid \(flag) '\(raw)'. Sun event must be 'sunrise' or 'sunset' (noon/midnight not supported).")
+            throw ValidationError("Invalid \(flag) '\(raw)'. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (noon/midnight not supported).")
         }
 
         if rest.isEmpty { return lower }
@@ -459,61 +488,18 @@ struct CreateAutomation: ParsableCommand {
         ]
     }
 
-    /// CLI-side mirror of `HomeKitManager.TimeSpec.parse(_:)`. Implements the
-    /// same rules so the CLI fails fast with friendly error messages before the
-    /// socket round-trip. SocketServer re-validates via `TimeSpec.parse`; manager
-    /// is the canonical source of truth. Keep these two in sync.
+    /// The `--time` trigger-event spec for `create-time`. Same grammar as the
+    /// `--time-after` / `--time-before` conditions, so this is `validateTimeSpec`
+    /// with the flag name bound — kept as a named entry point because the call
+    /// sites read better and the two flags are conceptually distinct (`--time` is
+    /// the trigger event; `--time-after`/`--time-before` gate it).
     ///
     /// Accepts: `HH:MM`, `sunrise`, `sunset`, `sunrise±N`, `sunset±N` (where N is
     /// minutes, ≤ 1440). Returns the canonical lowercase string we pass to the
     /// socket layer. Strict HH:MM (two digits each) so the user can't ambiguously
     /// type `12:5` and silently mean `12:50`.
-    ///
-    /// This layer's job is to surface CLI-shaped error messages that say `--time`
-    /// not `time`. The SocketServer re-validates via `TimeSpec.parse` so direct
-    /// socket clients can't bypass the format check, and the manager re-runs
-    /// `TimeSpec.parse` at HomeKit-mutation time as the canonical source of truth.
     static func validateTimeOfDaySpec(_ raw: String) throws -> String {
-        let trimmed = raw.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else {
-            throw ValidationError("--time value is empty. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30').")
-        }
-        let lower = trimmed.lowercased()
-
-        // HH:MM
-        if lower.contains(":") {
-            let parts = lower.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
-            guard parts.count == 2 else {
-                throw ValidationError("Invalid --time '\(raw)'. Use 'HH:MM' (e.g. '06:30').")
-            }
-            let hourStr = String(parts[0])
-            let minStr = String(parts[1])
-            // Reject ambiguous widths so '12:5' doesn't silently become '12:50'.
-            guard hourStr.count == 2 else {
-                throw ValidationError("Invalid --time '\(raw)'. Hour must be exactly two digits (e.g. '06:30', not '6:30').")
-            }
-            guard minStr.count == 2 else {
-                throw ValidationError("Invalid --time '\(raw)'. Minute must be exactly two digits (e.g. '06:05', not '06:5').")
-            }
-            guard let hour = Int(hourStr), (0...23).contains(hour) else {
-                throw ValidationError("Invalid --time '\(raw)'. Hour must be 0-23.")
-            }
-            guard let minute = Int(minStr), (0...59).contains(minute) else {
-                throw ValidationError("Invalid --time '\(raw)'. Minute must be 0-59.")
-            }
-            return String(format: "%02d:%02d", hour, minute)
-        }
-
-        // sunrise / sunset (with optional ±N offset). Inline-handle the
-        // unknown-prefix case (e.g. `noon`, `midnight`, `dawn`) with a tailored
-        // error listing all four valid `--time` forms. Once we know the prefix
-        // is `sunrise` or `sunset`, forward to `validateTimeSpec` for offset
-        // parsing — that path's existing error messages are correct for
-        // sun-event-with-bad-offset cases.
-        guard lower.hasPrefix("sunrise") || lower.hasPrefix("sunset") else {
-            throw ValidationError("Invalid --time '\(raw)'. Use 'HH:MM' (e.g. '06:30'), 'sunrise', 'sunset', or '<sun-event>±<minutes>' (e.g. 'sunset-30').")
-        }
-        return try Self.validateTimeSpec(lower, flag: "--time")
+        try Self.validateTimeSpec(raw, flag: "--time")
     }
 
     /// Print the conditions / time conditions / weekdays portion of a create response.
@@ -623,10 +609,10 @@ struct CreateTimeAutomation: ParsableCommand {
     @Option(name: .long, parsing: .upToNextOption, help: "Extra characteristic predicate ANDed into the trigger as 'accessory:property:value' (repeatable). Example: 'Front Door:occupancy_detected:true'. Note: accessory names containing colons are not supported via --condition; use the MCP conditions array instead.")
     var condition: [String] = []
 
-    @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires after the given event. Format: '<sunrise|sunset>[±N]' where N is minutes. Composes with --time (e.g. --time 06:30 --time-after sunrise means '06:30, but only after sunrise').")
+    @Option(name: .long, parsing: .upToNextOption, help: "Time predicate (repeatable): trigger only fires after the given time. Format: 'HH:MM' or '<sunrise|sunset>[±N]' where N is minutes. Composes with --time (e.g. --time 06:30 --time-after sunrise means '06:30, but only after sunrise').")
     var timeAfter: [String] = []
 
-    @Option(name: .long, parsing: .upToNextOption, help: "Sun-relative time predicate (repeatable): trigger only fires before the given event. Same format as --time-after.")
+    @Option(name: .long, parsing: .upToNextOption, help: "Time predicate (repeatable): trigger only fires before the given time. Same format as --time-after.")
     var timeBefore: [String] = []
 
     @Option(name: .long, help: "Auto-revert the trigger's actions after this many seconds via HMDurationEvent (1-86400). Useful for sunset porch lights that should turn off after an hour.")

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -189,6 +189,13 @@ enum TimeSpec: Equatable {
             throw ParseError.unknownFormat(raw)
         }
 
+        // Tolerate whitespace anywhere in the offset (`sunset -30`, `sunset- 30`,
+        // `sunset - 30`). The pre-#81 condition parser trimmed the leading side, and
+        // the MCP layer forwards raw strings without format validation, so callers
+        // (including LLMs writing `"sunset -30"`) could and did rely on it. Stripping
+        // all whitespace here is a superset of both pre-#81 parsers, so unifying the
+        // grammar can't reject anything either surface used to accept.
+        rest = rest.filter { !$0.isWhitespace }
         if rest.isEmpty { return .significantTime(event: event, offsetMinutes: 0) }
 
         guard let sign = rest.first, sign == "+" || sign == "-" else { throw ParseError.badOffsetSign(raw) }

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -3,77 +3,77 @@ import os
 
 // MARK: - Time Condition
 
-/// A before/after sun-relative time predicate for automation triggers.
-/// Composes via `HMEventTrigger.predicateForEvaluatingTrigger(occurringBefore/After:)` with an
-/// `HMSignificantTimeEvent` carrying the optional offset.
+/// A before/after time predicate gating an automation trigger.
 ///
-/// Format: `<sun-event>[±<minutes>]` where sun-event is `sunrise` or `sunset` and the offset
-/// is signed minutes (e.g. `sunset-30`, `sunrise+15`, `sunset`).
+/// The moment itself is a `TimeSpec` — either a wall-clock `HH:MM` or a sun event
+/// (`sunrise`/`sunset`, optionally offset by ±N minutes) — so `--time-after` /
+/// `--time-before` accept exactly the same vocabulary as the `--time` trigger event.
+///
+/// Composes via:
+/// - `HMEventTrigger.predicateForEvaluatingTrigger(occurringBefore/After:)` with an
+///   `HMSignificantTimeEvent` for sun events
+/// - the `DateComponents` overloads of the same factories for clock times
 struct TimeCondition {
     enum Relation { case after, before }
     enum Event { case sunrise, sunset }
 
     let relation: Relation
-    let event: Event
-    let offsetMinutes: Int   // positive = after the event, negative = before
+    let spec: TimeSpec
 
     /// Reject offsets larger than 24h — almost certainly a typo (the user probably meant a
     /// `--days` filter). Smaller-than-24h but suspicious offsets (>720m / 12h) are allowed
     /// to keep the parser permissive; the CLI flag layer surfaces them in `--help`.
     static let maxOffsetMinutes = 1440
 
+    /// Canonical echo form (`06:30`, `sunset`, `sunrise+15`) — what the create
+    /// response reports back and what `AccessoryModel` renders on read-back.
+    var canonicalString: String { spec.canonicalString }
+
     func predicate() -> NSPredicate? {
-        var offset: DateComponents? = nil
-        if offsetMinutes != 0 {
+        switch spec {
+        case .significantTime(let event, let offsetMinutes):
+            var offset: DateComponents? = nil
+            if offsetMinutes != 0 {
+                var dc = DateComponents()
+                dc.minute = offsetMinutes
+                offset = dc
+            }
+            // The non-deprecated predicate APIs take an HMSignificantTimeEvent (which carries
+            // the offset) rather than a significant-event string + separate offset. Both are
+            // available on macCatalyst 14.0+.
+            let sigEvent = event == .sunrise ? HMSignificantEvent.sunrise : HMSignificantEvent.sunset
+            let significantEvent = HMSignificantTimeEvent(significantEvent: sigEvent, offset: offset)
+            switch relation {
+            case .after:
+                return HMEventTrigger.predicateForEvaluatingTriggerOccurring(afterSignificantEvent: significantEvent)
+            case .before:
+                return HMEventTrigger.predicateForEvaluatingTriggerOccurring(beforeSignificantEvent: significantEvent)
+            }
+        case .calendar(let hour, let minute):
+            // Clock-time conditions use the `...DateWithComponents:` sibling factories.
+            // This is the same predicate shape the Home app writes for its "Time is
+            // between X and Y" conditions, which `AccessoryModel.extractConditions`
+            // already decodes on read-back.
             var dc = DateComponents()
-            dc.minute = offsetMinutes
-            offset = dc
-        }
-        // The non-deprecated predicate APIs take an HMSignificantTimeEvent (which carries
-        // the offset) rather than a significant-event string + separate offset. Both are
-        // available on macCatalyst 14.0+.
-        let sigEvent = event == .sunrise ? HMSignificantEvent.sunrise : HMSignificantEvent.sunset
-        let significantEvent = HMSignificantTimeEvent(significantEvent: sigEvent, offset: offset)
-        switch relation {
-        case .after:
-            return HMEventTrigger.predicateForEvaluatingTriggerOccurring(afterSignificantEvent: significantEvent)
-        case .before:
-            return HMEventTrigger.predicateForEvaluatingTriggerOccurring(beforeSignificantEvent: significantEvent)
+            dc.hour = hour
+            dc.minute = minute
+            switch relation {
+            case .after:
+                return HMEventTrigger.predicateForEvaluatingTrigger(occurringAfter: dc)
+            case .before:
+                return HMEventTrigger.predicateForEvaluatingTrigger(occurringBefore: dc)
+            }
         }
     }
 
-    /// Parse a sun-relative time spec. Returns nil for malformed input;
-    /// throws via the caller's `ValidationError` boundary.
-    /// Accepts: `sunrise`, `sunset`, `sunrise+15`, `sunset-30`. Rejects: bare offsets,
-    /// `noon`/`midnight`, missing-numeric offset (`sunset+`), unknown events.
+    /// Parse a time-condition spec. Returns nil for malformed input; the caller
+    /// maps that to its own validation-error shape.
+    /// Accepts everything `TimeSpec.parse` accepts: `06:30`, `sunrise`, `sunset`,
+    /// `sunrise+15`, `sunset-30`. Rejects bare offsets, `noon`/`midnight`,
+    /// non-zero-padded clock times (`6:30`), and missing offset magnitudes (`sunset+`).
     static func parse(_ raw: String, relation: Relation) -> TimeCondition? {
-        let s = raw.lowercased().trimmingCharacters(in: .whitespaces)
-        guard !s.isEmpty else { return nil }
-
-        let event: Event
-        var rest: String
-        if s.hasPrefix("sunrise") {
-            event = .sunrise
-            rest = String(s.dropFirst("sunrise".count))
-        } else if s.hasPrefix("sunset") {
-            event = .sunset
-            rest = String(s.dropFirst("sunset".count))
-        } else {
-            return nil
-        }
-
-        rest = rest.trimmingCharacters(in: .whitespaces)
-        if rest.isEmpty {
-            return TimeCondition(relation: relation, event: event, offsetMinutes: 0)
-        }
-
-        // Must start with + or -, followed by a positive integer (minutes).
-        guard let sign = rest.first, sign == "+" || sign == "-" else { return nil }
-        let numStr = String(rest.dropFirst())
-        guard !numStr.isEmpty, let magnitude = Int(numStr), magnitude >= 0 else { return nil }
-        if magnitude > maxOffsetMinutes { return nil }
-        let offset = sign == "+" ? magnitude : -magnitude
-        return TimeCondition(relation: relation, event: event, offsetMinutes: offset)
+        guard let spec = try? TimeSpec.parse(raw) else { return nil }
+        return TimeCondition(relation: relation, spec: spec)
     }
 }
 
@@ -1173,22 +1173,17 @@ final class HomeKitManager: NSObject, Observable {
         return ["room": room.name, "zone": zone.name, "home": home.name, "dry_run": false] as [String: Any]
     }
 
-    // MARK: - Demo-mode helpers
-
-    /// Render `TimeCondition`s back into the `sunrise±N` / `sunset±N` echo strings
-    /// the create-automation response uses, split by relation. Mirrors the echo
-    /// logic in `createAutomation` so demo responses match the real shape.
-    static func demoTimeEchoes(_ timeConditions: [TimeCondition]) -> (after: [String], before: [String]) {
-        func render(_ tc: TimeCondition) -> String {
-            let ev = tc.event == .sunrise ? "sunrise" : "sunset"
-            if tc.offsetMinutes == 0 { return ev }
-            return tc.offsetMinutes > 0 ? "\(ev)+\(tc.offsetMinutes)" : "\(ev)\(tc.offsetMinutes)"
-        }
+    /// Render `TimeCondition`s back into the `HH:MM` / `sunrise±N` / `sunset±N` echo
+    /// strings the create-automation response uses, split by relation. Shared by the
+    /// real and demo create paths so both responses have the same shape.
+    static func timeEchoes(_ timeConditions: [TimeCondition]) -> (after: [String], before: [String]) {
         return (
-            timeConditions.filter { $0.relation == .after }.map(render),
-            timeConditions.filter { $0.relation == .before }.map(render)
+            timeConditions.filter { $0.relation == .after }.map(\.canonicalString),
+            timeConditions.filter { $0.relation == .before }.map(\.canonicalString)
         )
     }
+
+    // MARK: - Demo-mode helpers
 
     /// Map a numeric press type (0/1/2) to its human label, for demo automations.
     static func demoPressLabel(_ pressType: Int) -> String {
@@ -1254,7 +1249,7 @@ final class HomeKitManager: NSObject, Observable {
         if Self.isDemoMode {
             let weekdaysAutoFilled = !timeConditions.isEmpty && weekdays.isEmpty
             let effectiveWeekdays = weekdaysAutoFilled ? [1, 2, 3, 4, 5, 6, 7] : weekdays
-            let echoes = Self.demoTimeEchoes(timeConditions)
+            let echoes = Self.timeEchoes(timeConditions)
             let isButton = characteristic == nil
             guard let result = DemoFixtures.createAutomation(
                 name: name,
@@ -1310,18 +1305,7 @@ final class HomeKitManager: NSObject, Observable {
                 "value": $0.rawValue,
             ]
         }
-        let timeAfterEcho: [String] = timeConditions.compactMap {
-            guard $0.relation == .after else { return nil }
-            let ev = $0.event == .sunrise ? "sunrise" : "sunset"
-            if $0.offsetMinutes == 0 { return ev }
-            return $0.offsetMinutes > 0 ? "\(ev)+\($0.offsetMinutes)" : "\(ev)\($0.offsetMinutes)"
-        }
-        let timeBeforeEcho: [String] = timeConditions.compactMap {
-            guard $0.relation == .before else { return nil }
-            let ev = $0.event == .sunrise ? "sunrise" : "sunset"
-            if $0.offsetMinutes == 0 { return ev }
-            return $0.offsetMinutes > 0 ? "\(ev)+\($0.offsetMinutes)" : "\(ev)\($0.offsetMinutes)"
-        }
+        let (timeAfterEcho, timeBeforeEcho) = Self.timeEchoes(timeConditions)
         // Closure used by both dry-run and success paths to attach predicate-related fields.
         // Keeping the shape identical between paths means callers/tests don't need to special-case.
         let attachPredicateFields: ([String: Any]) -> [String: Any] = { existing in
@@ -1617,7 +1601,7 @@ final class HomeKitManager: NSObject, Observable {
         if Self.isDemoMode {
             let weekdaysAutoFilled = weekdays.isEmpty
             let effectiveWeekdays = weekdaysAutoFilled ? [1, 2, 3, 4, 5, 6, 7] : weekdays
-            let echoes = Self.demoTimeEchoes(timeConditions)
+            let echoes = Self.timeEchoes(timeConditions)
             return DemoFixtures.createTimeAutomation(
                 name: name,
                 time: time,
@@ -1663,18 +1647,7 @@ final class HomeKitManager: NSObject, Observable {
                 "value": $0.rawValue,
             ]
         }
-        let timeAfterEcho: [String] = timeConditions.compactMap {
-            guard $0.relation == .after else { return nil }
-            let ev = $0.event == .sunrise ? "sunrise" : "sunset"
-            if $0.offsetMinutes == 0 { return ev }
-            return $0.offsetMinutes > 0 ? "\(ev)+\($0.offsetMinutes)" : "\(ev)\($0.offsetMinutes)"
-        }
-        let timeBeforeEcho: [String] = timeConditions.compactMap {
-            guard $0.relation == .before else { return nil }
-            let ev = $0.event == .sunrise ? "sunrise" : "sunset"
-            if $0.offsetMinutes == 0 { return ev }
-            return $0.offsetMinutes > 0 ? "\(ev)+\($0.offsetMinutes)" : "\(ev)\($0.offsetMinutes)"
-        }
+        let (timeAfterEcho, timeBeforeEcho) = Self.timeEchoes(timeConditions)
 
         // Derive the read-side trigger_type tag to match what
         // `AccessoryModel.automationSummary` will render on subsequent list/get.
@@ -1975,7 +1948,7 @@ final class HomeKitManager: NSObject, Observable {
     }
 
     /// Build the AND-combined trigger predicate from characteristic conditions
-    /// and sun-relative time conditions.
+    /// and time conditions (clock times and sun-relative events).
     ///
     /// Returns nil if all inputs are empty.
     /// Returns the single subpredicate directly if only one is present, or an

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -997,8 +997,9 @@ final class SocketServer: @unchecked Sendable {
                 } catch let err as AccessoryRowsArgError {
                     return encodeResponse(success: false, error: err.message)
                 }
-                // Parse sun-relative time predicates. The CLI/MCP layer pre-validates format,
-                // but defensively re-validate here so direct socket clients can't bypass it.
+                // Parse time predicates (clock times and sun-relative events). The CLI/MCP
+                // layer pre-validates format, but defensively re-validate here so direct
+                // socket clients can't bypass it.
                 let timeAfterRaw: [String]
                 let timeBeforeRaw: [String]
                 do {
@@ -1011,14 +1012,14 @@ final class SocketServer: @unchecked Sendable {
                 for raw in timeAfterRaw {
                     guard let tc = TimeCondition.parse(raw, relation: .after) else {
                         return encodeResponse(success: false,
-                            error: "Invalid 'time_after' value '\(raw)'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunset-30').")
+                            error: "Invalid 'time_after' value '\(raw)'. Use a clock time 'HH:MM' (zero-padded, e.g. '07:00') or sunrise/sunset with optional ±N minutes (e.g. 'sunset-30').")
                     }
                     timeConditions.append(tc)
                 }
                 for raw in timeBeforeRaw {
                     guard let tc = TimeCondition.parse(raw, relation: .before) else {
                         return encodeResponse(success: false,
-                            error: "Invalid 'time_before' value '\(raw)'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunrise+15').")
+                            error: "Invalid 'time_before' value '\(raw)'. Use a clock time 'HH:MM' (zero-padded, e.g. '20:30') or sunrise/sunset with optional ±N minutes (e.g. 'sunrise+15').")
                     }
                     timeConditions.append(tc)
                 }
@@ -1120,14 +1121,14 @@ final class SocketServer: @unchecked Sendable {
                 for raw in timeAfterRaw {
                     guard let tc = TimeCondition.parse(raw, relation: .after) else {
                         return encodeResponse(success: false,
-                            error: "Invalid 'time_after' value '\(raw)'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunset-30').")
+                            error: "Invalid 'time_after' value '\(raw)'. Use a clock time 'HH:MM' (zero-padded, e.g. '07:00') or sunrise/sunset with optional ±N minutes (e.g. 'sunset-30').")
                     }
                     timeConditions.append(tc)
                 }
                 for raw in timeBeforeRaw {
                     guard let tc = TimeCondition.parse(raw, relation: .before) else {
                         return encodeResponse(success: false,
-                            error: "Invalid 'time_before' value '\(raw)'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunrise+15').")
+                            error: "Invalid 'time_before' value '\(raw)'. Use a clock time 'HH:MM' (zero-padded, e.g. '20:30') or sunrise/sunset with optional ±N minutes (e.g. 'sunrise+15').")
                     }
                     timeConditions.append(tc)
                 }

--- a/Tests/homeclaw-cliTests/AutomationsHelperTests.swift
+++ b/Tests/homeclaw-cliTests/AutomationsHelperTests.swift
@@ -6,8 +6,9 @@ import Testing
 // and FormatDurationTests covers formatDuration. The two helpers below were
 // previously untested:
 //   - formatWeekdays: the inverse of parseWeekdays, used to render list/get output
-//   - validateTimeSpec: the --time-after / --time-before parser (distinct from the
-//     --time parser, which is validateTimeOfDaySpec and rejects HH:MM here)
+//   - validateTimeSpec: the --time-after / --time-before parser. Since #81 it shares
+//     its grammar with the --time parser (validateTimeOfDaySpec now delegates to it),
+//     so both clock times and sun events are accepted.
 
 // MARK: - formatWeekdays (HomeKit weekday numbers → label)
 
@@ -69,13 +70,25 @@ struct ValidateTimeSpecTests {
         }
     }
 
-    @Test("HH:MM is NOT a valid sun-relative spec (that's --time, not --time-after)")
-    func clockTimeRejected() {
-        // validateTimeSpec only accepts sunrise/sunset forms — a wall-clock time
-        // belongs to validateTimeOfDaySpec. This guards against the two parsers
-        // being accidentally swapped.
-        #expect(throws: (any Error).self) {
-            _ = try CreateAutomation.validateTimeSpec("06:30", flag: "--time-after")
+    @Test("HH:MM clock times accepted as conditions (#81)")
+    func clockTimeAccepted() throws {
+        // Gating a sensor automation to a fixed time-of-day window is the whole
+        // point of #81 — `--time-after 07:00 --time-before 20:30`.
+        #expect(try CreateAutomation.validateTimeSpec("07:00", flag: "--time-after") == "07:00")
+        #expect(try CreateAutomation.validateTimeSpec("20:30", flag: "--time-before") == "20:30")
+        #expect(try CreateAutomation.validateTimeSpec("00:00", flag: "--time-after") == "00:00")
+        #expect(try CreateAutomation.validateTimeSpec("23:59", flag: "--time-before") == "23:59")
+        #expect(try CreateAutomation.validateTimeSpec("  09:15  ", flag: "--time-after") == "09:15")
+    }
+
+    @Test("clock times keep the strict two-digit / in-range rules of --time")
+    func clockTimeStrictness() {
+        // Same rules as validateTimeOfDaySpec: '6:30' must not be silently widened,
+        // and '12:5' must not become '12:50'.
+        for bad in ["6:30", "12:5", "12:345", "25:00", "24:00", "12:60", "12:ab", ":30", "12:", ":"] {
+            #expect(throws: (any Error).self) {
+                _ = try CreateAutomation.validateTimeSpec(bad, flag: "--time-after")
+            }
         }
     }
 

--- a/Tests/homeclaw-cliTests/AutomationsHelperTests.swift
+++ b/Tests/homeclaw-cliTests/AutomationsHelperTests.swift
@@ -62,6 +62,19 @@ struct ValidateTimeSpecTests {
         #expect(try CreateAutomation.validateTimeSpec("sunrise+0", flag: "--time-after") == "sunrise+0")
     }
 
+    @Test("whitespace inside a sun offset is tolerated and normalized away")
+    func spacedOffsets() throws {
+        // The pre-#81 socket-side condition parser trimmed the leading side of the
+        // offset, so `sunset -30` reached HomeKit fine via MCP (which forwards raw
+        // strings unvalidated). Unifying the grammar must not regress that, and the
+        // value we put on the wire should be canonical either way.
+        #expect(try CreateAutomation.validateTimeSpec("sunset -30", flag: "--time-after") == "sunset-30")
+        #expect(try CreateAutomation.validateTimeSpec("sunrise +15", flag: "--time-before") == "sunrise+15")
+        #expect(try CreateAutomation.validateTimeSpec("sunset - 30", flag: "--time-after") == "sunset-30")
+        #expect(try CreateAutomation.validateTimeSpec("sunset- 30", flag: "--time-after") == "sunset-30")
+        #expect(try CreateAutomation.validateTimeSpec("  SUNRISE + 15  ", flag: "--time") == "sunrise+15")
+    }
+
     @Test("offset at the 1440-minute cap accepted, beyond it rejected")
     func offsetCap() throws {
         #expect(try CreateAutomation.validateTimeSpec("sunset+1440", flag: "--time-after") == "sunset+1440")

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -297,12 +297,12 @@ export const tools = [
         time_after: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Sun-relative time predicates ANDed into the trigger so it only fires after the given event. Format: "<sunrise|sunset>[±N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). On create_time these are gating predicates on top of the `time` trigger event, not the trigger itself. When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create / create_time actions)',
+          description: 'Time predicates ANDed into the trigger so it only fires after the given time. Same vocabulary as the `time` field: "HH:MM" for a wall-clock time (zero-padded, e.g. "07:00") or "<sunrise|sunset>[±N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["07:00"] + time_before=["20:30"] for "only during the day", or time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). On create_time these are gating predicates on top of the `time` trigger event, not the trigger itself. When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create / create_time actions)',
         },
         time_before: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Sun-relative time predicates ANDed into the trigger so it only fires before the given event. Same format and offset rules as time_after. (create / create_time actions)',
+          description: 'Time predicates ANDed into the trigger so it only fires before the given time. Same format and offset rules as time_after. (create / create_time actions)',
         },
         duration_seconds: {
           type: 'integer',

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -21109,12 +21109,12 @@ var tools = [
         time_after: {
           type: "array",
           items: { type: "string" },
-          description: 'Sun-relative time predicates ANDed into the trigger so it only fires after the given event. Format: "<sunrise|sunset>[\xB1N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). On create_time these are gating predicates on top of the `time` trigger event, not the trigger itself. When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create / create_time actions)'
+          description: 'Time predicates ANDed into the trigger so it only fires after the given time. Same vocabulary as the `time` field: "HH:MM" for a wall-clock time (zero-padded, e.g. "07:00") or "<sunrise|sunset>[\xB1N]" where N is minutes (e.g., "sunset-30", "sunrise+15", "sunset"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=["07:00"] + time_before=["20:30"] for "only during the day", or time_after=["sunset-30"] + time_before=["sunrise+15"] for "between dusk and dawn"). On create_time these are gating predicates on top of the `time` trigger event, not the trigger itself. When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create / create_time actions)'
         },
         time_before: {
           type: "array",
           items: { type: "string" },
-          description: "Sun-relative time predicates ANDed into the trigger so it only fires before the given event. Same format and offset rules as time_after. (create / create_time actions)"
+          description: "Time predicates ANDed into the trigger so it only fires before the given time. Same format and offset rules as time_after. (create / create_time actions)"
         },
         duration_seconds: {
           type: "integer",


### PR DESCRIPTION
Fixes #81, reported by @deltro68 with an unusually good root-cause analysis — it was correct on every point.

## Problem

`time_after` / `time_before` (CLI `--time-after` / `--time-before`, the socket API, and the `homekit_automations` MCP tool) only accepted `sunrise` / `sunset`. Passing a clock time was rejected:

```
Invalid 'time_after' value '07:00'. Use sunrise/sunset with optional ±N minutes (e.g. 'sunset-30').
```

So you couldn't gate a characteristic-triggered automation to a fixed time-of-day window — motion → scene, but only between 07:00 and 20:30. HomeKit supports it; it just wasn't wired up.

## Root cause

- `TimeCondition.parse` only recognized strings starting with `sunrise` / `sunset`.
- `TimeCondition.predicate()` only built the significant-event predicate. HomeKit's sibling factories for exact clock times (`predicateForEvaluatingTriggerOccurringAfterDateWithComponents:` / `...Before...`) were never used for conditions — even though `TimeSpec` already had the clock-time machinery for `--time` *triggers*.

## Fix

Rather than teach a third parser about `HH:MM`, this collapses the duplicates so they can't drift:

- **`TimeCondition` now wraps a `TimeSpec`.** One Swift-side grammar for both the trigger event and its gating conditions. Clock conditions emit `predicateForEvaluatingTrigger(occurringAfter:/occurringBefore:)` with `DateComponents(hour:minute:)`; sun conditions are unchanged.
- **CLI `validateTimeOfDaySpec` delegates to `validateTimeSpec`.** One CLI-side grammar; errors still name the offending flag (`--time`, `--time-after`, `--time-before`).
- **Three copies of the echo rendering** collapse into `TimeCondition.canonicalString` + `HomeKitManager.timeEchoes` (was `demoTimeEchoes`, now shared by the real and demo create paths).

The read side needed no change — `AccessoryModel.extractConditions` already decoded clock-time predicates (landed with #65), so these round-trip.

Net: **144 insertions, 171 deletions.**

## Verification

Live, against a real home on a locally installed release build:

```
$ homeclaw-cli automations create --name "..." \
    --accessory <contact sensor> --characteristic contact_state --trigger-value 1 \
    --action "<light>:power:true" --time-after 07:00 --time-before 20:30

$ homeclaw-cli automations get <id> --json
 condition: {"type": "weekdays", "weekdays": [1,2,3,4,5,6,7], ...}
 condition: {"type": "time", "relation": "after",  "time": "07:00", "summary": "after 07:00"}
 condition: {"type": "time", "relation": "before", "time": "20:30", "summary": "before 20:30"}
```

The predicate persists through HomeKit and decodes back with the correct relations (confirming the read-side relation inference isn't inverted). Test automation and its inline scene were deleted afterward.

Also confirmed:
- `--time-after 7:00` → `Hour must be exactly two digits (e.g. '06:30', not '6:30')` — the strict zero-padding rule carries over from `--time`, so `12:5` can't silently mean `12:50`.
- `--time-after noon` → lists all valid forms.
- Clock and sun conditions mix freely (`--time-after sunset-30 --time-before 23:00`).
- Weekday auto-fill still applies (iOS 15+ marks unweekdayed time-conditional automations unreliable).

175 SPM tests pass; Catalyst build clean with zero warnings. New CLI tests cover clock acceptance plus the strictness rules; the old "HH:MM is NOT valid here" test is inverted since that's now the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)