### PR TITLE
build: surface xcodebuild failures, report toolchain, add Catalyst CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,52 @@ jobs:
       - name: Build MCP server
         run: npm run build:mcp
 
+  catalyst:
+    name: Catalyst App
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # The Xcode build phase compiles openclaw/dist via tsc, resolved from
+      # node_modules before falling back to npx.
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Report toolchain
+        run: xcodebuild -version
+
+      # The app target is never compiled by the Build job — only the SPM CLI is —
+      # so a break in Sources/homeclaw (the HomeKit manager, socket server, and
+      # views) could reach main with CI green. Signing is disabled because the
+      # HomeKit entitlement is App Store-only and cannot be provisioned here;
+      # this checks that the Catalyst target compiles and links, not that it
+      # is distributable.
+      - name: Build Catalyst app (no signing)
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project HomeClaw.xcodeproj \
+            -scheme HomeClaw \
+            -configuration Debug \
+            -destination 'generic/platform=macOS,variant=Mac Catalyst' \
+            build \
+            CODE_SIGNING_ALLOWED=NO \
+            | tee /tmp/catalyst-build.log \
+            | grep -E "error:|warning:|^\*\* BUILD" || true
+          grep -q "^\*\* BUILD SUCCEEDED \*\*" /tmp/catalyst-build.log
+
   version-check:
     name: Version Consistency
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,9 +201,15 @@ If status shows `ready: false` with 0 homes:
 ## CI
 
 GitHub Actions (`.github/workflows/tests.yml`) runs on `macos-26`:
-- Builds `homeclaw-cli` via SPM
-- Builds `mcp-server` (Node.js)
-- HomeClaw Catalyst app is NOT built in CI (requires signing identity + provisioning)
+- **Build** — builds `homeclaw-cli` via SPM, runs `swift test`, builds `mcp-server` (Node.js)
+- **Catalyst App** — runs `xcodegen` and builds the HomeClaw Catalyst target with
+  `CODE_SIGNING_ALLOWED=NO`, asserting `** BUILD SUCCEEDED **`
+- **Version Consistency** — checks the plugin manifest versions agree
+
+CI builds the Catalyst app **unsigned only**. The HomeKit entitlement is App
+Store-only and cannot be provisioned on a runner, so CI proves the app target
+compiles and links, not that it is signable or distributable. A signed build
+still has to happen locally (`scripts/build.sh`) or via `fastlane`.
 
 ## Clawpatch Code Review
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,6 +33,39 @@ end
 load_env_file(File.join(PROJECT_ROOT, ".env.local"))
 load_env_file(File.expand_path("~/.secrets.env"))
 
+# Resolve the Xcode to build with, and say which one it was.
+#
+# A machine with several Xcodes installed otherwise archives against whatever
+# `xcode-select` points at, invisibly — a release built on the wrong toolchain
+# is not something to discover from App Store Connect. Honors DEVELOPER_DIR or
+# XCODE_APP from the environment or .env.local; falls back to xcode-select.
+def resolve_toolchain!
+  if ENV["DEVELOPER_DIR"].to_s.empty? && !ENV["XCODE_APP"].to_s.empty?
+    ENV["DEVELOPER_DIR"] = File.join(ENV["XCODE_APP"], "Contents/Developer")
+  end
+  dir = ENV["DEVELOPER_DIR"]
+  UI.user_error!("DEVELOPER_DIR does not exist: #{dir}") if !dir.to_s.empty? && !Dir.exist?(dir)
+
+  version = `xcodebuild -version 2>/dev/null`.lines.first.to_s.strip
+  path = `xcode-select -p 2>/dev/null`.strip
+  UI.message("Toolchain: #{version.empty? ? 'unknown' : version} (#{path})")
+  version
+end
+
+# Concurrent xcodebuild runs against the same project can wedge the build
+# service: a run sits at the toolchain probe producing nothing, which reads as a
+# broken toolchain rather than contention. Fail fast instead of hanging a
+# release. Scoped to this project; unrelated builds on the machine are allowed.
+def ensure_no_concurrent_build!
+  pids = `pgrep -f "xcodebuild.*#{APP_NAME}.xcodeproj" 2>/dev/null`.split.reject { |p| p == Process.pid.to_s }
+  return if pids.empty?
+
+  UI.user_error!(
+    "Another xcodebuild is already running against #{APP_NAME}.xcodeproj (pid #{pids.first}). " \
+    "Concurrent builds wedge the build service. Wait for it to finish, or kill #{pids.first}."
+  )
+end
+
 def asc_api_key
   # Accept the ASC_* names or the canonical App Store Connect API names used
   # machine-wide (so a shell with ~/.secrets.env sourced works without remapping).
@@ -194,6 +227,9 @@ platform :ios do
   # Pre-archive prep: regenerate Xcode project + build the Node.js MCP server.
   private_lane :prepare do
     UI.user_error!("xcodegen not installed. brew install xcodegen") unless system("command -v xcodegen >/dev/null 2>&1")
+
+    resolve_toolchain!
+    ensure_no_concurrent_build!
 
     UI.message("Generating Xcode project...")
     sh("cd #{Shellwords.escape(PROJECT_ROOT)} && xcodegen generate --use-cache", log: false)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,6 +16,30 @@ if [[ -f "$PROJECT_ROOT/.env.local" ]]; then
 fi
 TEAM_ID="${HOMEKIT_TEAM_ID:-}"
 
+# ─── Toolchain ──────────────────────────────────────────────────────
+#
+# Machines with several Xcodes installed otherwise build against whatever
+# `xcode-select` happens to point at, which is invisible in the output. Honor an
+# explicit override (env or .env.local) and always report what we used.
+# XCODE_APP is a convenience spelling of DEVELOPER_DIR.
+if [[ -n "${XCODE_APP:-}" && -z "${DEVELOPER_DIR:-}" ]]; then
+    DEVELOPER_DIR="$XCODE_APP/Contents/Developer"
+fi
+if [[ -n "${DEVELOPER_DIR:-}" ]]; then
+    if [[ ! -d "$DEVELOPER_DIR" ]]; then
+        echo "Error: DEVELOPER_DIR does not exist: $DEVELOPER_DIR" >&2
+        exit 1
+    fi
+    export DEVELOPER_DIR
+fi
+# Capture without a `||` fallback inside the substitution: `head -1` closes the
+# pipe early, xcodebuild takes SIGPIPE, and the non-zero pipeline status would
+# fire the fallback too, concatenating both strings. Default afterwards instead.
+XCODE_VERSION="$(xcodebuild -version 2>/dev/null | head -1)"
+XCODE_PATH="$(xcode-select -p 2>/dev/null)"
+XCODE_VERSION="${XCODE_VERSION:-unknown}"
+XCODE_PATH="${XCODE_PATH:-unknown}"
+
 # Defaults
 BUILD_CONFIG="release"
 DO_INSTALL=false
@@ -56,6 +80,11 @@ Options:
 
 Environment:
   HOMEKIT_TEAM_ID   Same as --team-id (flag takes precedence)
+  DEVELOPER_DIR     Xcode toolchain to build with (defaults to xcode-select)
+  XCODE_APP         Path to an Xcode.app; shorthand for DEVELOPER_DIR
+
+Both toolchain variables may also be set in .env.local. The Xcode in use is
+printed on every build.
 EOF
     exit 0
 }
@@ -115,7 +144,21 @@ next_step() { CURRENT_STEP=$((CURRENT_STEP + 1)); }
 
 echo ""
 echo "$(bold "Building $APP_NAME...") ($BUILD_CONFIG) v$MARKETING_VERSION build $BUILD_NUMBER"
+echo "  Toolchain: $XCODE_VERSION ($XCODE_PATH)"
 echo ""
+
+# Concurrent xcodebuild runs against the same project can wedge the build
+# service: a run sits at the toolchain probe indefinitely, producing no object
+# files, while `xcodebuild -list` keeps answering — which reads as a broken
+# toolchain rather than contention, and costs a long time to diagnose. Refuse up
+# front instead of hanging. Scoped to this project deliberately; unrelated
+# xcodebuild runs elsewhere on the machine are not blocked.
+EXISTING_BUILD="$(pgrep -f "xcodebuild.*$APP_NAME.xcodeproj" 2>/dev/null | grep -v "^$$\$" | head -1 || true)"
+if [[ -n "$EXISTING_BUILD" ]]; then
+    echo "Error: another xcodebuild is already running against $APP_NAME.xcodeproj (pid $EXISTING_BUILD)." >&2
+    echo "  Concurrent builds wedge the build service. Wait for it, or: kill $EXISTING_BUILD" >&2
+    exit 1
+fi
 
 # Clean if requested
 if $DO_CLEAN; then
@@ -169,10 +212,19 @@ XCODE_ARGS=(
     -quiet
 )
 
-if xcodebuild "${XCODE_ARGS[@]}" 2>/dev/null; then
+# Keep the full log: -quiet plus a discarded stderr used to reduce every failure
+# to "xcodebuild failed" with no way to tell why.
+BUILD_LOG="$PROJECT_ROOT/.build/xcodebuild.log"
+mkdir -p "$(dirname "$BUILD_LOG")"
+if xcodebuild "${XCODE_ARGS[@]}" >"$BUILD_LOG" 2>&1; then
     step_done
 else
-    step_fail "xcodebuild failed"
+    printf "  %s\n" "$(red)"
+    echo "" >&2
+    echo "xcodebuild failed. Last 40 lines of $BUILD_LOG:" >&2
+    echo "" >&2
+    tail -40 "$BUILD_LOG" >&2
+    exit 1
 fi
 
 # Phase 4: Locate built app

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,11 +32,14 @@ if [[ -n "${DEVELOPER_DIR:-}" ]]; then
     fi
     export DEVELOPER_DIR
 fi
-# Capture without a `||` fallback inside the substitution: `head -1` closes the
-# pipe early, xcodebuild takes SIGPIPE, and the non-zero pipeline status would
-# fire the fallback too, concatenating both strings. Default afterwards instead.
-XCODE_VERSION="$(xcodebuild -version 2>/dev/null | head -1)"
-XCODE_PATH="$(xcode-select -p 2>/dev/null)"
+# Take the first line with parameter expansion rather than `| head -1`: head
+# exits after one line, xcodebuild takes SIGPIPE, and under `set -o pipefail`
+# the resulting 141 makes the assignment fail — which `set -e` turns into a
+# silent abort of the whole script before it builds anything.
+# `|| true` keeps a missing or broken xcode-select from aborting it the same way.
+XCODE_VERSION="$(xcodebuild -version 2>/dev/null || true)"
+XCODE_VERSION="${XCODE_VERSION%%$'\n'*}"
+XCODE_PATH="$(xcode-select -p 2>/dev/null || true)"
 XCODE_VERSION="${XCODE_VERSION:-unknown}"
 XCODE_PATH="${XCODE_PATH:-unknown}"
 


### PR DESCRIPTION
Follow-up to #86. While fixing #85 I spent about an hour unable to tell why Catalyst builds were failing, and every minute of that was avoidable tooling opacity rather than anything about the code.

## What this changes

**`build.sh` threw away every diagnostic.** Phase 3 ran `xcodebuild -quiet ... 2>/dev/null`, so any failure surfaced as exactly one line — `Error: xcodebuild failed` — with no way to tell whether it was a compile error, a signing problem, or a stall. Diagnosing anything meant reconstructing the xcodebuild invocation by hand. It now tees the full output to `.build/xcodebuild.log` and prints the last 40 lines on failure.

**Neither script said which Xcode it used.** On a machine with more than one Xcode installed, `build.sh` and `fastlane archive` silently build against whatever `xcode-select` points at — and a release archived on the wrong toolchain is not something you want to learn from App Store Connect. Both now print the Xcode version and path on every run, and honor an explicit `DEVELOPER_DIR` or `XCODE_APP` override from the environment or `.env.local`.

No toolchain is hardcoded. `xcode-select` stays the default, and `project.yml`'s `xcodeVersion: "26.0"` is correct — Xcode 26.6 builds this project fine. (I briefly believed a beta was required; it isn't. See below.)

**Concurrent builds.** Both scripts now refuse to start when another `xcodebuild` is already running against `HomeClaw.xcodeproj`, naming the PID. This is a safeguard, not a fix for the stall described below — concurrent runs are a plausible way to wedge the build service and cost nothing to rule out. Scoped to this project, so unrelated builds elsewhere on the machine are not blocked.

**CI never compiled the app.** The `Build` job builds `homeclaw-cli` via SPM and the MCP server, and stops there. Everything in `Sources/homeclaw` — `HomeKitManager`, `SocketServer`, `AccessoryModel`, the SwiftUI views — was never compiled by CI, so a break there could merge with a green tick. #86 was exactly that shape of change and CI could not have caught a mistake in it.

New `Catalyst App` job generates the project and builds the app target with `CODE_SIGNING_ALLOWED=NO`. Signing stays off deliberately: the HomeKit entitlement is App Store-only and cannot be provisioned on a runner. This proves the target compiles and links, not that it is distributable.

## An unresolved local issue, reported rather than fixed

`xcodebuild` on this project intermittently stalls before compiling anything: the `clang -v -E -dM` toolchain probe sits at 0% CPU with zero `.o` files for 10–25 minutes, while `xcodebuild -list` and `-showBuildSettings` keep answering normally.

I proposed three causes and disproved each one:

| Theory | Result |
|---|---|
| Stable Xcode 26.6 is the wrong toolchain, beta 27.0 required | **Wrong** — an isolated 26.6 build reached `** BUILD SUCCEEDED **` in ~2 min |
| Two concurrent `xcodebuild` runs wedge the build service | **Not sufficient** — it stalls with exactly one running |
| Signing / `-allowProvisioningUpdates` blocks it | **Wrong** — stalls with `CODE_SIGNING_ALLOWED=NO`, and on both generic and concrete destinations |

Defender was idle (~1% CPU) throughout, so it is not that either. The one correlation left untested: the two runs that succeeded used the **default** DerivedData location, while the runs that stalled passed `-derivedDataPath .build/DerivedData`. Suggestive, not established.

I have not tried to fix that here. The diagnostics change above is what makes it tractable next time, and the CI job means a stalling local machine no longer blocks knowing whether the app compiles.

## Test plan

- `bash -n scripts/build.sh` and `ruby -c fastlane/Fastfile` pass; workflow YAML parses.
- Toolchain capture verified: it previously produced `"Xcode 26.6\nunknown"`, because `head -1` SIGPIPEs `xcodebuild` and the non-zero pipeline status also fired the `|| echo unknown` fallback. Fixed and re-checked.
- Concurrency guard verified in both directions — fires against a running build and stays quiet otherwise.
- Failure path verified against a command that exits non-zero: prints the marker, the log path, and the captured stderr.
- **Not verified: an end-to-end `build.sh --debug` happy path**, because of the stall above. Phases 1, 2 and the xcodebuild launch were exercised; phase 4 and the summary are untouched by this change.
- The `Catalyst App` job is exercised for the first time by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
