### PR TITLE
ci: deploy site to Cloudflare Pages on push to main

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,58 @@
+name: Deploy Site to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+    # The workflow file is in the filter on purpose. apple-pim's copy of this
+    # workflow filtered on site/** alone, so a fix to the workflow itself did not
+    # redeploy and had to be dispatched by hand. Keeping a filter at all (rather
+    # than dropping it) matters here: most commits to this repo are Swift app
+    # changes with nothing to publish, and macOS CI already competes for the
+    # account's Actions minutes.
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-site.yml'
+  workflow_dispatch:
+
+# Deploys are not safe to cancel mid-flight, so newer runs queue behind older
+# ones rather than replacing them.
+concurrency:
+  group: deploy-site
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          # astro 7 requires ">=22.12.0". apple-pim's identical workflow was
+          # pinned to 20 and failed at deploy time immediately after its astro
+          # 5 -> 7 upgrade; 24 matches every other workflow in this repo.
+          node-version: 24
+
+      # site/package-lock.json is gitignored here, so `npm ci` is not available.
+      - name: Install dependencies
+        run: npm install
+        working-directory: site
+
+      - name: Build Astro site
+        run: npm run build
+        working-directory: site
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --branch is explicit because this Pages project has no Git
+          # integration: wrangler would otherwise infer a branch, and only
+          # "main" maps to this project's production deployment.
+          command: pages deploy site/dist --project-name=homeclaw --branch=main


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge yet — two repo secrets are missing.** See "Blocked on credentials" below. Merging as-is would give a red `main` on the next `site/**` commit.

The site has no automated deploy. The `homeclaw` Pages project has no Git integration and was last touched three months ago, so every publish has been manual — which is why `homeclaw.omarknows.app` is still serving the astro 5 build that #103 replaced. A hand-deployed site just drifts from `main` again, so this fixes the cause rather than the symptom.

## Modelled on apple-pim, with its two mistakes fixed up front

| | apple-pim | here |
|---|---|---|
| node | `20` — failed at deploy time on astro 7's `>=22.12.0`, needed a follow-up PR | **`24`** from the start |
| path filter | `site/**` only — so the fix to the workflow itself didn't redeploy and had to be dispatched by hand | **`site/**` + `.github/workflows/deploy-site.yml`** |

I kept a path filter rather than dropping it: most commits to this repo are Swift app changes with nothing to publish, and the macOS jobs already compete for the account's Actions minutes. Adding the workflow file to its own filter gets the self-applying behaviour without deploying on every unrelated commit.

Two more places where I made explicit what apple-pim leaves to inference:

- **`--branch=main`.** A Pages project with no Git integration would otherwise have wrangler guess a branch. Confirmed against this project's deployment history that every existing deployment is `Production` from `main`.
- **`npm install`, not `npm ci`.** `site/package-lock.json` is gitignored in this repo, so there is no lockfile to `ci` from.

Also `workflow_dispatch` so it can be run by hand without a commit, and a `concurrency` group with `cancel-in-progress: false` — deploys are not safe to cancel mid-flight.

## Blocked on credentials

`cloudflare/wrangler-action` needs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. **This repo has neither**, and there is no fallback source:

```
actions secrets     : 0
environments        : 0
dependabot secrets  : 0
org-level secrets   : n/a (personal account)
```

apple-pim has both, set in Feb 2026, pointing at the same Cloudflare account that hosts the `homeclaw` project. I have not created, copied, or guessed at any credential. **Both secrets need adding to this repo before this merges.**

## What is verified, and what isn't

**Build half: proven.** Cloned this branch to a clean directory and ran the workflow's exact commands on node 24 — `npm install`, `npm run build`. 4 pages built; the output is byte-identical to the astro 7 build verified in #103, same bundle hash, and no double-escaped entities.

**Deploy half: unproven, and cannot be until the secrets exist.** Once they're added and this merges, the publish still needs checking the way apple-pim's was: confirm the live bundle name matches the local build and that no entity renders double-escaped.

Nothing outside `.github/` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk