### PR TITLE
feat: add Hermes MCP plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,22 @@ After installing, verify Claude can reach HomeKit:
 
 HomeClaw includes an [OpenClaw](https://openclaw.ai) plugin that registers a HomeKit skill on the gateway. The skill calls `homeclaw-cli` by name, so it must be in your PATH.
 
+## Using with Hermes
+
+HomeClaw also ships a portable [Agent Plugin](https://agent-plugins.org/) package for [Hermes Agent](https://hermes-agent.nousresearch.com/). It connects Hermes to the existing HomeClaw stdio MCP server; it does not duplicate HomeKit access or install the app.
+
+### Prerequisites
+
+1. Install HomeClaw from the Mac App Store.
+2. Launch HomeClaw and grant HomeKit access when macOS asks.
+3. Keep HomeClaw running while Hermes uses the MCP tools.
+
+Install the plugin from a checkout of this repository using Hermes' portable-plugin installer, or copy the root `mcp.json` into Hermes' MCP configuration. The Settings > Integrations > Hermes section can copy a configuration for the installed app and Node.js path without modifying Hermes automatically.
+
+The first verification should be the read-only `homekit_status` tool. If it reports that the backend is unavailable, confirm that HomeClaw is running; no `sudo`, symlink, credentials, or HomeKit write is required.
+
+For a nonstandard app location, use the generated configuration from Settings and keep the absolute server path inside the installed HomeClaw bundle.
+
 ### Same-Mac Install (Recommended)
 
 If HomeClaw and OpenClaw run on the same Mac, use the one-click installer:

--- a/Sources/homeclaw/Shared/HermesIntegrationSupport.swift
+++ b/Sources/homeclaw/Shared/HermesIntegrationSupport.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Pure formatting and discovery helpers for the Hermes integration UI.
+enum HermesIntegrationSupport {
+    static let serverName = "homeclaw"
+
+    static func mcpConfiguration(nodePath: String, serverPath: String) -> String {
+        let config: [String: Any] = [
+            "mcpServers": [
+                serverName: [
+                    "type": "stdio",
+                    "command": nodePath,
+                    "args": [serverPath],
+                ]
+            ]
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys]),
+              let result = String(data: data, encoding: .utf8)
+        else { return "" }
+        return result + "\n"
+    }
+
+    static func setupInstructions(nodePath: String, serverPath: String) -> String {
+        "# HomeClaw → Hermes\n"
+            + "# Start the HomeClaw app first, then add the JSON below to Hermes' MCP configuration.\n"
+            + "# No sudo, symlink, credentials, or HomeKit write operation is required.\n"
+            + mcpConfiguration(nodePath: nodePath, serverPath: serverPath)
+    }
+
+    static func findHermesExecutable(fileManager: FileManager = .default) -> String? {
+        [
+            "/opt/homebrew/bin/hermes",
+            "/usr/local/bin/hermes",
+            "/usr/bin/hermes",
+        ].first(where: { fileManager.isExecutableFile(atPath: $0) })
+    }
+}

--- a/Sources/homeclaw/Views/IntegrationsSettingsView.swift
+++ b/Sources/homeclaw/Views/IntegrationsSettingsView.swift
@@ -6,6 +6,7 @@ struct IntegrationsSettingsView: View {
     @State private var claudeCodeStatus: ClaudeCodeStatus = .checking
     @State private var openClawStatus: OpenClawStatus = .checking
     @State private var cliStatus: CLIStatus = .checking
+    @State private var hermesStatus: HermesStatus = .checking
     @State private var statusMessage: StatusMessage?
 
     // MARK: - Status Enums
@@ -42,6 +43,13 @@ struct IntegrationsSettingsView: View {
         case notInstalled
         /// Plugin found in extensions directory or OpenClaw config.
         case installed
+    }
+
+    private enum HermesStatus {
+        case checking
+        case detected
+        case notDetected
+        case serverUnavailable
     }
 
     // MARK: - Constants & Paths
@@ -111,6 +119,7 @@ struct IntegrationsSettingsView: View {
             claudeDesktopSection
             claudeCodeSection
             openClawSection
+            hermesSection
 
             if let message = statusMessage {
                 Section {
@@ -356,6 +365,37 @@ struct IntegrationsSettingsView: View {
         }
     }
 
+    // MARK: - Hermes Section
+
+    @ViewBuilder
+    private var hermesSection: some View {
+        Section {
+            LabeledContent("Status") {
+                hermesStatusLabel
+            }
+
+            if let nodePath = nodeJSPath(), let serverPath = Self.bundledServerJSPath {
+                Button("Copy Hermes MCP Configuration") {
+                    UIPasteboard.general.string = HermesIntegrationSupport.setupInstructions(
+                        nodePath: nodePath, serverPath: serverPath)
+                    statusMessage = StatusMessage(
+                        text: "Hermes configuration copied to the clipboard.", isError: false)
+                }
+
+                Text("Start HomeClaw before using the homekit_status MCP tool. The generated configuration uses the bundled server and does not modify Hermes automatically.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            } else {
+                Text("Build the app with the bundled MCP server, then copy the Hermes configuration here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Hermes").font(.headline).foregroundStyle(.primary)
+        }
+    }
+
     @ViewBuilder
     private var openClawRemoteInstructionsView: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -428,6 +468,24 @@ struct IntegrationsSettingsView: View {
         }
     }
 
+    @ViewBuilder
+    private var hermesStatusLabel: some View {
+        switch hermesStatus {
+        case .checking:
+            Label("Checking\u{2026}", systemImage: "circle.dotted")
+                .foregroundStyle(.secondary)
+        case .detected:
+            Label("Detected", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .notDetected:
+            Label("Not Detected", systemImage: "circle")
+                .foregroundStyle(.secondary)
+        case .serverUnavailable:
+            Label("MCP Server Not Bundled", systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.orange)
+        }
+    }
+
     // MARK: - Status Checking
 
     private func refreshStatuses() {
@@ -435,6 +493,13 @@ struct IntegrationsSettingsView: View {
         claudeDesktopStatus = checkClaudeDesktopStatus()
         claudeCodeStatus = checkClaudeCodeStatus()
         openClawStatus = checkOpenClawStatus()
+        hermesStatus = checkHermesStatus()
+    }
+
+    private func checkHermesStatus() -> HermesStatus {
+        guard HermesIntegrationSupport.findHermesExecutable() != nil else { return .notDetected }
+        guard Self.bundledServerJSPath != nil else { return .serverUnavailable }
+        return .detected
     }
 
     private func checkClaudeDesktopStatus() -> DesktopStatus {

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "homeclaw": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${PLUGIN_ROOT}/mcp-server/dist/server.js"],
+      "cwd": "${PLUGIN_ROOT}"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "homeclaw",
+  "version": "1.0.5",
+  "description": "HomeKit smart home control and monitoring through the HomeClaw MCP server.",
+  "homepage": "https://github.com/omarshahine/HomeClaw",
+  "repository": "https://github.com/omarshahine/HomeClaw",
+  "license": "MIT",
+  "keywords": ["homekit", "smart-home", "mcp"],
+  "mcp": true
+}

--- a/test/hermes-plugin.test.mjs
+++ b/test/hermes-plugin.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function readJSON(name) {
+  return JSON.parse(await readFile(resolve(root, name), "utf8"));
+}
+
+test("HomeClaw portable plugin manifest identifies the MCP component", async () => {
+  const manifest = await readJSON("plugin.json");
+  assert.equal(manifest.$schema, "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json");
+  assert.equal(manifest.name, "homeclaw");
+  assert.equal(manifest.version, "1.0.5");
+  assert.match(manifest.description, /HomeKit/i);
+  assert.equal(manifest.mcp, true);
+});
+
+test("HomeClaw portable MCP config is a safe in-package stdio server", async () => {
+  const config = await readJSON("mcp.json");
+  assert.equal(config.$schema, "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json");
+  const server = config.mcpServers.homeclaw;
+  assert.equal(server.type, "stdio");
+  assert.equal(server.command, "node");
+  assert.deepEqual(server.args, ["${PLUGIN_ROOT}/mcp-server/dist/server.js"]);
+  assert.equal(server.cwd, "${PLUGIN_ROOT}");
+  assert.equal(JSON.stringify(config).includes("sudo"), false);
+  assert.equal(JSON.stringify(config).includes("password"), false);
+});


### PR DESCRIPTION
Adds first-class Hermes support via the portable Agent Plugin format and native stdio MCP configuration.

- Adds plugin.json and mcp.json
- Adds HomeClaw Hermes setup guidance in Integrations settings
- Adds focused manifest/config tests
- Keeps setup safe: no sudo, symlink, credentials, or automatic HomeKit writes

Verified locally with npm run build:mcp, node --test test/hermes-plugin.test.mjs, and swiftc -parse.