### PR TITLE
fix(control): address a single service and fail unapplied writes (#85)

### DIFF
--- a/Sources/homeclaw-cli/Commands/SetCommand.swift
+++ b/Sources/homeclaw-cli/Commands/SetCommand.swift
@@ -15,11 +15,23 @@ struct Set: ParsableCommand {
     @Argument(help: "Value to set (e.g., true, 75, locked)")
     var value: String
 
-    @Option(name: .long, help: "Target a specific service by UUID when the characteristic exists on multiple services")
+    @Option(name: .long, help: "Target services by service type UUID when the characteristic exists on multiple services")
     var serviceType: String?
+
+    @Option(name: .long, help: "Target one service by its name or service UUID (use for multi-gang switches, where every channel shares a service type)")
+    var serviceName: String?
+
+    @Option(name: .long, help: "Target one service by its unique UUID (the service_id shown in the ambiguity error and in `get --json`)")
+    var serviceID: String?
+
+    @Option(name: .long, help: "Target one service by its channel number (ServiceLabelIndex), e.g. 1 for the first gang")
+    var serviceIndex: Int?
 
     @Flag(name: .long, help: "Validate without writing to the device")
     var dryRun = false
+
+    @Flag(name: .long, help: "Accept the write without reading the value back (skips the check that the device actually changed)")
+    var noVerify = false
 
     @Flag(name: .long, help: "Output raw JSON")
     var json = false
@@ -28,6 +40,8 @@ struct Set: ParsableCommand {
         if let err = validateInput(accessory, label: "accessory") { throw ValidationError(err) }
         if let err = validateInput(characteristic, label: "characteristic") { throw ValidationError(err) }
         if let err = validateInput(value, label: "value") { throw ValidationError(err) }
+        if let serviceName, let err = validateInput(serviceName, label: "service-name") { throw ValidationError(err) }
+        if let serviceID, let err = validateInput(serviceID, label: "service-id") { throw ValidationError(err) }
 
         var args: [String: String] = [
             "id": accessory,
@@ -35,7 +49,11 @@ struct Set: ParsableCommand {
             "value": value,
         ]
         if let serviceType { args["service_type"] = serviceType }
+        if let serviceName { args["service_name"] = serviceName }
+        if let serviceID { args["service_id"] = serviceID }
+        if let serviceIndex { args["service_index"] = String(serviceIndex) }
         if dryRun { args["dry_run"] = "true" }
+        if noVerify { args["verify"] = "false" }
 
         let response = try SocketClient.send(
             command: "control",
@@ -57,7 +75,16 @@ struct Set: ParsableCommand {
                 let current = data["current_value"] as? String ?? "?"
                 print("Dry run: \(name).\(characteristic) = \(current) -> \(value) (valid)")
             } else if let name = data["name"] as? String {
-                print("Set \(name).\(characteristic) = \(value)")
+                // Name the service too when it adds information, so a multi-gang write
+                // says which channel it hit.
+                let written = (data["service"] as? [String: Any])?["name"] as? String
+                let serviceLabel = (written == nil || written == name) ? "" : ".\(written ?? "")"
+                print("Set \(name)\(serviceLabel).\(characteristic) = \(value)")
+                // An unapplied write comes back as a failed response, so reaching here
+                // means the write landed or could not be checked. Say which.
+                if let reason = data["verification_skipped"] as? String, reason == "read_failed" {
+                    print("Note: could not read the value back to confirm the change.")
+                }
             } else {
                 print("Done.")
             }

--- a/Sources/homeclaw/HomeKit/AccessoryModel.swift
+++ b/Sources/homeclaw/HomeKit/AccessoryModel.swift
@@ -152,11 +152,17 @@ enum AccessoryModel {
                 chars.append(charDict)
             }
 
-            services.append([
+            // `id` and `index` are what `control` accepts as service_id / service_index to
+            // target one channel of a multi-gang accessory, where `type` is identical
+            // across channels and `name` may repeat.
+            var serviceDict: [String: Any] = [
+                "id": service.uniqueIdentifier.uuidString,
                 "name": service.name,
                 "type": service.serviceType,
                 "characteristics": chars,
-            ])
+            ]
+            if let index = serviceLabelIndex(of: service) { serviceDict["index"] = index }
+            services.append(serviceDict)
         }
         dict["services"] = services
 
@@ -819,6 +825,11 @@ enum AccessoryModel {
     /// Reads the ServiceLabelIndex value from the same service as the given characteristic.
     private static func serviceIndexForCharacteristic(_ characteristic: HMCharacteristic) -> Int? {
         guard let service = characteristic.service else { return nil }
+        return serviceLabelIndex(of: service)
+    }
+
+    /// The ServiceLabelIndex value of a service — which physical channel/button it is.
+    static func serviceLabelIndex(of service: HMService) -> Int? {
         guard let indexChar = service.characteristics.first(where: { $0.characteristicType == CharacteristicMapper.serviceLabelIndexType }),
               let value = indexChar.value as? NSNumber
         else { return nil }

--- a/Sources/homeclaw/HomeKit/DemoFixtures.swift
+++ b/Sources/homeclaw/HomeKit/DemoFixtures.swift
@@ -174,9 +174,10 @@ enum DemoFixtures {
         // Match the real control response shape. Demo accessories are single-service,
         // so there is nothing to disambiguate and the write always "lands" — but the
         // fields have to be present or demo output would look like an older build.
+        // The caller fills in verified / verification_skipped, since only it knows
+        // whether verification was asked for.
         result["characteristic"] = characteristic
         result["value"] = value
-        result["verified"] = true
         result["service"] = ["id": acc.id, "name": acc.name, "type": acc.category]
         return result
     }

--- a/Sources/homeclaw/HomeKit/DemoFixtures.swift
+++ b/Sources/homeclaw/HomeKit/DemoFixtures.swift
@@ -170,7 +170,15 @@ enum DemoFixtures {
         var current = state(for: id)
         current[characteristic] = value
         accessoryState[id] = current
-        return acc.summaryDict(roomName: roomName(for: acc.roomID), state: current)
+        var result = acc.summaryDict(roomName: roomName(for: acc.roomID), state: current)
+        // Match the real control response shape. Demo accessories are single-service,
+        // so there is nothing to disambiguate and the write always "lands" — but the
+        // fields have to be present or demo output would look like an older build.
+        result["characteristic"] = characteristic
+        result["value"] = value
+        result["verified"] = true
+        result["service"] = ["id": acc.id, "name": acc.name, "type": acc.category]
+        return result
     }
 
     // MARK: - Search / device map (read derivations)

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -550,8 +550,15 @@ final class HomeKitManager: NSObject, Observable {
         await waitForReady()
 
         if Self.isDemoMode {
-            guard let result = DemoFixtures.control(id: id, characteristic: characteristic, value: value) else {
+            guard var result = DemoFixtures.control(id: id, characteristic: characteristic, value: value) else {
                 throw ControlError.accessoryNotFound(id)
+            }
+            // Demo writes always land, but honor `verify` so an explicitly unverified
+            // write doesn't come back claiming it was confirmed by a readback.
+            if verify {
+                result["verified"] = true
+            } else {
+                result["verification_skipped"] = "disabled"
             }
             scheduleMenuDataPush()
             return result
@@ -715,22 +722,33 @@ final class HomeKitManager: NSObject, Observable {
     /// immediate read would report a false failure.
     private static let verifyAttempts = 3
     private static let verifyRetryDelay: Duration = .milliseconds(250)
+    /// Verification runs on top of a full `readInterestingValues` refresh, inside a
+    /// control call that clients give ~30s. Retrying at the 6s `readTimeout` used for
+    /// normal reads could blow that budget and turn an applied write into a request
+    /// timeout — the failure mode of issue #66 — so verification reads get a much
+    /// tighter per-read ceiling and an overall wall-clock cap on top of it.
+    private static let verifyReadTimeout: TimeInterval = 1.5
+    private static let verifyBudget: Duration = .seconds(3)
 
     private func confirmWrite(
         of parsedValue: Any, on characteristic: HMCharacteristic
     ) async -> WriteVerification {
         let step = characteristic.metadata?.stepValue?.doubleValue
+        let deadline = ContinuousClock.now + Self.verifyBudget
         var anyReadSucceeded = false
         for attempt in 0..<Self.verifyAttempts {
             if attempt > 0 {
+                guard ContinuousClock.now < deadline else { break }
                 try? await Task.sleep(for: Self.verifyRetryDelay)
             }
-            let readSucceeded = await readValueWithTimeout(characteristic)
+            let readSucceeded = await readValueWithTimeout(
+                characteristic, timeout: Self.verifyReadTimeout
+            )
             anyReadSucceeded = anyReadSucceeded || readSucceeded
-            guard readSucceeded else { continue }
-            if Self.valuesMatch(characteristic.value, parsedValue, step: step) {
+            if readSucceeded, Self.valuesMatch(characteristic.value, parsedValue, step: step) {
                 return .matched
             }
+            guard ContinuousClock.now < deadline else { break }
         }
         guard anyReadSucceeded else { return .unreadable }
         let actual = characteristic.value.map {
@@ -3581,8 +3599,9 @@ final class HomeKitManager: NSObject, Observable {
     /// `characteristic.value` now holds a fresh device read. On false the cached
     /// value is stale and callers must not treat it as evidence of anything.
     @discardableResult
-    private func readValueWithTimeout(_ characteristic: HMCharacteristic) async -> Bool {
-        let timeout = Self.readTimeout
+    private func readValueWithTimeout(
+        _ characteristic: HMCharacteristic, timeout: TimeInterval = HomeKitManager.readTimeout
+    ) async -> Bool {
         let logger = AppLogger.homekit
         // One-shot guard: whichever of the HomeKit completion or the timer fires
         // first resumes the continuation; the loser is a no-op.

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -505,6 +505,7 @@ final class HomeKitManager: NSObject, Observable {
         case sceneNotFound(String)
         case serviceNotFound(String)
         case invalidArgument(String)
+        case writeNotApplied(String)
 
         var errorDescription: String? {
             switch self {
@@ -515,7 +516,12 @@ final class HomeKitManager: NSObject, Observable {
             case .invalidValue(let detail): "Invalid value: \(detail)"
             case .writeFailed(let detail): "Write failed: \(detail)"
             case .ambiguousCharacteristic(let name, let options):
-                "Ambiguous: '\(name)' exists on multiple services. Use service_type to disambiguate:\n\(options)"
+                """
+                Ambiguous: '\(name)' exists on multiple services. \
+                Pass service_name, service_index, or service_id to pick one \
+                (service_type is identical across channels on multi-gang accessories):
+                \(options)
+                """
             case .homeNotFound(let id): "Home not found: \(id)"
             case .roomNotFound(let id): "Room not found: \(id)"
             case .zoneNotFound(let id): "Zone not found: \(id)"
@@ -523,11 +529,24 @@ final class HomeKitManager: NSObject, Observable {
             case .sceneNotFound(let id): "Scene not found: \(id)"
             case .serviceNotFound(let detail): "Service not found: \(detail)"
             case .invalidArgument(let detail): "Invalid argument: \(detail)"
+            case .writeNotApplied(let detail):
+                "Write not applied: \(detail). Pass verify=false to accept unconfirmed writes."
             }
         }
     }
 
-    func controlAccessory(id: String, characteristic: String, value: String, homeID: String? = nil, serviceType: String? = nil, dryRun: Bool = false) async throws -> [String: Any] {
+    func controlAccessory(
+        id: String,
+        characteristic: String,
+        value: String,
+        homeID: String? = nil,
+        serviceType: String? = nil,
+        serviceName: String? = nil,
+        serviceID: String? = nil,
+        serviceIndex: Int? = nil,
+        dryRun: Bool = false,
+        verify: Bool = true
+    ) async throws -> [String: Any] {
         await waitForReady()
 
         if Self.isDemoMode {
@@ -550,14 +569,32 @@ final class HomeKitManager: NSObject, Observable {
 
         // Find the characteristic by human-readable name or UUID
         let hmCharacteristic: HMCharacteristic
-        switch findCharacteristic(named: characteristic, on: accessory, serviceType: serviceType) {
-        case .found(let c, _):
+        let targetService: ServiceDescriptor
+        switch findCharacteristic(
+            named: characteristic,
+            on: accessory,
+            serviceType: serviceType,
+            serviceName: serviceName,
+            serviceID: serviceID,
+            serviceIndex: serviceIndex
+        ) {
+        case .found(let c, _, let service):
             hmCharacteristic = c
+            targetService = service
         case .notFound:
             throw ControlError.characteristicNotFound(characteristic)
-        case .ambiguous(let matches):
-            let options = matches.map { "  - service_type: \($0.serviceType) (service: \($0.service))" }.joined(separator: "\n")
+        case .ambiguous(let services):
+            let options = services.map(\.selectorHint).joined(separator: "\n")
             throw ControlError.ambiguousCharacteristic(characteristic, options)
+        case .noServiceMatched(let services):
+            let options = services.map(\.selectorHint).joined(separator: "\n")
+            throw ControlError.serviceNotFound(
+                """
+                No service on '\(accessory.name)' matches the given selectors. \
+                '\(characteristic)' is on:
+                \(options)
+                """
+            )
         }
 
         // Check writability via properties
@@ -583,6 +620,7 @@ final class HomeKitManager: NSObject, Observable {
                 "current_value": currentValue,
                 "new_value": value,
                 "parsed_value": "\(parsedValue)",
+                "service": targetService.dictionary,
             ]
             if let home = findHome(for: accessory) {
                 result["home"] = home.name
@@ -594,7 +632,9 @@ final class HomeKitManager: NSObject, Observable {
         do {
             try await hmCharacteristic.writeValue(parsedValue)
             let home = findHome(for: accessory)
-            AppLogger.homekit.info("[\(home?.name ?? "?")] Set \(accessory.name).\(characteristic) = \(value)")
+            AppLogger.homekit.info(
+                "[\(home?.name ?? "?")] Set \(accessory.name).\(targetService.name).\(characteristic) = \(value)"
+            )
             HomeEventLogger.shared.logAccessoryControlled(
                 accessoryID: accessory.uniqueIdentifier.uuidString,
                 accessoryName: accessory.name,
@@ -607,18 +647,113 @@ final class HomeKitManager: NSObject, Observable {
             throw ControlError.writeFailed("\(error.localizedDescription)")
         }
 
-        // Read back current values, update cache, and return updated state
+        // Refresh the accessory, then confirm the written characteristic last so its
+        // outcome is the authoritative one behind `verified`. The explicit read is
+        // needed on top of `readInterestingValues` because that only refreshes the
+        // subset it considers interesting, and it discards whether a read succeeded.
         await readInterestingValues(for: accessory)
+        let isReadable = hmCharacteristic.properties.contains(HMCharacteristicPropertyReadable)
+        let verification = verify && isReadable
+            ? await confirmWrite(of: parsedValue, on: hmCharacteristic)
+            : nil
         updateCacheFromAccessory(accessory)
+
+        // The whole point of issue #85: HomeKit accepted the write and the device did
+        // not change. Returning success here is what made the failure silent for every
+        // automation built on top, so this is an error, not a note in the payload.
+        if case .mismatched(let actual) = verification {
+            throw ControlError.writeNotApplied(
+                "\(accessory.name).\(targetService.name).\(characteristic) still reads \(actual) after writing \(value)"
+            )
+        }
+
         let bridgeMetadata = BridgeMetadata(
             homes: findHome(for: accessory).map { [$0] } ?? filteredHomes(homeID: homeID),
             isAccessoryVisible: isAccessoryAllowed
         )
-        return AccessoryModel.accessorySummary(
+        var result = AccessoryModel.accessorySummary(
             accessory,
             bridge: bridgeMetadata.bridgeSummary(for: accessory),
             bridgedAccessoryIDs: bridgeMetadata.bridgedAccessoryIDs(for: accessory)
         )
+
+        // The summary's flat `state` map keys on characteristic name, so on a multi-gang
+        // accessory every channel collapses into one entry and the caller can't tell
+        // which channel was written. Report the targeted service and its post-write
+        // readback explicitly.
+        result["characteristic"] = characteristic
+        result["service"] = targetService.dictionary
+        if let current = hmCharacteristic.value {
+            result["value"] = CharacteristicMapper.formatValue(
+                current, for: hmCharacteristic.characteristicType
+            )
+        }
+        // A mismatch already threw above, so the only outcomes left are "confirmed" and
+        // "couldn't tell". Never report the second as the first: a write-only
+        // characteristic, a failed read, or an explicit opt-out says so by name.
+        switch verification {
+        case .matched:
+            result["verified"] = true
+        case .unreadable:
+            result["verification_skipped"] = "read_failed"
+        default:
+            result["verification_skipped"] = verify ? "not_readable" : "disabled"
+        }
+        return result
+    }
+
+    /// Outcome of reading a characteristic back after writing it.
+    private enum WriteVerification {
+        case matched
+        case mismatched(String)
+        /// No fresh read came back, so nothing can be concluded.
+        case unreadable
+    }
+
+    /// How many times to re-read before declaring a write unapplied. Some accessories
+    /// acknowledge a write and only publish the new value a moment later, so a single
+    /// immediate read would report a false failure.
+    private static let verifyAttempts = 3
+    private static let verifyRetryDelay: Duration = .milliseconds(250)
+
+    private func confirmWrite(
+        of parsedValue: Any, on characteristic: HMCharacteristic
+    ) async -> WriteVerification {
+        let step = characteristic.metadata?.stepValue?.doubleValue
+        var anyReadSucceeded = false
+        for attempt in 0..<Self.verifyAttempts {
+            if attempt > 0 {
+                try? await Task.sleep(for: Self.verifyRetryDelay)
+            }
+            let readSucceeded = await readValueWithTimeout(characteristic)
+            anyReadSucceeded = anyReadSucceeded || readSucceeded
+            guard readSucceeded else { continue }
+            if Self.valuesMatch(characteristic.value, parsedValue, step: step) {
+                return .matched
+            }
+        }
+        guard anyReadSucceeded else { return .unreadable }
+        let actual = characteristic.value.map {
+            CharacteristicMapper.formatValue($0, for: characteristic.characteristicType)
+        } ?? "unknown"
+        return .mismatched(actual)
+    }
+
+    /// Compares a post-write readback against the value we asked HomeKit to write.
+    ///
+    /// Numbers get a tolerance of *half* the characteristic's step: an accessory that
+    /// snaps a write to its step grid lands within half a step, while a value that
+    /// never changed sits a full step or more away. A full-step tolerance would call
+    /// brightness 0 a successful write of brightness 1. Everything else is compared by
+    /// string description.
+    static func valuesMatch(_ readBack: Any?, _ written: Any, step: Double? = nil) -> Bool {
+        guard let readBack else { return false }
+        if let a = readBack as? NSNumber, let b = written as? NSNumber {
+            // Bools bridge to NSNumber too, and there `1 == true` is exactly what we want.
+            let tolerance = max((step ?? 0) / 2, 0.0001)
+            return abs(a.doubleValue - b.doubleValue) <= tolerance
+        }
+        return String(describing: readBack) == String(describing: written)
     }
 
     // MARK: - Scenes
@@ -3441,20 +3576,25 @@ final class HomeKitManager: NSObject, Observable {
     /// read otherwise stalls every later request: the "first call fast, later
     /// calls balloon to ~95s / hang" signature in the bug report. A timed-out
     /// read simply leaves the previously cached `characteristic.value` in place.
-    private func readValueWithTimeout(_ characteristic: HMCharacteristic) async {
+    ///
+    /// Returns true only when HomeKit answered without an error, i.e. when
+    /// `characteristic.value` now holds a fresh device read. On false the cached
+    /// value is stale and callers must not treat it as evidence of anything.
+    @discardableResult
+    private func readValueWithTimeout(_ characteristic: HMCharacteristic) async -> Bool {
         let timeout = Self.readTimeout
         let logger = AppLogger.homekit
         // One-shot guard: whichever of the HomeKit completion or the timer fires
         // first resumes the continuation; the loser is a no-op.
         let guardBox = ReadResumeGuard()
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             // Cancellable timer leg: when HomeKit responds before the deadline we
             // cancel it, so a large readAllValues loop (50–100+ characteristics)
             // doesn't leave a burst of no-op main-thread wakeups draining 6s later.
             let timerWork = DispatchWorkItem {
                 guard guardBox.claim() else { return }
                 logger.warning("readValue timed out after \(timeout, format: .fixed(precision: 0))s; serving last-known value")
-                continuation.resume()
+                continuation.resume(returning: false)
             }
             characteristic.readValue { error in
                 timerWork.cancel()
@@ -3462,7 +3602,7 @@ final class HomeKitManager: NSObject, Observable {
                 if let error {
                     logger.debug("readValue failed: \(error.localizedDescription, privacy: .public)")
                 }
-                continuation.resume()
+                continuation.resume(returning: error == nil)
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: timerWork)
         }
@@ -3548,45 +3688,150 @@ final class HomeKitManager: NSObject, Observable {
         return nil
     }
 
+    /// Identifying details for a single service, used to disambiguate characteristics
+    /// that appear on several services of the same accessory (multi-gang switches,
+    /// multi-button remotes) and to describe the service a write landed on.
+    struct ServiceDescriptor {
+        let name: String
+        let type: String
+        let id: String
+        let index: Int?
+
+        init(_ service: HMService) {
+            name = service.name
+            type = service.serviceType
+            id = service.uniqueIdentifier.uuidString
+            index = Self.labelIndex(of: service)
+        }
+
+        /// The ServiceLabelIndex value, i.e. which physical channel/button this is.
+        /// Multi-gang accessories expose it; single-service accessories usually don't.
+        static func labelIndex(of service: HMService) -> Int? {
+            AccessoryModel.serviceLabelIndex(of: service)
+        }
+
+        /// One line describing how to address this specific service.
+        var selectorHint: String {
+            var parts = ["service_name: \"\(name)\""]
+            if let index { parts.append("service_index: \(index)") }
+            parts.append("service_id: \(id)")
+            parts.append("service_type: \(type)")
+            return "  - " + parts.joined(separator: ", ")
+        }
+
+        var dictionary: [String: Any] {
+            var dict: [String: Any] = ["name": name, "type": type, "id": id]
+            if let index { dict["index"] = index }
+            return dict
+        }
+    }
+
     /// Result of a characteristic lookup, which may be ambiguous.
     enum CharacteristicLookup {
-        case found(HMCharacteristic, String)
-        case ambiguous([(service: String, serviceType: String, characteristicName: String)])
+        case found(HMCharacteristic, String, ServiceDescriptor)
+        case ambiguous([ServiceDescriptor])
         case notFound
+        /// The characteristic exists on the accessory, but the service selectors
+        /// excluded every service carrying it. Carries the services that do have it,
+        /// so the error can say what the caller could have asked for.
+        case noServiceMatched([ServiceDescriptor])
+    }
+
+    /// True when `characteristic` is addressed by `name`, given either as its
+    /// human-readable name (`power`) or its type UUID.
+    private static func characteristic(_ characteristic: HMCharacteristic, matches name: String) -> Bool {
+        CharacteristicMapper.name(for: characteristic.characteristicType)
+            .localizedCaseInsensitiveCompare(name) == .orderedSame
+            || characteristic.characteristicType.localizedCaseInsensitiveCompare(name) == .orderedSame
+    }
+
+    /// True when `service` matches every caller-supplied selector. An unset selector
+    /// matches everything, so selectors combine with AND.
+    ///
+    /// `name` also accepts the service's UUID, so a caller that pasted the wrong field
+    /// out of the ambiguity error still lands on the right service; `id` matches the
+    /// UUID only.
+    private func serviceMatches(
+        _ service: HMService, type: String?, name: String?, id: String?, index: Int?
+    ) -> Bool {
+        let uuid = service.uniqueIdentifier.uuidString
+        if let type, service.serviceType.localizedCaseInsensitiveCompare(type) != .orderedSame {
+            return false
+        }
+        if let id, uuid.localizedCaseInsensitiveCompare(id) != .orderedSame {
+            return false
+        }
+        if let name {
+            let matchesName = service.name.localizedCaseInsensitiveCompare(name) == .orderedSame
+            let matchesID = uuid.localizedCaseInsensitiveCompare(name) == .orderedSame
+            if !matchesName && !matchesID { return false }
+        }
+        if let index, ServiceDescriptor.labelIndex(of: service) != index {
+            return false
+        }
+        return true
     }
 
     /// Find a characteristic on an accessory by human-readable name or UUID.
-    /// When `serviceType` is provided, only matches within that service.
-    /// When nil and multiple services have a matching characteristic, returns `.ambiguous`.
+    ///
+    /// The optional `serviceType` / `serviceName` / `serviceID` / `serviceIndex`
+    /// selectors narrow the search to one service. Multi-gang switches expose several
+    /// services that share a `serviceType`, so `serviceType` alone cannot pick a
+    /// channel — `serviceName`, `serviceID`, or `serviceIndex` (ServiceLabelIndex) can.
+    ///
+    /// Returns `.ambiguous` whenever the surviving matches span more than one service,
+    /// rather than silently writing to whichever service happens to come first.
     private func findCharacteristic(
-        named name: String, on accessory: HMAccessory, serviceType: String? = nil
+        named name: String,
+        on accessory: HMAccessory,
+        serviceType: String? = nil,
+        serviceName: String? = nil,
+        serviceID: String? = nil,
+        serviceIndex: Int? = nil
     ) -> CharacteristicLookup {
-        var matches: [(characteristic: HMCharacteristic, humanName: String, serviceName: String, serviceType: String)] = []
+        var matches: [(characteristic: HMCharacteristic, humanName: String, service: HMService)] = []
 
         for service in accessory.services {
-            if let filter = serviceType, service.serviceType.localizedCaseInsensitiveCompare(filter) != .orderedSame { continue }
-            for characteristic in service.characteristics {
-                let humanName = CharacteristicMapper.name(for: characteristic.characteristicType)
-                if humanName.localizedCaseInsensitiveCompare(name) == .orderedSame
-                    || characteristic.characteristicType == name
-                {
-                    matches.append((characteristic, humanName, service.name, service.serviceType))
-                }
+            guard serviceMatches(
+                service, type: serviceType, name: serviceName, id: serviceID, index: serviceIndex
+            ) else { continue }
+            for characteristic in service.characteristics
+            where Self.characteristic(characteristic, matches: name) {
+                matches.append((
+                    characteristic,
+                    CharacteristicMapper.name(for: characteristic.characteristicType),
+                    service
+                ))
             }
         }
 
-        switch matches.count {
-        case 0:
-            return .notFound
-        case 1:
-            return .found(matches[0].characteristic, matches[0].humanName)
-        default:
-            if serviceType != nil {
-                // Filter was provided but still matched multiple in the same service — take first
-                return .found(matches[0].characteristic, matches[0].humanName)
+        guard let first = matches.first else {
+            // Distinguish "this accessory has no such characteristic" from "your
+            // selectors excluded the service(s) that do have it" — the second one is a
+            // fixable mistake and deserves to say so.
+            let hadSelector = serviceType != nil || serviceName != nil || serviceID != nil || serviceIndex != nil
+            guard hadSelector else { return .notFound }
+            let carriers = accessory.services.filter { service in
+                service.characteristics.contains { Self.characteristic($0, matches: name) }
             }
-            return .ambiguous(matches.map { (service: $0.serviceName, serviceType: $0.serviceType, characteristicName: $0.humanName) })
+            guard !carriers.isEmpty else { return .notFound }
+            return .noServiceMatched(carriers.map(ServiceDescriptor.init))
         }
+
+        // Only a spread across *different* services is ambiguous. Two matches inside a
+        // single service (same characteristic listed twice, aliased names) are equivalent
+        // for writing purposes, so the first is fine.
+        let distinctServices = Set(matches.map(\.service.uniqueIdentifier))
+        guard distinctServices.count > 1 else {
+            return .found(first.characteristic, first.humanName, ServiceDescriptor(first.service))
+        }
+
+        var seen: Set<UUID> = []
+        let descriptors = matches.compactMap { match -> ServiceDescriptor? in
+            guard seen.insert(match.service.uniqueIdentifier).inserted else { return nil }
+            return ServiceDescriptor(match.service)
+        }
+        return .ambiguous(descriptors)
     }
 }
 

--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -21,6 +21,31 @@ final class SocketServer: @unchecked Sendable {
     private var intentionallyStopped = false
     private let watchdogInterval: TimeInterval = 30
 
+    /// Reads an integer argument, rejecting values that would otherwise be coerced
+    /// into a plausible-but-wrong selector. Returns nil only when the key is absent;
+    /// a present-but-malformed value throws so it can never be silently dropped
+    /// (dropping a service selector would send the write to a different channel).
+    private func parseInt(_ args: [String: Any], key: String) throws -> Int? {
+        guard let raw = args[key] else { return nil }
+        if let nsNum = raw as? NSNumber {
+            // JSON booleans bridge to NSNumber and `as? Int` turns `true` into 1.
+            guard CFGetTypeID(nsNum) != CFBooleanGetTypeID() else {
+                throw HomeKitManager.ControlError.invalidArgument("\(key) must be an integer, got a boolean")
+            }
+            guard let int = nsNum as? Int else {
+                throw HomeKitManager.ControlError.invalidArgument("\(key) must be a whole number, got \(nsNum)")
+            }
+            return int
+        }
+        if let string = raw as? String {
+            guard let int = Int(string) else {
+                throw HomeKitManager.ControlError.invalidArgument("\(key) must be a whole number, got '\(string)'")
+            }
+            return int
+        }
+        throw HomeKitManager.ControlError.invalidArgument("\(key) must be a whole number")
+    }
+
     /// Parse a boolean wire arg, distinguishing absent from present-but-unparseable.
     ///
     /// Accepts:
@@ -519,7 +544,11 @@ final class SocketServer: @unchecked Sendable {
                     id: id, characteristic: characteristic, value: value,
                     homeID: args["home_id"] as? String,
                     serviceType: args["service_type"] as? String,
-                    dryRun: parseBool(args, key: "dry_run")
+                    serviceName: args["service_name"] as? String,
+                    serviceID: args["service_id"] as? String,
+                    serviceIndex: try parseInt(args, key: "service_index"),
+                    dryRun: parseBool(args, key: "dry_run"),
+                    verify: parseBool(args, key: "verify", default: true)
                 )
 
             case "list_rooms":

--- a/Tests/homeclaw-cliTests/CommandParsingTests.swift
+++ b/Tests/homeclaw-cliTests/CommandParsingTests.swift
@@ -114,6 +114,48 @@ struct SetCommandParsingTests {
     func missingValue() {
         #expect(throws: (any Error).self) { _ = try Set.parse(["Lamp", "power"]) }
     }
+
+    // Regression for issue #85: every channel of a multi-gang switch shares one
+    // service type, so --service-type alone can't pick a channel. --service-name
+    // and --service-index are the selectors that can.
+    @Test("--service-name and --service-index are parsed")
+    func perServiceSelectors() throws {
+        let cmd = try Set.parse(["Wall Switch", "power", "true", "--service-name", "Pendentes", "--service-index", "3"])
+        #expect(cmd.serviceName == "Pendentes")
+        #expect(cmd.serviceIndex == 3)
+        #expect(cmd.serviceType == nil)
+    }
+
+    @Test("service selectors default to nil")
+    func selectorsDefaultNil() throws {
+        let cmd = try Set.parse(["Lamp", "power", "on"])
+        #expect(cmd.serviceName == nil)
+        #expect(cmd.serviceIndex == nil)
+    }
+
+    // The ambiguity error tells users to retry with service_id, so the flag it names
+    // has to exist and resolve to exactly that spelling.
+    @Test("--service-id is parsed")
+    func serviceIDSelector() throws {
+        let cmd = try Set.parse(["Wall Switch", "power", "true", "--service-id", "B3E0-UUID"])
+        #expect(cmd.serviceID == "B3E0-UUID")
+        #expect(cmd.serviceName == nil)
+    }
+
+    @Test("--service-index rejects non-numeric input")
+    func serviceIndexMustBeNumeric() {
+        #expect(throws: (any Error).self) {
+            _ = try Set.parse(["Lamp", "power", "on", "--service-index", "first"])
+        }
+    }
+
+    // Verification is on by default; --no-verify is the opt-out for accessories whose
+    // readback is unreliable.
+    @Test("--no-verify defaults off and parses")
+    func noVerifyFlag() throws {
+        #expect(try Set.parse(["Lamp", "power", "on"]).noVerify == false)
+        #expect(try Set.parse(["Lamp", "power", "on", "--no-verify"]).noVerify == true)
+    }
 }
 
 // MARK: - scenes

--- a/lib/handlers/homekit.js
+++ b/lib/handlers/homekit.js
@@ -47,6 +47,10 @@ export async function handleAccessories(args) {
       };
       if (args.home_id) socketArgs.home_id = args.home_id;
       if (args.service_type) socketArgs.service_type = args.service_type;
+      if (args.service_name) socketArgs.service_name = args.service_name;
+      if (args.service_id) socketArgs.service_id = args.service_id;
+      if (args.verify === false) socketArgs.verify = 'false';
+      if (args.service_index != null) socketArgs.service_index = String(args.service_index);
       return sendCommand('control', socketArgs);
     }
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -53,7 +53,23 @@ export const tools = [
         },
         service_type: {
           type: 'string',
-          description: 'Service UUID to target when the characteristic exists on multiple services (control action). Required when an ambiguity error is returned.',
+          description: 'Service TYPE UUID to narrow the target when the characteristic exists on multiple services (control action). Note: every channel of a multi-gang switch shares one service type, so this alone cannot pick a channel — use service_name or service_index for that.',
+        },
+        service_name: {
+          type: 'string',
+          description: 'Name or unique UUID of the specific service to write to (control action). This is how you pick one channel of a multi-gang switch. Both values are listed in the ambiguity error and in the get action output.',
+        },
+        service_id: {
+          type: 'string',
+          description: 'Unique UUID of the specific service to write to (control action). Listed as `service_id` in the ambiguity error and as `id` per service in the get action output. Use this when two services share a name.',
+        },
+        service_index: {
+          type: 'number',
+          description: 'Channel number (ServiceLabelIndex) of the specific service to write to, e.g. 1 for the first gang (control action). Listed as `index` in the get action output when the accessory reports one.',
+        },
+        verify: {
+          type: 'boolean',
+          description: 'Default true (control action). After writing, the value is read back and a write the device did not apply is returned as an error rather than a success. Set false only for accessories whose readback is unreliable; the response then carries verification_skipped: "disabled".',
         },
         no_refresh: {
           type: 'boolean',

--- a/mcp-server/dist/server.js
+++ b/mcp-server/dist/server.js
@@ -20865,7 +20865,23 @@ var tools = [
         },
         service_type: {
           type: "string",
-          description: "Service UUID to target when the characteristic exists on multiple services (control action). Required when an ambiguity error is returned."
+          description: "Service TYPE UUID to narrow the target when the characteristic exists on multiple services (control action). Note: every channel of a multi-gang switch shares one service type, so this alone cannot pick a channel \u2014 use service_name or service_index for that."
+        },
+        service_name: {
+          type: "string",
+          description: "Name or unique UUID of the specific service to write to (control action). This is how you pick one channel of a multi-gang switch. Both values are listed in the ambiguity error and in the get action output."
+        },
+        service_id: {
+          type: "string",
+          description: "Unique UUID of the specific service to write to (control action). Listed as `service_id` in the ambiguity error and as `id` per service in the get action output. Use this when two services share a name."
+        },
+        service_index: {
+          type: "number",
+          description: "Channel number (ServiceLabelIndex) of the specific service to write to, e.g. 1 for the first gang (control action). Listed as `index` in the get action output when the accessory reports one."
+        },
+        verify: {
+          type: "boolean",
+          description: 'Default true (control action). After writing, the value is read back and a write the device did not apply is returned as an error rather than a success. Set false only for accessories whose readback is unreliable; the response then carries verification_skipped: "disabled".'
         },
         no_refresh: {
           type: "boolean",
@@ -21287,6 +21303,10 @@ async function handleAccessories(args) {
       };
       if (args.home_id) socketArgs.home_id = args.home_id;
       if (args.service_type) socketArgs.service_type = args.service_type;
+      if (args.service_name) socketArgs.service_name = args.service_name;
+      if (args.service_id) socketArgs.service_id = args.service_id;
+      if (args.verify === false) socketArgs.verify = "false";
+      if (args.service_index != null) socketArgs.service_index = String(args.service_index);
       return sendCommand("control", socketArgs);
     }
     default:

--- a/openclaw/skills/homekit/SKILL.md
+++ b/openclaw/skills/homekit/SKILL.md
@@ -68,6 +68,11 @@ homeclaw-cli set "<uuid>" target_heating_cooling auto  # HVAC: off/heat/cool/aut
 homeclaw-cli set "<uuid>" lock_target_state locked     # Locks: locked/unlocked
 homeclaw-cli set "<uuid>" target_position 100          # Blinds (0=closed, 100=open)
 
+# Multi-gang switches — one accessory, several channels sharing a service type
+homeclaw-cli set "<uuid>" power true --service-name "Pendentes"  # By service name
+homeclaw-cli set "<uuid>" power true --service-id "<service-uuid>"  # By service UUID (names can repeat)
+homeclaw-cli set "<uuid>" power true --service-index 2           # By channel number (ServiceLabelIndex)
+
 # Scenes
 homeclaw-cli scenes --json              # List all scenes
 homeclaw-cli get-scene "<name>" --json  # Full detail: all actions (accessory, room, characteristic, value)
@@ -145,6 +150,43 @@ The `type` field in the compact map tells you what a device IS. The `controls` a
 | `security` | Cameras, water shutoff | Varies: `active`, `power` |
 
 **Critical**: A device named "Closet Light" or "Under Cabinet" with `type: power` is a relay switch. Sending `brightness 50` will fail. Always check `controls` first.
+
+### Multi-Gang Switches and Multi-Button Remotes
+
+Some accessories expose the same characteristic on several services: a 3-gang wall switch has three `power` characteristics, one per channel. Every channel reports the **same** `service_type`, so `--service-type` cannot pick one.
+
+`set` refuses to guess. When a characteristic exists on more than one service it fails with an ambiguity error listing every candidate:
+
+```
+Ambiguous: 'power' exists on multiple services. Pass service_name, service_index, or service_id to pick one
+(service_type is identical across channels on multi-gang accessories):
+  - service_name: "Switch 1", service_index: 1, service_id: 5F2A..., service_type: 00000049-...
+  - service_name: "Switch 2", service_index: 2, service_id: 91C7..., service_type: 00000049-...
+  - service_name: "Pendentes", service_index: 3, service_id: B3E0..., service_type: 00000049-...
+```
+
+Passing selectors that match no service is a different error ("No service on '<name>' matches the given selectors") which lists the same candidates, so an over-constrained retry says so instead of claiming the characteristic doesn't exist.
+
+Copy one of those selectors into the retry. `homeclaw-cli get "<uuid>" --json` lists the same `id`, `name`, and `index` per service if you want them before writing.
+
+### Confirming a Write Landed
+
+`set` reads the characteristic back after writing and reports which service it hit:
+
+```json
+{ "characteristic": "power", "value": "true", "verified": true,
+  "service": { "id": "B3E0...", "name": "Pendentes", "type": "00000049-...", "index": 3 } }
+```
+
+If the device still reports the old value after a few re-reads, `set` **fails** rather than returning success. That is the point of the check: a write HomeKit accepted but the device ignored used to come back as `success: true`.
+
+```
+Write not applied: Wall Switch.Pendentes.power still reads false after writing true. Pass verify=false to accept unconfirmed writes.
+```
+
+When no verdict is possible the response carries `verification_skipped` instead: `not_readable` (a write-only characteristic), `read_failed` (the readback errored or timed out), or `disabled` (you passed `--no-verify` / `verify: false`). None of these mean the write failed, only that it could not be confirmed.
+
+Use `--no-verify` for accessories whose readback is unreliable. Verification already retries a few times, so a device that acknowledges a write and publishes the new value a moment later is not flagged.
 
 ## Event Log
 

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -377,7 +377,6 @@ const TOOLS: ToolDef[] = [
 				String(params.press ?? 'single'),
 			];
 			optionalFlag(args, '--service-index', params.service_index);
-			if (params.verify === false) args.push('--no-verify');
 			optionalFlag(args, '--dry-run', params.dry_run);
 			args.push('--json');
 			return args;

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -144,7 +144,31 @@ const TOOLS: ToolDef[] = [
 			service_type: Type.Optional(
 				Type.String({
 					description:
-						'Target a specific service by UUID when the characteristic exists on multiple services',
+						'Narrow to services of this TYPE UUID when the characteristic exists on multiple services. Every channel of a multi-gang switch shares one service type, so use service_name or service_index to pick a channel.',
+				})
+			),
+			service_name: Type.Optional(
+				Type.String({
+					description:
+						'Name or unique UUID of the specific service to write to. This is how you pick one channel of a multi-gang switch; both values appear in the ambiguity error and in homekit_get output.',
+				})
+			),
+			service_id: Type.Optional(
+				Type.String({
+					description:
+						'Unique UUID of the specific service to write to. Use when two services share a name; listed as service_id in the ambiguity error and as `id` per service in homekit_get output.',
+				})
+			),
+			service_index: Type.Optional(
+				Type.Number({
+					description:
+						'Channel number (ServiceLabelIndex) of the specific service to write to, e.g. 1 for the first gang.',
+				})
+			),
+			verify: Type.Optional(
+				Type.Boolean({
+					description:
+						'Default true. After writing, the value is read back and a write the device did not apply comes back as an error rather than a success. Set false only for accessories whose readback is unreliable.',
 				})
 			),
 			dry_run: Type.Optional(
@@ -159,6 +183,10 @@ const TOOLS: ToolDef[] = [
 				String(params.value),
 			];
 			optionalFlag(args, '--service-type', params.service_type);
+			optionalFlag(args, '--service-name', params.service_name);
+			optionalFlag(args, '--service-id', params.service_id);
+			optionalFlag(args, '--service-index', params.service_index);
+			if (params.verify === false) args.push('--no-verify');
 			optionalFlag(args, '--dry-run', params.dry_run);
 			args.push('--json');
 			return args;
@@ -349,6 +377,7 @@ const TOOLS: ToolDef[] = [
 				String(params.press ?? 'single'),
 			];
 			optionalFlag(args, '--service-index', params.service_index);
+			if (params.verify === false) args.push('--no-verify');
 			optionalFlag(args, '--dry-run', params.dry_run);
 			args.push('--json');
 			return args;


### PR DESCRIPTION
Fixes #85.

## The two defects

**1. A channel of a multi-gang switch could not be addressed.**

`findCharacteristic` filtered candidate services by `service_type` only, and when the filter still matched several services it took `matches[0]` and wrote to it silently:

```swift
if serviceType != nil {
    // Filter was provided but still matched multiple in the same service — take first
    return .found(matches[0].characteristic, matches[0].humanName)
}
```

The comment assumed the leftover matches were inside *one* service. On an Aqara S1E (3 gangs) all three `Switch` services report the **same** `serviceType` (`00000049-…`), so the filter narrowed nothing and every write landed on gang 1 regardless of which channel the caller meant. `service_type` was also the only field the ambiguity error printed, which is why the reporter saw three identical values and had nothing to disambiguate with.

**2. `control` reported the wrong state back.**

The response is `AccessoryModel.accessorySummary`, whose `state` is a flat `[characteristicName: value]` map. Three `power` characteristics collapse into one key, last service wins. So the response could show `power: "false"` immediately after a successful `power=true` write, and nothing in the payload said which channel was touched or whether the value stuck.

## The fix

**Address a single service.** `control` now accepts `service_name`, `service_id`, and `service_index` (ServiceLabelIndex) alongside `service_type`. Selectors combine with AND; `service_name` also accepts the service UUID so a pasted `service_id` still resolves.

**Never guess.** Matches spanning more than one service are always `.ambiguous`, filter or no filter — the silent first-match write is gone. Two matches *within* one service still resolve to the first, which is what the old comment intended. The error now prints every selector that can pick each candidate:

```
Ambiguous: 'power' exists on multiple services. Pass service_name, service_index, or service_id to pick one
(service_type is identical across channels on multi-gang accessories):
  - service_name: "Switch 1", service_index: 1, service_id: 5F2A…, service_type: 00000049-…
  - service_name: "Pendentes", service_index: 3, service_id: B3E0…, service_type: 00000049-…
```

**Fail when the write does not land.** After writing, `control` re-reads the characteristic (a few times, ~250ms apart, so a device that acknowledges then settles is not flagged). If the device still reports the old value, the command now **fails**:

```
Write not applied: Wall Switch.Pendentes.power still reads false after writing true.
Pass verify=false to accept unconfirmed writes.
```

That is the half of #85 that made the failure silent: an unapplied write reached automations as `success: true`. It is now an error at every layer — `success: false` on the socket, a non-zero exit from the CLI, an error result from MCP.

A success carries the evidence:

```json
{ "characteristic": "power", "value": "true", "verified": true,
  "service": { "id": "B3E0…", "name": "Pendentes", "type": "00000049-…", "index": 3 } }
```

When no verdict is possible the response says so by name rather than implying one: `verification_skipped` is `not_readable` (write-only characteristic), `read_failed` (readback errored or timed out), or `disabled`. A failed readback is never reported as a failed write. Numeric comparison tolerates half the characteristic's step — enough for an accessory snapping to its step grid, not enough to call brightness 0 a successful write of brightness 1.

`--no-verify` (CLI) / `verify: false` (socket, MCP, OpenClaw) opts out for accessories whose readback is unreliable.

**Input strictness.** `service_index` from the socket is now parsed strictly: present-but-malformed throws instead of silently dropping the selector, which would have sent the write to a different channel. JSON `true` no longer bridges through `as? Int` into channel 1.

**Discoverability.** `get --json` now includes each service's `id` and `index`, so the selector values are visible before you need the error message.

## Behavior changes

Two, both deliberate, both the bug being fixed:

1. A caller that passed `service_type` on a multi-service accessory previously got a silent write to the first match; it now gets an ambiguity error naming the selectors to retry with. The no-selector case already errored, so most callers already handle this error shape.
2. A write the device does not apply is now an error rather than a success. `--no-verify` / `verify: false` restores the old behavior for accessories where the readback cannot be trusted.

## Test plan

- `swift test` — 181 tests pass, including new `set` parsing coverage for `--service-name` / `--service-id` / `--service-index` / `--no-verify`.
- `npm run build:mcp` and the OpenClaw `tsc` build pass; regenerated bundles are included.
- The Catalyst target type-checks clean under the real build settings (`-target arm64-apple-ios18.0-macabi`, Swift 6, `-strict-concurrency=complete`), with no new warnings. **A full `xcodebuild` could not be completed on this machine** — the Xcode build system wedged before compiling anything on five attempts, including on an untouched target, producing zero object files each time. That is environmental, but it means link/resource/signing phases are unverified here and CI or a local build should confirm.
- Runtime verification on a real multi-gang accessory still needs the reporter (no S1E here).

## Known follow-up (not in this PR)

`findCharacteristicByDescription`, used to resolve **scene and automation actions**, has the same first-match defect and no way to select a service. Fixing it means extending the action-dict schema across the CLI, MCP, and OpenClaw surfaces, so it is left as separate work rather than widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
