### PR TITLE
fix(ci): scope the Pages deploy to site/, which is not a workspace member

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -55,4 +55,12 @@ jobs:
           # --branch is explicit because this Pages project has no Git
           # integration: wrangler would otherwise infer a branch, and only
           # "main" maps to this project's production deployment.
-          command: pages deploy site/dist --project-name=homeclaw --branch=main
+          # ⚠️ workingDirectory MUST be `site`, and not for tidiness.
+          # wrangler-action runs `npm i wrangler@4` in this directory. The repo
+          # ROOT declares `workspaces: ["openclaw", "mcp-server"]`, and
+          # openclaw/package.json is `os: ["darwin"]` because it wraps a macOS
+          # binary — so any npm install at the root fails on a Linux runner with
+          # EBADPLATFORM before wrangler is even fetched, let alone authenticated.
+          # `site` is not a workspace member, so installing there is isolated.
+          workingDirectory: site
+          command: pages deploy dist --project-name=homeclaw --branch=main


### PR DESCRIPTION
The first automated deploy failed **before authentication was attempted** — this was never a credentials problem.

```
npm error code EBADPLATFORM
npm error notsup Unsupported platform for homeclaw@1.0.5:
          wanted {"os":"darwin"} (current: {"os":"linux"})
```

`wrangler-action` runs `npm i wrangler@4` in its working directory, which defaulted to the repo root. The root declares `workspaces: ["openclaw", "mcp-server"]`, and `openclaw/package.json` is `os: ["darwin"]` because it wraps a macOS binary — so **any** npm install at the root fails on a Linux runner. npm blames the workspace root by name, which is why the error names `homeclaw@1.0.5` even though the root manifest has no `os` field at all.

`site` is not a workspace member, so scoping the action there isolates the install. Command path drops the `site/` prefix accordingly.