### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,10 +28,10 @@ jobs:
       deployments: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           # astro 7 requires ">=22.12.0". apple-pim's identical workflow was
           # pinned to 20 and failed at deploy time immediately after its astro
@@ -48,7 +48,7 @@ jobs:
         working-directory: site
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0  # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/plugin-inspector.yml
+++ b/.github/workflows/plugin-inspector.yml
@@ -9,14 +9,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           node-version: 24
       - name: Run plugin-inspector
         working-directory: openclaw
         run: npx --yes @openclaw/plugin-inspector ci --no-openclaw --runtime --mock-sdk --allow-execute
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: plugin-inspector-reports

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Verify HomeKit entitlement
         run: |
@@ -36,7 +36,7 @@ jobs:
         run: swift test
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           node-version: 24
 
@@ -52,10 +52,10 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           node-version: 24
 
@@ -121,8 +121,8 @@ jobs:
     name: Version Consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: omarshahine/version-consistency-action@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: omarshahine/version-consistency-action@de358297133489498bca32eaea89a296e9e4a5b0  # v1
         with:
           sets: |
             - name: "HomeClaw plugin"


### PR DESCRIPTION
Pins every `uses:` in this repo's workflows to a full 40-character commit SHA, keeping the version as a trailing comment.

**Why.** An upstream tag retarget on a mutable major (`@v7`, `@v4`) silently changes the code that runs — including in workflows that hold production Cloudflare tokens. A SHA cannot be moved.

**Why this stays maintainable.** Dependabot's `github-actions` ecosystem is already configured in this repo, and it reads the trailing `# vN` comment to keep both the pin and the annotation current. Pinning without it would just freeze the actions.

**How the SHAs were resolved.** Each from the tag it currently points at, via `gh api /repos/<owner>/<repo>/git/ref/tags/<tag>`, dereferencing annotated tag objects through `/git/tags/<sha>` to the underlying commit. Resolved per repo, not copied between repos — different repos sit on different majors.

**Verification.** A wrong SHA fails at run time, not parse time, so a green run on this PR is the proof the pins resolve.

## Pinned

 .github/workflows/deploy-site.yml      |  6 +++---
 .github/workflows/plugin-inspector.yml |  6 +++---
 .github/workflows/tests.yml            | 12 ++++++------
 3 files changed, 12 insertions(+), 12 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk