### PR TITLE
feat: native MCP Streamable HTTP server

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build homeclaw-cli
         run: swift build --product homeclaw-cli
 
-      - name: Run Swift tests
+      - name: Run Swift CLI tests (not Catalyst coverage)
         run: swift test
 
       - name: Setup Node
@@ -42,6 +42,11 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+
+      - name: Verify native MCP schema parity
+        run: |
+          node --test scripts/check-mcp-schema-parity.test.mjs
+          node scripts/check-mcp-schema-parity.mjs
 
       - name: Build MCP server
         run: npm run build:mcp
@@ -97,25 +102,43 @@ jobs:
           fi
           xcodebuild -version
 
-      # The app target is never compiled by the Build job — only the SPM CLI is —
-      # so a break in Sources/homeclaw (the HomeKit manager, socket server, and
-      # views) could reach main with CI green. Signing is disabled because the
-      # HomeKit entitlement is App Store-only and cannot be provisioned here;
-      # this checks that the Catalyst target compiles and links, not that it
-      # is distributable.
-      - name: Build Catalyst app (no signing)
+      - name: Verify CI evidence harness and settings wiring
         run: |
-          set -o pipefail
-          xcodebuild \
-            -project HomeClaw.xcodeproj \
-            -scheme HomeClaw \
-            -configuration Debug \
-            -destination 'generic/platform=macOS,variant=Mac Catalyst' \
-            build \
-            CODE_SIGNING_ALLOWED=NO \
-            | tee /tmp/catalyst-build.log \
-            | grep -E "error:|warning:|^\*\* BUILD" || true
-          grep -q "^\*\* BUILD SUCCEEDED \*\*" /tmp/catalyst-build.log
+          python3 scripts/test-ci-evidence.py -v
+          python3 scripts/test-integration-settings.py -v
+
+      - name: Verify generated HomeKit entitlement
+        run: |
+          python3 - <<'PY'
+          import plistlib
+          with open('Resources/HomeClaw.entitlements', 'rb') as handle:
+              entitlements = plistlib.load(handle)
+          assert entitlements.get('com.apple.developer.homekit') is True
+          assert 'group.com.shahine.homeclaw' in entitlements.get('com.apple.security.application-groups', [])
+          PY
+
+      # SPM runs CLI tests only. This builds and executes every app-hosted
+      # HomeClawTests case, without filters/skips. Unsigned execution is not
+      # evidence of HomeKit provisioning or distribution signing.
+      - name: Run full Catalyst HomeClawTests (no signing)
+        timeout-minutes: 25
+        env:
+          CATALYST_EVIDENCE_DIR: ${{ runner.temp }}/catalyst-test-evidence
+        run: bash scripts/test-catalyst.sh
+
+      - name: Upload Catalyst test evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: catalyst-homeclawtests-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            ${{ runner.temp }}/catalyst-test-evidence/xcodebuild.log
+            ${{ runner.temp }}/catalyst-test-evidence/xcodebuild-exit-status.txt
+            ${{ runner.temp }}/catalyst-test-evidence/summary.json
+            ${{ runner.temp }}/catalyst-test-evidence/tests.json
+            ${{ runner.temp }}/catalyst-test-evidence/HomeClawTests.xcresult
 
   version-check:
     name: Version Consistency

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ OpenClaw → Plugin (openclaw/) → homeclaw-cli ──────────�
 
 **Single-process design.** `HMHomeManager` requires a UIKit/Catalyst app with the HomeKit entitlement. By making the entire app Catalyst, HomeKit access is direct (no IPC), signing is unified (single archive), and App Store submission is clean. The macOSBridge plugin bundle provides the native macOS menu bar via `NSStatusItem`.
 
-**Note:** The HTTP MCP server (port 9090, bearer token auth) has been disabled. The implementation is preserved in `Sources/homeclaw/MCP/_disabled/` and `Sources/homeclaw/Shared/_disabled/` for reference but is not compiled. All MCP clients now use the stdio server or CLI.
+**Note:** The native Streamable HTTP MCP server is **off by default** and can be enabled in Settings → Integrations. When enabled it binds only to loopback at `http://127.0.0.1:9090/mcp`, is owned by the Catalyst app lifecycle, and exposes `/healthz` for readiness. It uses SwiftNIO directly, with Host/Origin validation and a deny-by-default read-only tool allowlist; no bearer token or shell launch is required. The Node stdio server remains available independently. `MCP/_disabled/` contains an excluded, superseded SDK/token prototype, not the active implementation.
 
 ## Project Structure
 
@@ -224,9 +224,12 @@ If status shows `ready: false` with 0 homes:
 
 GitHub Actions (`.github/workflows/tests.yml`) runs on `macos-26`:
 - **Build** — builds `homeclaw-cli` via SPM, runs `swift test`, builds `mcp-server` (Node.js)
-- **Catalyst App** — runs `xcodegen`, selects the `.xcode-version` Xcode when the
-  runner has it, and builds the HomeClaw Catalyst target with
-  `CODE_SIGNING_ALLOWED=NO`, asserting `** BUILD SUCCEEDED **`
+- **Catalyst App** — runs XcodeGen, selects the `.xcode-version` Xcode when the
+  runner has it, checks complete Node/native schema parity, and executes the full
+  `HomeClawTests` suite via `scripts/test-catalyst.sh` with
+  `CODE_SIGNING_ALLOWED=NO`. The script preserves xcodebuild's exit status and
+  requires passing, nonempty xcresult evidence with no skipped tests. CI uploads
+  the log and result bundle. Catalyst deployment targets support the macOS 26 runner.
 - **Version Consistency** — checks the plugin manifest versions agree
 
 The two macOS jobs (**Build**, **Catalyst App**) run only on pull requests —
@@ -234,10 +237,11 @@ macOS minutes bill at 10x Linux, and re-running them on the merge commit's push
 to main duplicated what the PR already proved. Pushes to main run only the
 Linux **Version Consistency** job.
 
-CI builds the Catalyst app **unsigned only**. The HomeKit entitlement is App
-Store-only and cannot be provisioned on a runner, so CI proves the app target
-compiles and links, not that it is signable or distributable. A signed build
-still has to happen locally (`scripts/build.sh`) or via `fastlane`.
+CI builds and tests the Catalyst app **unsigned only**. The HomeKit entitlement
+cannot be provisioned on a runner. Unit tests avoid live HomeKit operations;
+passing them proves native code execution, not real accessory access, signing,
+or distributability. A signed build still has to happen locally
+(`scripts/build.sh`) or via `fastlane`.
 
 ## Clawpatch Code Review
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,51 @@ OpenClaw --> Plugin (openclaw/) --> homeclaw-cli --------------------------+
 
 **Single-process design.** Apple's `HMHomeManager` requires a UIKit/Catalyst app with the HomeKit entitlement. By making the entire app Catalyst, HomeKit access is direct (no IPC), signing is unified (single archive), and App Store submission is clean. The `macOSBridge` plugin bundle provides the native macOS menu bar via `NSStatusItem`.
 
+## Native MCP for Hermes
+
+HomeClaw must be running before connecting. In **Settings → Integrations**, enable **Streamable HTTP MCP**. This persistent setting is **off by default**; turning it off stops the HTTP listener without disabling existing stdio or Unix-socket clients. When enabled, the Catalyst app owns a loopback-only Streamable HTTP endpoint:
+
+```text
+http://127.0.0.1:9090/mcp
+```
+
+Loopback binding prevents remote network access; no bearer token or shell launch is required. Readiness is available at `http://127.0.0.1:9090/healthz`. In Hermes, add:
+
+```yaml
+mcp_servers:
+  homeclaw:
+    url: http://127.0.0.1:9090/mcp
+    timeout: 120
+    connect_timeout: 30
+```
+
+The stdio MCP server remains supported for Claude Desktop, Claude Code, and OpenClaw. Use the existing `npm run build:mcp` and stdio setup when a client cannot use native HTTP.
+
+### Native transport development checks
+
+`swift test` covers the CLI package only. To build and execute the full native
+Catalyst `HomeClawTests` suite on macOS 26 or later:
+
+```bash
+npm install
+node scripts/check-mcp-schema-parity.mjs
+xcodegen generate
+bash scripts/test-catalyst.sh
+```
+
+The test script saves the xcodebuild log and `.xcresult` under
+`.build/catalyst-test-evidence/` and fails on empty or skipped test results. For a
+repeat run, set `CATALYST_EVIDENCE_DIR` to a fresh directory. Unit-test hosting
+suppresses live HomeKit, socket, and menu-bar startup; these tests are not proof
+of HomeKit provisioning or real accessory access.
+
+`lib/schemas.js` is the canonical tool schema. The Swift descriptors are readable
+JSON and CI compares every descriptor against the Node export and the XCTest
+fixture. After an intentional schema edit, regenerate both reviewed copies with
+`node scripts/check-mcp-schema-parity.mjs --write`, then inspect their diff. The
+HTTP read-only allowlist remains separate and deny-by-default; adding a tool to
+the canonical schema does not expose it over HTTP.
+
 ## Install
 
 Marketing site with screenshots and full pitch: **[homeclaw.omarknows.app](https://homeclaw.omarknows.app/)**.

--- a/Sources/homeclaw/App/AppLaunchPolicy.swift
+++ b/Sources/homeclaw/App/AppLaunchPolicy.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// App-hosted unit tests exercise services explicitly with controlled fixtures;
+/// they must not also launch the user's real HomeKit/socket/menu-bar services.
+enum AppLaunchPolicy {
+    static func isUnitTestHost(environment: [String: String]) -> Bool {
+        environment["XCTestConfigurationFilePath"] != nil || environment["XCTestBundlePath"] != nil
+    }
+
+    static var suppressLiveServices: Bool {
+        #if DEBUG
+        isUnitTestHost(environment: ProcessInfo.processInfo.environment)
+            || NSClassFromString("XCTestCase") != nil
+        #else
+        false
+        #endif
+    }
+}

--- a/Sources/homeclaw/App/HTTPIntegrationLifecycle.swift
+++ b/Sources/homeclaw/App/HTTPIntegrationLifecycle.swift
@@ -1,0 +1,66 @@
+import Combine
+import Foundation
+
+/// The app owns one controller; settings only change its persisted intent.
+@MainActor
+final class HTTPIntegrationLifecycle: ObservableObject {
+    static let enabledKey = "nativeMCPHTTPEnabled"
+    @Published private(set) var isEnabled: Bool
+    @Published private(set) var errorMessage: String?
+    private let defaults: UserDefaults
+    private let start: @MainActor () async throws -> Void
+    private let stop: @MainActor () async -> Void
+    private var pending: Task<Void, Never>?
+    private var isShuttingDown = false
+
+    init(defaults: UserDefaults = .standard,
+         start: @escaping @MainActor () async throws -> Void,
+         stop: @escaping @MainActor () async -> Void) {
+        self.defaults = defaults
+        self.start = start
+        self.stop = stop
+        isEnabled = defaults.bool(forKey: Self.enabledKey)
+    }
+
+    func startIfEnabled() {
+        guard !isShuttingDown else { return }
+        if isEnabled { schedule(enabled: true) }
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        guard !isShuttingDown else { return }
+        isEnabled = enabled
+        defaults.set(enabled, forKey: Self.enabledKey)
+        schedule(enabled: enabled)
+    }
+
+    private func schedule(enabled: Bool) {
+        // Do not overlap start/stop across actor suspension points. A stop must
+        // await a pending bind, and a subsequent start must await full teardown.
+        let previous = pending
+        pending = Task {
+            await previous?.value
+            if enabled {
+                guard isEnabled, !isShuttingDown else { return }
+                do { try await start(); errorMessage = nil }
+                catch { errorMessage = error.localizedDescription }
+            } else {
+                await stop()
+                errorMessage = nil
+            }
+        }
+    }
+
+    func waitUntilSettled() async { await pending?.value }
+
+    /// Synchronous cleanup must happen before returning from UIKit's final
+    /// termination callback. Explicit Quit can additionally await this task.
+    @discardableResult
+    func beginShutdown(stopLegacy: () -> Void) -> Task<Void, Never> {
+        if isShuttingDown, let pending { return pending }
+        isShuttingDown = true
+        stopLegacy()
+        schedule(enabled: false)
+        return pending!
+    }
+}

--- a/Sources/homeclaw/App/HomeClawApp.swift
+++ b/Sources/homeclaw/App/HomeClawApp.swift
@@ -17,6 +17,21 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
     private var homeKitObserver: NSObjectProtocol?
     private var menuDataObserver: NSObjectProtocol?
     private var webhookCircuitObserver: NSObjectProtocol?
+    private lazy var mcpServer = MCPServer()
+    private(set) lazy var httpIntegration = makeHTTPIntegration()
+
+    private func makeHTTPIntegration() -> HTTPIntegrationLifecycle {
+        // Build closures outside the lazy initializer's isolation context.
+        let server = mcpServer
+        return HTTPIntegrationLifecycle(
+            start: {
+                try await server.start()
+                AppLogger.app.info("Native MCP HTTP server started")
+            },
+            stop: { await server.stop() })
+    }
+    private var terminationTask: Task<Void, Never>?
+    private let socketLifecycleQueue = DispatchQueue(label: "com.shahine.homeclaw.socket-lifecycle")
 
     /// Held for the app's lifetime to opt out of App Nap. HomeClaw is an
     /// `LSUIElement` background agent: on a headless Mac (no display/UI activity)
@@ -119,9 +134,25 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
     }
 
     @objc func quitApp() {
-        // Clean up socket before exit
-        SocketServer.shared.stop()
+        guard !AppLaunchPolicy.suppressLiveServices else { return }
+        guard terminationTask == nil else { return }
+        let shutdown = beginServerShutdown()
+        terminationTask = Task { @MainActor in
+            await shutdown.value
+            terminateApplication()
+        }
+    }
 
+    @discardableResult
+    private func beginServerShutdown() -> Task<Void, Never> {
+        httpIntegration.beginShutdown {
+            // Serialize with the off-main startup so it cannot bind after stop.
+            // This only joins synchronous socket setup, never HTTP/MainActor work.
+            socketLifecycleQueue.sync { SocketServer.shared.stop() }
+        }
+    }
+
+    private func terminateApplication() {
         #if targetEnvironment(macCatalyst)
         // Use NSApplication to terminate cleanly
         if let nsAppClass: AnyClass = NSClassFromString("NSApplication"),
@@ -146,6 +177,7 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        guard !AppLaunchPolicy.suppressLiveServices else { return true }
         AppLogger.app.info("HomeClaw starting (unified Catalyst)...")
 
         // Opt out of App Nap for the lifetime of the process so the control socket
@@ -171,8 +203,16 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
         // after the first scene connects. Creating HMHomeManager before a
         // window exists causes a TCC privacy violation crash on macOS 26.4+.
 
-        // Start socket server for CLI and MCP clients
-        SocketServer.shared.start()
+        // Opt-in only: an absent preference is false. The controller serializes
+        // runtime toggles with startup and shutdown without blocking launch.
+        httpIntegration.startIfEnabled()
+
+        // Start the legacy socket listener off the application launch path. Its
+        // filesystem bind must not prevent the native MCP HTTP listener from
+        // starting if an old app-group socket is stale or unavailable.
+        socketLifecycleQueue.async {
+            SocketServer.shared.start()
+        }
 
         // Load macOSBridge bundle for the menu bar
         #if targetEnvironment(macCatalyst)
@@ -187,8 +227,12 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
         ) { [weak self] notification in
             let ready = notification.userInfo?["ready"] as? Bool ?? false
             let names = notification.userInfo?["homeNames"] as? [String] ?? []
-            MainActor.assumeIsolated {
-                self?.macOSController?.updateStatus(ready: ready, homeNames: names)
+            Task { [weak self] in
+                guard let self else { return }
+                await self.mcpServer.updateHomeKitReady(ready)
+                await MainActor.run {
+                    self.macOSController?.updateStatus(ready: ready, homeNames: names)
+                }
             }
         }
 
@@ -258,8 +302,11 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
+        guard !AppLaunchPolicy.suppressLiveServices else { return }
         AppLogger.app.info("HomeClaw shutting down...")
-        SocketServer.shared.stop()
+        // UIKit cannot defer this callback. Stop the legacy socket synchronously;
+        // HTTP is best-effort here, but explicit Quit awaits it before terminate.
+        beginServerShutdown()
         if let observer = homeKitObserver {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -278,6 +325,10 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
         configurationForConnecting connectingSceneSession: UISceneSession,
         options: UIScene.ConnectionOptions
     ) -> UISceneConfiguration {
+        if AppLaunchPolicy.suppressLiveServices {
+            // No scene delegate means no restored settings/onboarding or HomeKit.
+            return UISceneConfiguration(name: "Unit Tests", sessionRole: connectingSceneSession.role)
+        }
         // Settings window — triggered by openSettings() via macOSBridge menu
         if options.userActivities.first?.activityType == "com.shahine.homeclaw.settings" {
             let config = UISceneConfiguration(
@@ -420,7 +471,9 @@ class SettingsSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     private func createAndShowWindow(in windowScene: UIWindowScene) {
         let w = UIWindow(windowScene: windowScene)
-        w.rootViewController = UIHostingController(rootView: SettingsView())
+        guard let app = UIApplication.shared.delegate as? HomeClawApp else { return }
+        w.rootViewController = UIHostingController(
+            rootView: SettingsView().environmentObject(app.httpIntegration))
         w.makeKeyAndVisible()
         self.window = w
 
@@ -668,6 +721,7 @@ class HeadlessSceneDelegate: UIResponder, UIWindowSceneDelegate {
         options connectionOptions: UIScene.ConnectionOptions
     ) {
         window = nil
+        guard !AppLaunchPolicy.suppressLiveServices else { return }
 
         #if targetEnvironment(macCatalyst)
         if let windowScene = scene as? UIWindowScene {

--- a/Sources/homeclaw/App/HomeClawApp.swift
+++ b/Sources/homeclaw/App/HomeClawApp.swift
@@ -31,6 +31,7 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
             stop: { await server.stop() })
     }
     private var terminationTask: Task<Void, Never>?
+    private var macTerminationObserver: NSObjectProtocol?
     private let socketLifecycleQueue = DispatchQueue(label: "com.shahine.homeclaw.socket-lifecycle")
 
     /// Held for the app's lifetime to opt out of App Nap. HomeClaw is an
@@ -179,6 +180,16 @@ class HomeClawApp: UIResponder, UIApplicationDelegate, Mac2iOS {
     ) -> Bool {
         guard !AppLaunchPolicy.suppressLiveServices else { return true }
         AppLogger.app.info("HomeClaw starting (unified Catalyst)...")
+        #if targetEnvironment(macCatalyst)
+        // AppKit system/Apple-event quit need not call UIKit's termination hook.
+        // Observe the synchronous final notification without replacing its delegate.
+        macTerminationObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name("NSApplicationWillTerminateNotification"),
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { _ = self?.beginServerShutdown() }
+        }
+        #endif
 
         // Opt out of App Nap for the lifetime of the process so the control socket
         // and menu-data pipeline keep running on headless/idle Macs. `.allowing`

--- a/Sources/homeclaw/HomeKit/HomeEventLogger.swift
+++ b/Sources/homeclaw/HomeKit/HomeEventLogger.swift
@@ -446,6 +446,18 @@ final class HomeEventLogger {
 
     // MARK: - Webhook
 
+    /// Sends a synthetic event through the same webhook delivery path used by HomeKit events.
+    @discardableResult
+    func testWebhook() -> [String: Any] {
+        guard let config = HomeClawConfig.shared.webhookConfig,
+              config.enabled,
+              !config.url.isEmpty,
+              let url = URL(string: config.url + HomeClawConfig.shared.effectiveEndpoint)
+        else { return ["sent": false, "error": "Webhook is not configured"] }
+        sendWebhookPayload(["type": "test", "source": "homeclaw"], to: url, token: config.token)
+        return ["sent": true, "endpoint": url.path]
+    }
+
     private func sendWebhookPayload(
         _ payload: [String: Any], to url: URL, token: String,
         timeout: TimeInterval = 10, isCritical: Bool = false,

--- a/Sources/homeclaw/HomeKit/HomeKitManager.swift
+++ b/Sources/homeclaw/HomeKit/HomeKitManager.swift
@@ -3913,6 +3913,7 @@ extension Notification.Name {
     static let homeKitStatusDidChange = Notification.Name("HomeKitStatusDidChange")
     static let homeKitMenuDataDidChange = Notification.Name("HomeKitMenuDataDidChange")
     static let webhookCircuitStateDidChange = Notification.Name("WebhookCircuitStateDidChange")
+    static let mcpListenerStatusDidChange = Notification.Name("MCPListenerStatusDidChange")
 }
 
 // MARK: - HMAccessoryDelegate

--- a/Sources/homeclaw/MCP/HTTPMCPConfiguration.swift
+++ b/Sources/homeclaw/MCP/HTTPMCPConfiguration.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct HTTPMCPConfiguration: Equatable, Sendable {
+    static let defaultPort = 9090
+    static let defaultBindHost = "127.0.0.1"
+    static let defaultMaxSessions = 128
+    static let defaultMaxInflightPerChannel = 16
+
+    let port: Int
+    let bindHost: String
+    let sessionTTL: TimeInterval
+    let maxSessions: Int
+    let maxInflightPerChannel: Int
+
+    init(port: Int = defaultPort, bindHost: String = defaultBindHost, sessionTTL: TimeInterval = 3600, maxSessions: Int = defaultMaxSessions, maxInflightPerChannel: Int = defaultMaxInflightPerChannel) {
+        self.port = port
+        self.bindHost = bindHost
+        self.sessionTTL = sessionTTL
+        self.maxSessions = maxSessions
+        self.maxInflightPerChannel = maxInflightPerChannel
+    }
+
+    enum ValidationError: Error, Equatable {
+        case portOutOfRange
+        case nonLoopbackBind(String)
+    }
+
+    func validateLoopbackBind() throws {
+        guard (1...65535).contains(port) else { throw ValidationError.portOutOfRange }
+        guard bindHost == "127.0.0.1" || bindHost == "::1" else {
+            throw ValidationError.nonLoopbackBind(bindHost)
+        }
+    }
+}

--- a/Sources/homeclaw/MCP/HTTPMCPHealthResponse.swift
+++ b/Sources/homeclaw/MCP/HTTPMCPHealthResponse.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A stable, deliberately minimal liveness/readiness representation.
+struct HTTPMCPHealthResponse: Equatable, Sendable {
+    let listenerReady: Bool
+    let homeKitReady: Bool
+
+    var statusCode: Int { listenerReady && homeKitReady ? 200 : 503 }
+
+    /// Serialized manually to keep key order and output stable across runtimes.
+    var bodyString: String {
+        "{\"homekit_ready\":\(homeKitReady ? "true" : "false"),\"listener_ready\":\(listenerReady ? "true" : "false"),\"status\":\"\(listenerReady && homeKitReady ? "ready" : "not_ready")\"}"
+    }
+
+    var bodyData: Data { Data(bodyString.utf8) }
+}

--- a/Sources/homeclaw/MCP/HTTPMCPRequestPolicy.swift
+++ b/Sources/homeclaw/MCP/HTTPMCPRequestPolicy.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// The request policy for the loopback-only HTTP listener.
+enum HTTPMCPRequestPolicy {
+    enum ValidationError: Error, Equatable {
+        case invalidHost
+        case nonLoopbackHost
+        case hostDoesNotMatchBind
+        case invalidOrigin
+        case nonLoopbackOrigin
+    }
+
+    static func validate(host: String, origin: String?, bindHost: String) throws {
+        guard let hostURL = URL(string: "http://\(host)"),
+              hostURL.user == nil, hostURL.password == nil,
+              hostURL.path.isEmpty || hostURL.path == "/",
+              hostURL.query == nil, hostURL.fragment == nil,
+              let hostName = hostURL.host?.lowercased()
+        else { throw ValidationError.invalidHost }
+
+        guard isLoopback(hostName) else { throw ValidationError.nonLoopbackHost }
+        let normalizedBindHost = normalized(bindHost)
+        let bindAllowsLocalhost = normalizedBindHost == "127.0.0.1" || normalizedBindHost == "localhost"
+        guard hostName == normalizedBindHost || (bindAllowsLocalhost && hostName == "localhost")
+        else { throw ValidationError.hostDoesNotMatchBind }
+
+        guard let origin = origin else { return }
+        guard let originURL = URL(string: origin),
+              (originURL.scheme?.lowercased() == "http" || originURL.scheme?.lowercased() == "https"),
+              originURL.user == nil, originURL.password == nil,
+              originURL.path.isEmpty || originURL.path == "/",
+              originURL.query == nil, originURL.fragment == nil,
+              let originHost = originURL.host?.lowercased()
+        else { throw ValidationError.invalidOrigin }
+        guard isLoopback(originHost) else { throw ValidationError.nonLoopbackOrigin }
+    }
+
+    private static func normalized(_ host: String) -> String {
+        host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+    }
+
+    private static func isLoopback(_ host: String) -> Bool {
+        ["127.0.0.1", "::1", "localhost"].contains(host)
+    }
+}

--- a/Sources/homeclaw/MCP/MCPHTTPHandler.swift
+++ b/Sources/homeclaw/MCP/MCPHTTPHandler.swift
@@ -1,0 +1,136 @@
+import Foundation
+@preconcurrency import NIOCore
+@preconcurrency import NIOHTTP1
+
+final class MCPHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPServerRequestPart; typealias OutboundOut = HTTPServerResponsePart
+    private let server: MCPServer; private let maximumBodyBytes = 1_048_576
+    private struct RequestState: Sendable { var head: HTTPRequestHead; var bodyBuffer: ByteBuffer; let responseTicket: Int }
+    private var requestState: RequestState?; private var rejectedBody = false
+    private var activeTasks: [UUID: Task<Void, Never>] = [:]
+    private let maxInflight = HTTPMCPConfiguration.defaultMaxInflightPerChannel
+    private let lifecycle = MCPHTTPHandlerLifecycle()
+    private let responseOrder = MCPHTTPResponseOrder()
+    init(server: MCPServer) { self.server = server }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch unwrapInboundIn(data) {
+        case .head(let head):
+            rejectedBody = false
+            let responseTicket = responseOrder.reserve()
+            if let length = head.headers.first(name: "Content-Length").flatMap(Int.init), length > maximumBodyBytes {
+                rejectedBody = true; requestState = nil
+                Self.schedule(.error(statusCode: 413, "Request body too large"), version: head.version, on: context.channel, order: responseOrder, ticket: responseTicket)
+                return
+            }
+            requestState = RequestState(head: head, bodyBuffer: context.channel.allocator.buffer(capacity: 0), responseTicket: responseTicket)
+        case .body(var buffer):
+            guard !rejectedBody else { return }
+            guard var state = requestState, buffer.readableBytes <= maximumBodyBytes, state.bodyBuffer.readableBytes + buffer.readableBytes <= maximumBodyBytes else {
+                rejectedBody = true; let version = requestState?.head.version ?? .http1_1; let ticket = requestState?.responseTicket
+                requestState = nil
+                if let ticket { Self.schedule(.error(statusCode: 413, "Request body too large"), version: version, on: context.channel, order: responseOrder, ticket: ticket) }
+                return
+            }
+            state.bodyBuffer.writeBuffer(&buffer); requestState = state
+        case .end:
+            guard !rejectedBody, let state = requestState else { requestState = nil; rejectedBody = false; return }
+            // Bound pipelined work per channel — 1 MiB per request does not bound aggregate
+            if activeTasks.count >= maxInflight {
+                let ticket = state.responseTicket; requestState = nil
+                Self.schedule(.error(statusCode: 429, "Too many concurrent requests"), version: state.head.version, on: context.channel, order: responseOrder, ticket: ticket)
+                return
+            }
+            requestState = nil; let taskID = UUID(); let sessionID = state.head.headers.first(name: "Mcp-Session-Id"); lifecycle.begin(taskID: taskID, sessionID: sessionID)
+            let channel = context.channel
+            let responseOrder = self.responseOrder
+            let responseTicket = state.responseTicket
+            let task = Task { [weak self, server, state, channel, responseOrder, responseTicket] in
+                defer {
+                    responseOrder.finish(responseTicket)
+                    channel.eventLoop.execute { [weak self] in self?.lifecycle.finish(taskID: taskID); self?.activeTasks.removeValue(forKey: taskID) }
+                }
+                guard channel.isActive, let self else { return }
+                let request = Self.makeHTTPRequest(from: state)
+                let response: HTTPResponse
+                if let host = request.header("Host") {
+                    do { try HTTPMCPRequestPolicy.validate(host: host, origin: request.header("Origin"), bindHost: await server.bindHost); response = await server.handleHTTPRequest(request) }
+                    catch { response = .error(statusCode: 400, "Invalid request policy") }
+                } else { response = .error(statusCode: 400, "Invalid request policy") }
+                await Self.cleanupCancelledRequestIfNeeded(sseOwnership: response.sseOwnership, isCancelled: Task.isCancelled) { await server.cleanupSSE(for: $0) }
+                guard !Task.isCancelled, channel.isActive else { return }
+                if let ownership = response.sseOwnership { channel.eventLoop.execute { [weak self] in self?.lifecycle.markSSEActive(ownership) } }
+                await Self.writeOrdered(response, version: state.head.version, channel: channel, order: responseOrder, ticket: responseTicket)
+                if let ownership = response.sseOwnership { channel.eventLoop.execute { [weak self] in self?.lifecycle.finishSSE(ownership) } }
+            }
+            activeTasks[taskID] = task
+        }
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        activeTasks.values.forEach { $0.cancel() }; activeTasks.removeAll(); responseOrder.cancelAll(); let sessions = lifecycle.cancelAll(); requestState = nil; rejectedBody = false
+        Task { await server.cleanupSSE(for: sessions) }
+    }
+    static func cleanupCancelledRequestIfNeeded(sseOwnership: SSEStreamOwnership?, isCancelled: Bool, cleanup: @escaping @Sendable (SSEStreamOwnership) async -> Void) async { guard isCancelled, let sseOwnership else { return }; await cleanup(sseOwnership) }
+    static func normalizedHeaders(from headers: HTTPHeaders) -> [String: String] {
+        var normalized: [String: String] = [:]
+        for (name, value) in headers {
+            if let existing = normalized.first(where: { $0.key.caseInsensitiveCompare(name) == .orderedSame }) {
+                normalized[existing.key] = "\(existing.value), \(value)"
+            } else {
+                normalized[name] = value
+            }
+        }
+        return normalized
+    }
+
+    private static func makeHTTPRequest(from state: RequestState) -> HTTPRequest {
+        let body = state.bodyBuffer.readableBytes > 0 ? state.bodyBuffer.getBytes(at: 0, length: state.bodyBuffer.readableBytes).map { Data(bytes: $0) } : nil
+        return HTTPRequest(method: state.head.method.rawValue, uri: state.head.uri, headers: normalizedHeaders(from: state.head.headers), body: body)
+    }
+    private static func schedule(_ response: HTTPResponse, version: HTTPVersion, on channel: Channel, order: MCPHTTPResponseOrder, ticket: Int) {
+        Task {
+            await order.waitTurn(ticket)
+            defer { order.finish(ticket) }
+            channel.eventLoop.execute {
+                guard channel.isActive else { return }
+                writeParts(response, version: version, channel: channel)
+                channel.writeAndFlush(wrapOutbound(.end(nil)), promise: nil)
+            }
+        }
+    }
+    private static func writeOrdered(_ response: HTTPResponse, version: HTTPVersion, channel: Channel, order: MCPHTTPResponseOrder, ticket: Int) async {
+        await order.waitTurn(ticket)
+        defer { order.finish(ticket) }
+        await write(response, version: version, channel: channel)
+    }
+    private static func write(_ response: HTTPResponse, version: HTTPVersion, channel: Channel) async {
+        await withTaskCancellationHandler(operation: {
+            guard !Task.isCancelled, channel.isActive else { return }
+            await writePartsAsync(response, version: version, channel: channel)
+        }, onCancel: {})
+    }
+    private static func writePartsAsync(_ response: HTTPResponse, version: HTTPVersion, channel: Channel) async {
+        channel.eventLoop.execute { guard channel.isActive else { return }; writeParts(response, version: version, channel: channel) }
+        if let stream = response.stream {
+            for await chunk in stream {
+                if Task.isCancelled { return }
+                channel.eventLoop.execute { guard channel.isActive else { return }; var buffer = channel.allocator.buffer(capacity: chunk.count); buffer.writeBytes(chunk); channel.writeAndFlush(Self.wrapOutbound(.body(.byteBuffer(buffer))), promise: nil) }
+            }
+        }
+        guard !Task.isCancelled else { return }
+        channel.eventLoop.execute { guard channel.isActive else { return }; channel.writeAndFlush(Self.wrapOutbound(.end(nil)), promise: nil) }
+    }
+    private static func writeParts(_ response: HTTPResponse, version: HTTPVersion, channel: Channel) {
+        var head = HTTPResponseHead(version: version, status: HTTPResponseStatus(statusCode: response.statusCode))
+        // Add Content-Length for fixed-size non-stream responses (HTTP/1.1 framing)
+        if let body = response.bodyData, response.stream == nil {
+            head.headers.add(name: "Content-Length", value: "\(body.count)")
+        }
+        for (name, value) in response.headers { head.headers.add(name: name, value: value) }
+        channel.write(wrapOutbound(.head(head)), promise: nil)
+        if response.stream == nil, let body = response.bodyData { var buffer = channel.allocator.buffer(capacity: body.count); buffer.writeBytes(body); channel.write(wrapOutbound(.body(.byteBuffer(buffer))), promise: nil) }
+        if response.stream != nil { channel.flush() }
+    }
+    private static func wrapOutbound(_ part: HTTPServerResponsePart) -> NIOAny { NIOAny(part) }
+}

--- a/Sources/homeclaw/MCP/MCPHTTPHandler.swift
+++ b/Sources/homeclaw/MCP/MCPHTTPHandler.swift
@@ -57,19 +57,34 @@ final class MCPHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
                     do { try HTTPMCPRequestPolicy.validate(host: host, origin: request.header("Origin"), bindHost: await server.bindHost); response = await server.handleHTTPRequest(request) }
                     catch { response = .error(statusCode: 400, "Invalid request policy") }
                 } else { response = .error(statusCode: 400, "Invalid request policy") }
-                await Self.cleanupCancelledRequestIfNeeded(sseOwnership: response.sseOwnership, isCancelled: Task.isCancelled) { await server.cleanupSSE(for: $0) }
-                guard !Task.isCancelled, channel.isActive else { return }
-                if let ownership = response.sseOwnership { channel.eventLoop.execute { [weak self] in self?.lifecycle.markSSEActive(ownership) } }
+                guard !Task.isCancelled, channel.isActive else {
+                    await Self.cleanupCancelledRequestIfNeeded(sseOwnership: response.sseOwnership, isCancelled: true) { await server.cleanupSSE(for: $0) }
+                    return
+                }
+                if let ownership = response.sseOwnership {
+                    channel.eventLoop.execute { [weak self] in
+                        // channelInactive may have run before this queued handoff.
+                        guard channel.isActive else { return }
+                        self?.lifecycle.markSSEActive(ownership)
+                    }
+                }
                 await Self.writeOrdered(response, version: state.head.version, channel: channel, order: responseOrder, ticket: responseTicket)
-                if let ownership = response.sseOwnership { channel.eventLoop.execute { [weak self] in self?.lifecycle.finishSSE(ownership) } }
+                if let ownership = response.sseOwnership {
+                    // The response task owns this token even before event-loop
+                    // registration. Always retire it on exit: cancellation can
+                    // race the guard above or occur while waiting for FIFO writes.
+                    // Token matching leaves a newer connection's stream intact.
+                    await server.cleanupSSE(for: ownership)
+                    channel.eventLoop.execute { [weak self] in self?.lifecycle.finishSSE(ownership) }
+                }
             }
             activeTasks[taskID] = task
         }
     }
 
     func channelInactive(context: ChannelHandlerContext) {
-        activeTasks.values.forEach { $0.cancel() }; activeTasks.removeAll(); responseOrder.cancelAll(); let sessions = lifecycle.cancelAll(); requestState = nil; rejectedBody = false
-        Task { await server.cleanupSSE(for: sessions) }
+        activeTasks.values.forEach { $0.cancel() }; activeTasks.removeAll(); responseOrder.cancelAll(); let ownerships = lifecycle.cancelAll(); requestState = nil; rejectedBody = false
+        Task { for ownership in ownerships { await server.cleanupSSE(for: ownership) } }
     }
     static func cleanupCancelledRequestIfNeeded(sseOwnership: SSEStreamOwnership?, isCancelled: Bool, cleanup: @escaping @Sendable (SSEStreamOwnership) async -> Void) async { guard isCancelled, let sseOwnership else { return }; await cleanup(sseOwnership) }
     static func normalizedHeaders(from headers: HTTPHeaders) -> [String: String] {

--- a/Sources/homeclaw/MCP/MCPHTTPHandlerLifecycle.swift
+++ b/Sources/homeclaw/MCP/MCPHTTPHandlerLifecycle.swift
@@ -101,14 +101,16 @@ final class MCPHTTPHandlerLifecycle {
         retireSessionIfUnused(ownership.sessionID)
     }
 
-    func cancelAll() -> [String] {
-        let sessions = activeSessionIDs
+    /// Only streams owned by this channel may be retired on disconnect. A POST
+    /// borrows a session ID; it does not own that session's stream.
+    func cancelAll() -> Set<SSEStreamOwnership> {
+        let ownerships = activeSSEOwnerships
         activeTaskIDs.removeAll()
         activeSessionIDs.removeAll()
         activeSSESessionIDs.removeAll()
         activeSSEOwnerships.removeAll()
         taskSessions.removeAll()
-        return sessions.sorted()
+        return ownerships
     }
 
     private func retireSessionIfUnused(_ sessionID: String?) {

--- a/Sources/homeclaw/MCP/MCPHTTPHandlerLifecycle.swift
+++ b/Sources/homeclaw/MCP/MCPHTTPHandlerLifecycle.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// A per-channel FIFO gate for HTTP/1.1 response writes.
+///
+/// Requests may execute concurrently, but a response cannot begin until every
+/// earlier request on the channel has finished writing its response.
+final class MCPHTTPResponseOrder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var nextTicket = 0
+    private var nextToWrite = 0
+    private var completed: Set<Int> = []
+    private var waiters: [Int: CheckedContinuation<Void, Never>] = [:]
+
+    func reserve() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        defer { nextTicket += 1 }
+        return nextTicket
+    }
+
+    func waitTurn(_ ticket: Int) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            let canProceed = ticket < nextToWrite || completed.contains(ticket) || ticket == nextToWrite
+            if !canProceed { waiters[ticket] = continuation }
+            lock.unlock()
+            if canProceed { continuation.resume() }
+        }
+    }
+
+    func finish(_ ticket: Int) {
+        var resumptions: [CheckedContinuation<Void, Never>] = []
+        lock.lock()
+        if ticket >= nextToWrite {
+            completed.insert(ticket)
+            while completed.remove(nextToWrite) != nil {
+                if let continuation = waiters.removeValue(forKey: nextToWrite) {
+                    resumptions.append(continuation)
+                }
+                nextToWrite += 1
+            }
+            // Advancing the frontier makes the next unfinished response eligible.
+            // It may already be suspended in waitTurn; wake it, not just tickets
+            // marked completed by cancellation or out-of-order completion.
+            if let continuation = waiters.removeValue(forKey: nextToWrite) {
+                resumptions.append(continuation)
+            }
+        }
+        lock.unlock()
+        resumptions.forEach { $0.resume() }
+    }
+
+    func cancelAll() {
+        var resumptions: [CheckedContinuation<Void, Never>] = []
+        lock.lock()
+        completed.formUnion(nextToWrite..<nextTicket)
+        while completed.remove(nextToWrite) != nil {
+            if let continuation = waiters.removeValue(forKey: nextToWrite) {
+                resumptions.append(continuation)
+            }
+            nextToWrite += 1
+        }
+        lock.unlock()
+        resumptions.forEach { $0.resume() }
+    }
+}
+
+/// Event-loop-confined bookkeeping for request tasks and SSE sessions.
+///
+/// This type intentionally stores only task handles and identifiers. Request
+/// closures are owned by their Task and are not retained by lifecycle state.
+final class MCPHTTPHandlerLifecycle {
+    private(set) var activeTaskIDs: Set<UUID> = []
+    private(set) var activeSessionIDs: Set<String> = []
+    private(set) var activeSSESessionIDs: Set<String> = []
+    private(set) var activeSSEOwnerships: Set<SSEStreamOwnership> = []
+    private var taskSessions: [UUID: String?] = [:]
+
+    func begin(taskID: UUID, sessionID: String?) {
+        activeTaskIDs.insert(taskID)
+        taskSessions[taskID] = sessionID
+        if let sessionID { activeSessionIDs.insert(sessionID) }
+    }
+
+    func markSSEActive(_ ownership: SSEStreamOwnership) {
+        activeSSEOwnerships.insert(ownership)
+        activeSSESessionIDs.insert(ownership.sessionID)
+        activeSessionIDs.insert(ownership.sessionID)
+    }
+
+    func finish(taskID: UUID) {
+        guard activeTaskIDs.remove(taskID) != nil else { return }
+        let sessionID = taskSessions.removeValue(forKey: taskID) ?? nil
+        retireSessionIfUnused(sessionID)
+    }
+
+    func finishSSE(_ ownership: SSEStreamOwnership) {
+        guard activeSSEOwnerships.remove(ownership) != nil else { return }
+        if !activeSSEOwnerships.contains(where: { $0.sessionID == ownership.sessionID }) {
+            activeSSESessionIDs.remove(ownership.sessionID)
+        }
+        retireSessionIfUnused(ownership.sessionID)
+    }
+
+    func cancelAll() -> [String] {
+        let sessions = activeSessionIDs
+        activeTaskIDs.removeAll()
+        activeSessionIDs.removeAll()
+        activeSSESessionIDs.removeAll()
+        activeSSEOwnerships.removeAll()
+        taskSessions.removeAll()
+        return sessions.sorted()
+    }
+
+    private func retireSessionIfUnused(_ sessionID: String?) {
+        guard let sessionID,
+              !activeSSESessionIDs.contains(sessionID),
+              !taskSessions.values.contains(where: { $0 == sessionID }) else { return }
+        activeSessionIDs.remove(sessionID)
+    }
+}

--- a/Sources/homeclaw/MCP/MCPServer.swift
+++ b/Sources/homeclaw/MCP/MCPServer.swift
@@ -1,0 +1,331 @@
+import Foundation
+import NIOCore
+import NIOPosix
+import NIOHTTP1
+
+struct HTTPRequest: Sendable {
+    let method: String
+    let uri: String
+    let headers: [String: String]
+    let body: Data?
+    init(method: String, uri: String = "/mcp", headers: [String: String] = [:], body: Data? = nil) {
+        self.method = method; self.uri = uri; self.body = body
+        var merged: [String: String] = [:]
+        for (name, value) in headers {
+            if let existing = merged.first(where: { $0.key.caseInsensitiveCompare(name) == .orderedSame }) {
+                merged[existing.key] = "\(existing.value), \(value)"
+            } else { merged[name] = value }
+        }
+        self.headers = merged
+    }
+    func header(_ name: String) -> String? { headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value }
+}
+
+struct SSEStreamOwnership: Sendable, Hashable { let sessionID: String; let token: UUID }
+
+struct HTTPResponse: Sendable, Equatable {
+    let statusCode: Int; let headers: [String: String]; let bodyData: Data?
+    let stream: AsyncStream<Data>?; let sseOwnership: SSEStreamOwnership?
+    init(statusCode: Int, headers: [String: String] = [:], bodyData: Data? = nil, stream: AsyncStream<Data>? = nil, sseOwnership: SSEStreamOwnership? = nil) {
+        self.statusCode = statusCode; self.headers = headers; self.bodyData = bodyData; self.stream = stream; self.sseOwnership = sseOwnership
+    }
+    func header(_ name: String) -> String? { headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value }
+    var bodyString: String? { bodyData.flatMap { String(data: $0, encoding: .utf8) } }
+    static func == (lhs: HTTPResponse, rhs: HTTPResponse) -> Bool { lhs.statusCode == rhs.statusCode && lhs.headers == rhs.headers && lhs.bodyData == rhs.bodyData }
+    static func error(statusCode: Int, _ message: String) -> HTTPResponse {
+        HTTPResponse(statusCode: statusCode, headers: ["Content-Type": "application/json; charset=utf-8"], bodyData: MCPServer.jsonRPCErrorData(code: -32600, message: message))
+    }
+}
+
+actor MCPServer {
+    static let supportedProtocolVersion = "2025-06-18"
+    private let configuration: HTTPMCPConfiguration
+    private var group: MultiThreadedEventLoopGroup?; private var channel: Channel?
+    private var listenerReady = false; private var homeKitReady: Bool
+    private let toolRegistry: MCPToolRegistry
+    private var sseContinuations: [String: (ownership: SSEStreamOwnership, continuation: AsyncStream<Data>.Continuation)] = [:]
+    private var expiryTask: Task<Void, Never>?
+    private let dispatchTimeout: Duration
+    let sessionStore: StreamableHTTPSessionStore
+    private var lifecycleGeneration: UInt64 = 0
+    private var isStarting = false
+    private static let readOnlyTools: Set<String> = ["homekit_status", "homekit_accessories", "homekit_rooms", "homekit_device_map", "homekit_events"]
+
+    init(configuration: HTTPMCPConfiguration = .init(port: AppConfig.mcpPort, bindHost: AppConfig.mcpBindHost), homeKitReady: Bool = false, sessionStore: StreamableHTTPSessionStore? = nil, toolRegistry: MCPToolRegistry = HomeClawMCPToolRegistry.shared, dispatchTimeout: Duration = .seconds(120)) {
+        self.configuration = configuration; self.homeKitReady = homeKitReady; self.toolRegistry = toolRegistry; self.dispatchTimeout = dispatchTimeout
+        self.sessionStore = sessionStore ?? .init(ttl: configuration.sessionTTL, maxSessions: configuration.maxSessions)
+    }
+    var endpoint: String { AppConfig.mcpEndpoint }; var bindHost: String { configuration.bindHost }
+    func updateHomeKitReady(_ ready: Bool) { homeKitReady = ready; NotificationCenter.default.post(name: .mcpListenerStatusDidChange, object: nil, userInfo: ["listenerReady": listenerReady, "homeKitReady": ready]) }
+
+    func start() async throws {
+        guard channel == nil, !isStarting else { return }; try configuration.validateLoopbackBind()
+        isStarting = true; defer { isStarting = false }
+        let generation = lifecycleGeneration
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        do {
+            let channel = try await ServerBootstrap(group: group).serverChannelOption(.backlog, value: 256).serverChannelOption(.socketOption(.so_reuseaddr), value: 1).childChannelInitializer { channel in channel.pipeline.configureHTTPServerPipeline().flatMap { channel.pipeline.addHandler(MCPHTTPHandler(server: self)) } }.bind(host: configuration.bindHost, port: configuration.port).get()
+            guard generation == lifecycleGeneration else {
+                try? await channel.close()
+                try? await group.shutdownGracefully()
+                return
+            }
+            self.group = group; self.channel = channel; listenerReady = true; startExpiryCleanup()
+            NotificationCenter.default.post(name: .mcpListenerStatusDidChange, object: nil, userInfo: ["listenerReady": true, "homeKitReady": homeKitReady])
+        } catch { try? await group.shutdownGracefully(); throw error }
+    }
+    func stop() async {
+        lifecycleGeneration &+= 1
+        let channel = self.channel; let group = self.group; self.channel = nil; self.group = nil; listenerReady = false
+        expiryTask?.cancel(); expiryTask = nil; cleanupSSE(for: Array(sseContinuations.keys)); _ = await sessionStore.removeAll()
+        NotificationCenter.default.post(name: .mcpListenerStatusDidChange, object: nil, userInfo: ["listenerReady": false, "homeKitReady": homeKitReady])
+        if let channel { try? await channel.close() }; if let group { try? await group.shutdownGracefully() }
+    }
+    func cleanupSSE(for sessionIDs: [String]) { sessionIDs.forEach { sseContinuations.removeValue(forKey: $0)?.continuation.finish() } }
+    func cleanupSSE(for ownership: SSEStreamOwnership) { guard sseContinuations[ownership.sessionID]?.ownership == ownership else { return }; sseContinuations.removeValue(forKey: ownership.sessionID)?.continuation.finish() }
+    func cleanupSSE(for sessionID: String) { cleanupSSE(for: [sessionID]) }
+    func cleanupExpiredSessions(now: Date = Date()) async { cleanupSSE(for: await sessionStore.removeExpiredIDs(now: now)) }
+    func startExpiryCleanup() { guard expiryTask == nil else { return }; let interval = max(1, min(configuration.sessionTTL / 2, 60)); expiryTask = Task { [weak self] in while !Task.isCancelled { do { try await Task.sleep(for: .seconds(interval)) } catch { return }; guard let self, !Task.isCancelled else { return }; await self.cleanupExpiredSessions() } } }
+
+    func handleHTTPRequest(_ request: HTTPRequest) async -> HTTPResponse {
+        await cleanupExpiredSessions(); let path = request.uri.split(separator: "?").first.map(String.init) ?? request.uri
+        if path == "/healthz" { let h = HTTPMCPHealthResponse(listenerReady: listenerReady, homeKitReady: homeKitReady); return HTTPResponse(statusCode: h.statusCode, headers: ["Content-Type": "application/json; charset=utf-8"], bodyData: h.bodyData) }
+        guard path == URL(string: endpoint)?.path || path == endpoint else { return protocolError(status: 404, code: -32600, message: "Not Found") }
+        let method = request.method.uppercased(); guard ["POST", "GET", "DELETE"].contains(method) else { return protocolError(status: 405, code: -32600, message: "Method Not Allowed", headers: ["Allow": "GET, POST, DELETE"]) }
+        let acceptableResponse = switch method {
+        case "POST": acceptsJSON(request.header("Accept"))
+        case "GET": acceptsEventStream(request.header("Accept"))
+        default: accepts(request.header("Accept"))
+        }
+        guard acceptableResponse else { return protocolError(status: 406, code: -32600, message: "Accept must include application/json for POST or text/event-stream for GET") }
+        if method == "POST" { return await handlePOST(request) }
+        guard let id = request.header("Mcp-Session-Id") else { return protocolError(status: 400, code: -32600, message: "Missing Mcp-Session-Id header") }
+        guard await sessionStore.validateAndTouch(id) else { return protocolError(status: 404, code: -32600, message: "Session not found or expired") }
+        guard request.header("MCP-Protocol-Version") == Self.supportedProtocolVersion else { return protocolError(status: 400, code: -32600, message: "Unsupported or missing MCP-Protocol-Version") }
+        if method == "DELETE" { cleanupSSE(for: id); _ = await sessionStore.remove(id); return HTTPResponse(statusCode: 200) }
+        var continuation: AsyncStream<Data>.Continuation!; let stream = AsyncStream<Data> { continuation = $0 }; continuation.yield(Data(": connected\n\n".utf8)); let ownership = SSEStreamOwnership(sessionID: id, token: UUID())
+        sseContinuations.removeValue(forKey: id)?.continuation.finish(); sseContinuations[id] = (ownership, continuation)
+        return HTTPResponse(statusCode: 200, headers: ["Content-Type": "text/event-stream", "Cache-Control": "no-cache"], stream: stream, sseOwnership: ownership)
+    }
+
+    private func handlePOST(_ request: HTTPRequest) async -> HTTPResponse {
+        guard contentTypeIsJSON(request.header("Content-Type")) else { return protocolError(status: 415, code: -32600, message: "Content-Type must be application/json") }
+        guard let body = request.body, let object = try? JSONSerialization.jsonObject(with: body), let json = object as? [String: Any], isJSONRPC(json) else { return protocolError(status: 400, code: -32600, message: "Invalid JSON-RPC request") }
+        let method = json["method"] as? String; let initialize = method == "initialize"; let supplied = request.header("Mcp-Session-Id")
+        if initialize && supplied != nil { return protocolError(status: 400, code: -32600, message: "Initialize must not include Mcp-Session-Id") }
+        // Notifications (no "id") never create sessions; they are not addressable — check before validation
+        let isNotification = !json.keys.contains("id")
+        if isNotification, initialize { return HTTPResponse(statusCode: 202) }
+        // Validate initialize params before allocating any session state (only for non-notification initialize)
+        if initialize, let paramsError = validateInitializeParams(json) { return paramsError }
+        if initialize {
+        } else {
+            guard request.header("MCP-Protocol-Version") == Self.supportedProtocolVersion else { return protocolError(status: 400, code: -32600, message: "Unsupported or missing MCP-Protocol-Version") }
+            guard let supplied else { return protocolError(status: 400, code: -32600, message: "Missing Mcp-Session-Id header") }
+            guard await sessionStore.validateAndTouch(supplied) else { return protocolError(status: 404, code: -32600, message: "Session not found or expired") }
+            if isNotification { return HTTPResponse(statusCode: 202) }
+        }
+        let id: String
+        if let supplied {
+            id = supplied
+        } else {
+            guard let created = await sessionStore.create() else {
+                return protocolError(status: 429, code: -32600, message: "Too many sessions")
+            }
+            id = created
+        }
+        guard !isNotification else { return HTTPResponse(statusCode: 202) }
+        var headers = ["Content-Type": "application/json; charset=utf-8"]; if supplied == nil { headers["Mcp-Session-Id"] = id }
+        return HTTPResponse(statusCode: 200, headers: headers, bodyData: await rpcResponse(for: json))
+    }
+
+    private func validateInitializeParams(_ json: [String: Any]) -> HTTPResponse? {
+        guard let params = json["params"] as? [String: Any] else {
+            return protocolError(status: 400, code: -32602, message: "Missing initialize params")
+        }
+        guard let pv = params["protocolVersion"] as? String, pv == Self.supportedProtocolVersion else {
+            return protocolError(status: 400, code: -32602, message: "Invalid or missing protocolVersion")
+        }
+        guard params["capabilities"] is [String: Any] else {
+            return protocolError(status: 400, code: -32602, message: "Missing capabilities")
+        }
+        guard let ci = params["clientInfo"] as? [String: Any], ci["name"] is String, ci["version"] is String else {
+            return protocolError(status: 400, code: -32602, message: "Missing clientInfo")
+        }
+        return nil
+    }
+
+    private func rpcResponse(for json: [String: Any]) async -> Data {
+        let id = json["id"] ?? NSNull(); guard let method = json["method"] as? String else { return Self.jsonRPCErrorData(id: id, code: -32600, message: "Invalid Request") }
+        if method == "initialize" { return jsonData(["jsonrpc":"2.0", "id":id, "result":["protocolVersion":Self.supportedProtocolVersion, "capabilities":["tools":["listChanged":false]], "serverInfo":["name":"HomeClaw", "version":AppConfig.version]]]) }
+        if method == "tools/list" { return jsonData(["jsonrpc":"2.0", "id":id, "result":["tools":advertisedReadOnlyTools()]]) }
+        guard method == "tools/call" else { return Self.jsonRPCErrorData(id: id, code: -32601, message: "Method not found") }
+        guard let params = json["params"] as? [String: Any], let name = params["name"] as? String, advertisedReadOnlyTools().contains(where: { $0["name"] as? String == name }), Self.isReadOnlyCall(name: name, arguments: params["arguments"] as? [String: Any] ?? [:]) else { return Self.jsonRPCErrorData(id: id, code: -32602, message: "Invalid params") }
+        let args = (try? JSONSerialization.data(withJSONObject: params["arguments"] as? [String: Any] ?? [:])) ?? Data("{}".utf8)
+        let data = await dispatchWithTimeout(name: name, arguments: args)
+        let isError = ((try? JSONSerialization.jsonObject(with: data)) as? [String: Any])?["error"] != nil
+        return jsonData(["jsonrpc":"2.0", "id":id, "result":["content":[["type":"text", "text":String(decoding:data, as: UTF8.self)]], "isError":isError]])
+    }
+    private func dispatchWithTimeout(name: String, arguments: Data) async -> Data {
+        await DispatchTimeoutRace.run(timeout: dispatchTimeout, timeoutValue: Data("{\"error\":\"Tool dispatch timed out\"}".utf8)) {
+            await self.toolRegistry.call(name: name, arguments: arguments)
+        }
+    }
+}
+
+final class DispatchTimeoutRace<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completed = false
+    private var work: Task<Void, Never>?
+    private var sleeper: Task<Void, Never>?
+    private let continuation: CheckedContinuation<Value, Never>
+
+    private init(_ continuation: CheckedContinuation<Value, Never>) {
+        self.continuation = continuation
+    }
+
+    static func run(
+        timeout: Duration,
+        timeoutValue: Value,
+        operation: @escaping @Sendable () async -> Value
+    ) async -> Value {
+        await withCheckedContinuation { continuation in
+            let race = DispatchTimeoutRace(continuation)
+            let work = Task { race.finish(with: await operation(), cancelling: .sleeper) }
+            let sleeper = Task {
+#if DEBUG
+                DispatchTimeoutDebug.sleeperStarted()
+                defer { DispatchTimeoutDebug.sleeperFinished() }
+#endif
+                do { try await Task.sleep(for: timeout) } catch { return }
+                race.finish(with: timeoutValue, cancelling: .work)
+            }
+            race.install(work: work, sleeper: sleeper)
+        }
+    }
+
+    private enum Loser { case work, sleeper }
+
+    private func install(work: Task<Void, Never>, sleeper: Task<Void, Never>) {
+        lock.lock()
+        if completed {
+            lock.unlock()
+            work.cancel(); sleeper.cancel()
+        } else {
+            self.work = work; self.sleeper = sleeper
+            lock.unlock()
+        }
+    }
+
+    private func finish(with value: Value, cancelling loser: Loser) {
+        lock.lock()
+        guard !completed else { lock.unlock(); return }
+        completed = true
+        let work = self.work
+        let sleeper = self.sleeper
+        self.work = nil; self.sleeper = nil
+        lock.unlock()
+
+        switch loser {
+        case .work: work?.cancel()
+        case .sleeper: sleeper?.cancel()
+        }
+        continuation.resume(returning: value)
+    }
+}
+
+#if DEBUG
+private enum DispatchTimeoutDebug {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var activeSleeperTasks = 0
+
+    static func sleeperStarted() { lock.lock(); activeSleeperTasks += 1; lock.unlock() }
+    static func sleeperFinished() { lock.lock(); activeSleeperTasks -= 1; lock.unlock() }
+    static var activeSleeperCount: Int { lock.lock(); defer { lock.unlock() }; return activeSleeperTasks }
+}
+
+extension MCPServer {
+    static var testActiveTimeoutSleeperCount: Int { DispatchTimeoutDebug.activeSleeperCount }
+}
+#endif
+
+private extension MCPServer {
+    func advertisedReadOnlyTools() -> [[String: Any]] {
+        ((try? JSONSerialization.jsonObject(with: toolRegistry.toolsJSON)) as? [[String: Any]] ?? [])
+            .filter { Self.readOnlyTools.contains($0["name"] as? String ?? "") }
+            .map { tool in
+                guard tool["name"] as? String == "homekit_accessories",
+                      var schema = tool["inputSchema"] as? [String: Any],
+                      var properties = schema["properties"] as? [String: Any],
+                      var action = properties["action"] as? [String: Any],
+                      let actions = action["enum"] as? [Any] else { return tool }
+                action["enum"] = actions.filter { $0 as? String != "control" }
+                properties["action"] = action
+                schema["properties"] = properties
+                var filteredTool = tool
+                filteredTool["inputSchema"] = schema
+                return filteredTool
+            }
+    }
+
+    static func isReadOnlyCall(name: String, arguments: [String: Any]) -> Bool {
+        guard name == "homekit_accessories" else { return true }
+        return ["list", "get", "search"].contains(arguments["action"] as? String ?? "list")
+    }
+    private func protocolError(status: Int, code: Int, message: String, headers: [String:String] = [:]) -> HTTPResponse { return HTTPResponse(statusCode: status, headers: headers.merging(["Content-Type":"application/json; charset=utf-8"]) { _, new in new }, bodyData: Self.jsonRPCErrorData(code: code, message: message)) }
+    private func jsonData(_ value: [String: Any]) -> Data { (try? JSONSerialization.data(withJSONObject: value)) ?? Data() }
+    static func jsonRPCErrorData(id: Any? = nil, code: Int, message: String) -> Data { var object: [String: Any] = ["jsonrpc":"2.0", "error":["code":code, "message":message]]; if let id { object["id"] = id }; return (try? JSONSerialization.data(withJSONObject: object)) ?? Data() }
+    private struct AcceptRange {
+        let mediaType: String
+        let quality: Double
+    }
+
+    private func accepts(_ value: String?) -> Bool {
+        ["application/json", "text/event-stream"].contains { acceptedMediaType($0, in: value) }
+    }
+
+    private func acceptsJSON(_ value: String?) -> Bool {
+        acceptedMediaType("application/json", in: value)
+    }
+
+    private func acceptsEventStream(_ value: String?) -> Bool {
+        acceptedMediaType("text/event-stream", in: value)
+    }
+
+    private func acceptedMediaType(_ mediaType: String, in value: String?) -> Bool {
+        guard let value else { return false }
+        let ranges = value.split(separator: ",").compactMap(parseAcceptRange)
+        let normalizedMediaType = mediaType.lowercased()
+        let matching = ranges.filter { $0.mediaType == normalizedMediaType || $0.mediaType == "*/*" }
+        guard let range = matching.max(by: {
+            let leftSpecificity = specificity(of: $0.mediaType)
+            let rightSpecificity = specificity(of: $1.mediaType)
+            return leftSpecificity == rightSpecificity ? $0.quality < $1.quality : leftSpecificity < rightSpecificity
+        }) else { return false }
+        return range.quality > 0
+    }
+
+    private func parseAcceptRange(_ raw: Substring) -> AcceptRange? {
+        let parts = raw.split(separator: ";", omittingEmptySubsequences: true)
+        guard let mediaTypePart = parts.first else { return nil }
+        let mediaType = mediaTypePart.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard mediaType == "*/*" || ["application/json", "text/event-stream"].contains(mediaType) else { return nil }
+        var quality = 1.0
+        for parameter in parts.dropFirst() {
+            let keyValue = parameter.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard keyValue.count == 2 else { continue }
+            let key = keyValue[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard key == "q" else { continue }
+            guard let parsed = Double(keyValue[1].trimmingCharacters(in: .whitespacesAndNewlines)), (0...1).contains(parsed) else { return nil }
+            quality = parsed
+        }
+        return AcceptRange(mediaType: mediaType, quality: quality)
+    }
+
+    private func specificity(of mediaType: String) -> Int { mediaType == "*/*" ? 0 : 1 }
+    private func contentTypeIsJSON(_ value: String?) -> Bool {
+        guard let value, let mediaType = value.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false).first else { return false }
+        return mediaType.trimmingCharacters(in: .whitespaces).caseInsensitiveCompare("application/json") == .orderedSame
+    }
+    private func isJSONRPC(_ json: [String: Any]) -> Bool { json["jsonrpc"] as? String == "2.0" && json["method"] is String }
+}

--- a/Sources/homeclaw/MCP/MCPServer.swift
+++ b/Sources/homeclaw/MCP/MCPServer.swift
@@ -81,6 +81,11 @@ actor MCPServer {
         NotificationCenter.default.post(name: .mcpListenerStatusDidChange, object: nil, userInfo: ["listenerReady": false, "homeKitReady": homeKitReady])
         if let channel { try? await channel.close() }; if let group { try? await group.shutdownGracefully() }
     }
+    #if DEBUG
+    /// Read-only ownership snapshot for channel lifecycle regressions.
+    var testSSEOwnerships: Set<SSEStreamOwnership> { Set(sseContinuations.values.map(\.ownership)) }
+    #endif
+
     func cleanupSSE(for sessionIDs: [String]) { sessionIDs.forEach { sseContinuations.removeValue(forKey: $0)?.continuation.finish() } }
     func cleanupSSE(for ownership: SSEStreamOwnership) { guard sseContinuations[ownership.sessionID]?.ownership == ownership else { return }; sseContinuations.removeValue(forKey: ownership.sessionID)?.continuation.finish() }
     func cleanupSSE(for sessionID: String) { cleanupSSE(for: [sessionID]) }

--- a/Sources/homeclaw/MCP/MCPToolRegistry.swift
+++ b/Sources/homeclaw/MCP/MCPToolRegistry.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// The single registration/dispatch seam shared by native MCP transport and HomeKit.
+protocol MCPToolRegistry: Sendable {
+    var toolsJSON: Data { get }
+    func call(name: String, arguments: Data) async -> Data
+}
+
+struct HomeClawMCPToolRegistry: MCPToolRegistry {
+    static let shared = HomeClawMCPToolRegistry()
+
+    let toolsJSON: Data = ToolHandlers.allToolsJSON
+
+    func call(name: String, arguments: Data) async -> Data {
+        await ToolHandlers.call(name: name, arguments: arguments)
+    }
+}
+
+#if DEBUG
+extension HomeClawMCPToolRegistry {
+    static func test(status: String) -> MCPToolRegistry { TestMCPToolRegistry(status: status) }
+}
+private struct TestMCPToolRegistry: MCPToolRegistry {
+    let status: String
+    var toolsJSON: Data { Data("[{\"name\":\"homekit_status\"}]".utf8) }
+    func call(name: String, arguments: Data) async -> Data { Data("{\"status\":\"\(status)\"}".utf8) }
+}
+#endif

--- a/Sources/homeclaw/MCP/StreamableHTTPSessionStore.swift
+++ b/Sources/homeclaw/MCP/StreamableHTTPSessionStore.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// The state retained for one Streamable HTTP MCP connection.
+/// The identifier is intentionally never included in logs.
+struct StreamableHTTPSession: Sendable, Equatable {
+    let createdAt: Date
+    var lastAccessedAt: Date
+}
+
+/// Serializes session lifecycle and expiry cleanup for the HTTP transport.
+actor StreamableHTTPSessionStore {
+    private var sessions: [String: StreamableHTTPSession] = [:]
+    private let ttl: TimeInterval
+    private let maxSessions: Int
+
+    init(ttl: TimeInterval = 3600, maxSessions: Int = 128) { self.ttl = ttl; self.maxSessions = maxSessions }
+
+    func create(now: Date = Date()) -> String? {
+        guard sessions.count < maxSessions else { return nil }
+        let id = UUID().uuidString
+        sessions[id] = StreamableHTTPSession(createdAt: now, lastAccessedAt: now)
+        return id
+    }
+
+    func get(_ id: String) -> StreamableHTTPSession? { sessions[id] }
+
+    @discardableResult
+    func touch(_ id: String, now: Date = Date()) -> Bool {
+        guard var session = sessions[id] else { return false }
+        session.lastAccessedAt = now
+        sessions[id] = session
+        return true
+    }
+
+    /// Atomically validates that the session exists and has not expired, and refreshes its TTL.
+    /// Returns false if missing or expired (expired entries are removed).
+    @discardableResult
+    func validateAndTouch(_ id: String, now: Date = Date()) -> Bool {
+        guard var session = sessions[id] else { return false }
+        if now.timeIntervalSince(session.lastAccessedAt) >= ttl {
+            sessions.removeValue(forKey: id)
+            return false
+        }
+        session.lastAccessedAt = now
+        sessions[id] = session
+        return true
+    }
+
+    @discardableResult
+    func remove(_ id: String) -> Bool { sessions.removeValue(forKey: id) != nil }
+
+    @discardableResult
+    func removeAll() -> Int {
+        let count = sessions.count
+        sessions.removeAll()
+        return count
+    }
+
+    func removeExpiredIDs(now: Date = Date()) -> [String] {
+        let expired = sessions.filter { now.timeIntervalSince($0.value.lastAccessedAt) >= ttl }.map(\.key)
+        expired.forEach { sessions.removeValue(forKey: $0) }
+        return expired
+    }
+
+    @discardableResult
+    func removeExpired(now: Date = Date()) -> Int {
+        removeExpiredIDs(now: now).count
+    }
+
+    var count: Int { sessions.count }
+}

--- a/Sources/homeclaw/MCP/ToolHandlers.swift
+++ b/Sources/homeclaw/MCP/ToolHandlers.swift
@@ -1,0 +1,720 @@
+import Foundation
+
+/// Canonical MCP tool registration shared by native HTTP and stdio clients.
+/// HTTP applies an explicit read-only allowlist; stdio retains the full tool set.
+enum ToolHandlers {
+    // Generated from lib/schemas.js; reviewed as plain JSON.
+    // Check/regenerate: node scripts/check-mcp-schema-parity.mjs [--write]
+    static let allToolsJSON: Data = Data(#"""
+    [
+      {
+        "name": "homekit_status",
+        "description": "Check HomeClaw status — shows connectivity, home count, and accessory count.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "homekit_accessories",
+        "description": "Manage HomeKit accessories: list all, get details, search by name/room/category, or control (set characteristic values). Returns only accessories visible under the current filter configuration. Defaults to configured home if home_id not specified.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "list",
+                "get",
+                "search",
+                "control"
+              ],
+              "description": "Action to perform. Default: list"
+            },
+            "home_id": {
+              "type": "string",
+              "description": "Filter by home UUID. Defaults to configured home if not specified."
+            },
+            "room": {
+              "type": "string",
+              "description": "Filter by room name (list action only)"
+            },
+            "accessory_id": {
+              "type": "string",
+              "description": "Accessory UUID or name (get/control actions)"
+            },
+            "query": {
+              "type": "string",
+              "description": "Search query — matches name, room, category (search action)"
+            },
+            "category": {
+              "type": "string",
+              "description": "Filter by category e.g. lightbulb, lock, thermostat (search action)"
+            },
+            "characteristic": {
+              "type": "string",
+              "description": "Characteristic to set e.g. power, brightness, target_temperature (control action)"
+            },
+            "value": {
+              "type": "string",
+              "description": "Value to set e.g. true, 75, locked (control action)"
+            },
+            "service_type": {
+              "type": "string",
+              "description": "Service TYPE UUID to narrow the target when the characteristic exists on multiple services (control action). Note: every channel of a multi-gang switch shares one service type, so this alone cannot pick a channel — use service_name or service_index for that."
+            },
+            "service_name": {
+              "type": "string",
+              "description": "Name or unique UUID of the specific service to write to (control action). This is how you pick one channel of a multi-gang switch. Both values are listed in the ambiguity error and in the get action output."
+            },
+            "service_id": {
+              "type": "string",
+              "description": "Unique UUID of the specific service to write to (control action). Listed as `service_id` in the ambiguity error and as `id` per service in the get action output. Use this when two services share a name."
+            },
+            "service_index": {
+              "type": "number",
+              "description": "Channel number (ServiceLabelIndex) of the specific service to write to, e.g. 1 for the first gang (control action). Listed as `index` in the get action output when the accessory reports one."
+            },
+            "verify": {
+              "type": "boolean",
+              "description": "Default true (control action). After writing, the value is read back and a write the device did not apply is returned as an error rather than a success. Set false only for accessories whose readback is unreliable; the response then carries verification_skipped: \"disabled\"."
+            },
+            "no_refresh": {
+              "type": "boolean",
+              "description": "Skip live characteristic reads and return last-known + static values only (get action). Much faster and avoids per-call slowdowns when reading many accessories in sequence; safe for static metadata like serial number, model, and firmware."
+            }
+          }
+        }
+      },
+      {
+        "name": "homekit_rooms",
+        "description": "List HomeKit rooms and their accessories. Defaults to configured home if home_id not specified.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "home_id": {
+              "type": "string",
+              "description": "Filter by home UUID. Defaults to configured home if not specified."
+            }
+          }
+        }
+      },
+      {
+        "name": "homekit_scenes",
+        "description": "List, get details of, or trigger HomeKit scenes (action sets). Defaults to configured home if home_id not specified.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "list",
+                "get",
+                "trigger"
+              ],
+              "description": "Action to perform. Default: list. \"get\" returns all actions in the scene."
+            },
+            "home_id": {
+              "type": "string",
+              "description": "Filter by home UUID (list/get action). Defaults to configured home if not specified."
+            },
+            "scene_id": {
+              "type": "string",
+              "description": "Scene UUID or name (get/trigger action)"
+            }
+          }
+        }
+      },
+      {
+        "name": "homekit_device_map",
+        "description": "Get an LLM-optimized device map organized by home/zone/room with semantic types, auto-generated aliases, controllable characteristics, and state summaries. Use this to understand the full device landscape before controlling devices.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "home_id": {
+              "type": "string",
+              "description": "Filter by home UUID. Defaults to configured home if not specified."
+            }
+          }
+        }
+      },
+      {
+        "name": "homekit_manage",
+        "description": "Manage HomeKit structure: rename accessories, assign rooms (with UUID support for duplicate names), create/rename/remove rooms, remove accessories, create/remove zones, and manage zone membership. All actions support dry_run for safe previews.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "rename",
+                "remove_accessory",
+                "assign_rooms",
+                "create_room",
+                "rename_room",
+                "remove_room",
+                "create_zone",
+                "remove_zone",
+                "add_room_to_zone",
+                "remove_room_from_zone"
+              ],
+              "description": "Management action to perform"
+            },
+            "home_id": {
+              "type": "string",
+              "description": "Home UUID or name. Defaults to configured home."
+            },
+            "id": {
+              "type": "string",
+              "description": "Accessory, room, or zone name/UUID (action-dependent)"
+            },
+            "new_name": {
+              "type": "string",
+              "description": "New name for rename actions"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name for create actions (create_room, create_zone)"
+            },
+            "room": {
+              "type": "string",
+              "description": "Room name/UUID (zone membership actions)"
+            },
+            "zone": {
+              "type": "string",
+              "description": "Zone name/UUID (zone membership actions)"
+            },
+            "assignments": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "uuid": {
+                    "type": "string",
+                    "description": "Accessory UUID (preferred for duplicate names)"
+                  },
+                  "accessory": {
+                    "type": "string",
+                    "description": "Accessory name (fallback, case-insensitive)"
+                  },
+                  "room": {
+                    "type": "string",
+                    "description": "Target room name (created if missing)"
+                  }
+                },
+                "required": [
+                  "room"
+                ]
+              },
+              "description": "Array of room assignments (assign_rooms action). Each must have \"room\" plus either \"uuid\" or \"accessory\"."
+            },
+            "dry_run": {
+              "type": "boolean",
+              "description": "Preview changes without applying (default: false)"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        }
+      },
+      {
+        "name": "homekit_config",
+        "description": "View or update HomeClaw configuration. Set a default home, or configure device filtering to control which accessories are exposed.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "get",
+                "set"
+              ],
+              "description": "Action to perform. Default: get"
+            },
+            "default_home_id": {
+              "type": "string",
+              "description": "Home UUID or name to set as active home (set action). All commands operate on the active home."
+            },
+            "accessory_filter_mode": {
+              "type": "string",
+              "enum": [
+                "all",
+                "allowlist"
+              ],
+              "description": "Filter mode: \"all\" exposes every accessory, \"allowlist\" only exposes selected accessories (set action)."
+            },
+            "allowed_accessory_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Array of accessory UUIDs to expose when filter mode is \"allowlist\" (set action)."
+            }
+          }
+        }
+      },
+      {
+        "name": "homekit_automations",
+        "description": "Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) or by a time of day (clock or sunrise/sunset), delete automations, or enable/disable them. For characteristic-change triggers use action=create with press_type (buttons) or characteristic+trigger_value (sensors). For time-of-day triggers use action=create_time with the `time` field (HH:MM, sunrise, sunset, or <sun-event>±N). Both create actions accept the same predicate vocabulary: weekdays, conditions, time_after, time_before, duration_seconds. Use duration_seconds to auto-revert actions after N seconds (e.g. motion-triggered lights or sunset porch lights that turn off after a delay). Use action=add_condition to append a characteristic condition (ANDed) to an existing automation in place — the trigger UUID is preserved, so button bindings and Siri references survive. List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type (\"button\" | \"characteristic\" | \"calendar\" | \"significant_time\" | \"timer\" | \"unknown\") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype. Note: the predicate-composition features (conditions, time_after/time_before, add_condition) are built on standard HMEventTrigger predicate composition — supported by Apple's HomeKit framework APIs but not yet surfaced in the Home app's Automations tab. They mirror the rule-editor capabilities exposed by third-party HomeKit apps like Controller for HomeKit. Rules created or modified this way execute correctly via HomeKit; use list/get to inspect them since they may not be editable from the Home app.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "list",
+                "get",
+                "create",
+                "create_time",
+                "delete",
+                "enable",
+                "disable",
+                "add_condition"
+              ],
+              "description": "Action to perform. Default: list"
+            },
+            "home_id": {
+              "type": "string",
+              "description": "Home UUID or name. Defaults to configured home."
+            },
+            "id": {
+              "type": "string",
+              "description": "Automation UUID or name (get/delete/enable/disable actions)"
+            },
+            "name": {
+              "type": "string",
+              "description": "Automation name (create / create_time actions)"
+            },
+            "accessory_id": {
+              "type": "string",
+              "description": "Trigger accessory UUID or name (create action)"
+            },
+            "time": {
+              "type": "string",
+              "description": "Time of day the automation fires (create_time action, required). Format: \"HH:MM\" for a wall-clock time (e.g. \"06:30\", \"17:45\"; both fields must be zero-padded two digits — \"6:30\" is rejected), \"sunrise\"/\"sunset\" for sun-relative events, or \"<sun-event>±N\" where N is minutes (e.g. \"sunset-30\", \"sunrise+15\"). Offsets larger than 1440 minutes (24h) are rejected. Implemented as HMCalendarEvent for HH:MM and HMSignificantTimeEvent for sunrise/sunset. All other predicate flags (weekdays, conditions, time_after, time_before, duration_seconds) compose with `time` the same way they do on the create action — `time` is the trigger event, those are the gating predicates."
+            },
+            "scene_id": {
+              "type": "string",
+              "description": "Scene UUID or name to trigger (create / create_time actions). Alternative to actions."
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accessory": {
+                    "type": "string",
+                    "description": "Target accessory UUID (strongly preferred) or name"
+                  },
+                  "property": {
+                    "type": "string",
+                    "description": "Characteristic to set (e.g., power, brightness, color_temperature)"
+                  },
+                  "characteristic": {
+                    "type": "string",
+                    "description": "Alias for \"property\" — provide one or the other"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "Target value as string (e.g., \"true\", \"50\", \"344\")"
+                  },
+                  "room": {
+                    "type": "string",
+                    "description": "Room name for disambiguation (optional)"
+                  }
+                },
+                "required": [
+                  "accessory",
+                  "value"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "property"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "characteristic"
+                    ]
+                  }
+                ]
+              },
+              "description": "Inline actions for the automation (create / create_time actions). Alternative to scene_id. Creates a scene named after the automation. Each action sets one characteristic on one accessory."
+            },
+            "press_type": {
+              "type": "number",
+              "enum": [
+                0,
+                1,
+                2
+              ],
+              "description": "Button press type: 0=single (default), 1=double, 2=long press. For button triggers only; mutually exclusive with characteristic. (create action)"
+            },
+            "characteristic": {
+              "type": "string",
+              "description": "Characteristic name to trigger on (e.g., motion_detected, contact_state, occupancy_detected, current_temperature). Alternative to press_type for non-button triggers. (create action)"
+            },
+            "trigger_value": {
+              "type": "string",
+              "description": "Value that triggers the automation (e.g., \"true\", \"false\", \"1\", \"0\"). Required when characteristic is set. Uses exact value matching. (create action)"
+            },
+            "service_index": {
+              "type": "number",
+              "description": "Button index for multi-button accessories (1 or 2). For button triggers only. (create action)"
+            },
+            "weekdays": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ]
+              },
+              "description": "Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, characteristic-trigger automations (create) fire every day; time-of-day automations (create_time) auto-fill all 7 days since iOS 15+ marks time-conditional automations without weekday gating as \"unreliable\". Setting time_after/time_before on create with no weekdays also auto-fills all 7 days and sets `weekdays_auto_filled: true` in the response. (create / create_time actions)"
+            },
+            "conditions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accessory": {
+                    "type": "string",
+                    "description": "Condition accessory UUID (preferred) or name"
+                  },
+                  "property": {
+                    "type": "string",
+                    "description": "Characteristic name (e.g., contact_state, occupancy_detected, power)"
+                  },
+                  "characteristic": {
+                    "type": "string",
+                    "description": "Alias for \"property\" — provide one or the other"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "Required value as string (e.g., \"true\", \"0\", \"50\"). Uses exact match (==)."
+                  },
+                  "room": {
+                    "type": "string",
+                    "description": "Room name for accessory disambiguation when multiple accessories share a name (optional)"
+                  }
+                },
+                "required": [
+                  "accessory",
+                  "value"
+                ],
+                "anyOf": [
+                  {
+                    "required": [
+                      "property"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "characteristic"
+                    ]
+                  }
+                ]
+              },
+              "description": "Extra characteristic predicates ANDed into the trigger predicate. The trigger fires only when the trigger event happens AND every condition holds. Example: porch motion (or sunset, on create_time) that only triggers when the front door is closed AND nobody is home. Each condition is a (characteristic == value) match against any accessory in the home. (create / create_time actions)"
+            },
+            "time_after": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Time predicates ANDed into the trigger so it only fires after the given time. Same vocabulary as the `time` field: \"HH:MM\" for a wall-clock time (zero-padded, e.g. \"07:00\") or \"<sunrise|sunset>[±N]\" where N is minutes (e.g., \"sunset-30\", \"sunrise+15\", \"sunset\"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=[\"07:00\"] + time_before=[\"20:30\"] for \"only during the day\", or time_after=[\"sunset-30\"] + time_before=[\"sunrise+15\"] for \"between dusk and dawn\"). On create_time these are gating predicates on top of the `time` trigger event, not the trigger itself. When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create / create_time actions)"
+            },
+            "time_before": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Time predicates ANDed into the trigger so it only fires before the given time. Same format and offset rules as time_after. (create / create_time actions)"
+            },
+            "duration_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400,
+              "description": "Auto-revert the trigger's actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger's endEvents — HomeKit handles the revert natively, no follow-up automation required. Common use cases: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold), or sunset porch lights that should turn off after an hour. (create / create_time actions)"
+            },
+            "condition": {
+              "type": "object",
+              "properties": {
+                "accessory": {
+                  "type": "string",
+                  "description": "Condition accessory UUID (preferred) or name"
+                },
+                "property": {
+                  "type": "string",
+                  "description": "Characteristic name (e.g., contact_state, occupancy_detected, power)"
+                },
+                "characteristic": {
+                  "type": "string",
+                  "description": "Alias for \"property\" — provide one or the other"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Required value as string (e.g., \"true\", \"0\", \"50\"). Uses exact match (==)."
+                },
+                "room": {
+                  "type": "string",
+                  "description": "Room name for accessory disambiguation when multiple accessories share a name (optional)"
+                }
+              },
+              "required": [
+                "accessory",
+                "value"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "property"
+                  ]
+                },
+                {
+                  "required": [
+                    "characteristic"
+                  ]
+                }
+              ],
+              "description": "Single characteristic condition (object — note the singular field name, distinct from the plural `conditions` array used by create / create_time) to append (ANDed) to an existing automation's trigger predicate. To add multiple conditions, call add_condition repeatedly — each call preserves the trigger UUID, so physical button bindings, Siri references, and other UUID-keyed integrations survive every modification. The read-side decoder (list/get) surfaces the new condition automatically. To replace an existing condition set, delete the automation and recreate it. (add_condition action)"
+            },
+            "dry_run": {
+              "type": "boolean",
+              "description": "Preview changes without applying (create/create_time/delete/add_condition actions)"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        }
+      },
+      {
+        "name": "homekit_webhook",
+        "description": "Manage webhook configuration for pushing HomeKit events to OpenClaw or other services. Actions: setup (configure URL, token, and enable in one step), test (send a test event and show the HTTP response), reset (reset the circuit breaker), status (show webhook health and delivery stats).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "setup",
+                "test",
+                "reset",
+                "status"
+              ],
+              "description": "Action to perform. Default: status"
+            },
+            "url": {
+              "type": "string",
+              "description": "Base gateway URL, e.g. http://127.0.0.1:18789 (setup action). HomeClaw appends /hooks/wake automatically — do NOT include the path."
+            },
+            "token": {
+              "type": "string",
+              "description": "Bearer token for webhook authentication (setup action)"
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable or disable the webhook (setup action). Default: true"
+            }
+          }
+        }
+      },
+      {
+        "name": "homekit_events",
+        "description": "Get recent HomeKit events — characteristic changes, scene triggers, and accessory control actions. Use to understand what happened recently in the home.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": "number",
+              "description": "Maximum number of events to return (default: 50)"
+            },
+            "since": {
+              "type": "string",
+              "description": "ISO 8601 timestamp — only return events after this time"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "characteristic_change",
+                "homes_updated",
+                "scene_triggered",
+                "accessory_controlled"
+              ],
+              "description": "Filter by event type"
+            }
+          }
+        }
+      }
+    ]
+    """#.utf8)
+
+    static var allToolNames: [String] {
+        ((try? JSONSerialization.jsonObject(with: allToolsJSON) as? [[String: Any]]) ?? []).compactMap { $0["name"] as? String }
+    }
+
+    @MainActor static func call(name: String, arguments: Data) async -> Data {
+        guard allToolNames.contains(name) else { return error("Unknown tool: \(name)") }
+        guard let args = (try? JSONSerialization.jsonObject(with: arguments)) as? [String: Any] else {
+            return error("Invalid arguments")
+        }
+        guard validateArguments(args, tool: name) else { return error("Invalid arguments") }
+
+        do {
+            let result: Any = try await { () async throws -> Any in
+                let hk = HomeKitManager.shared
+                switch name {
+                case "homekit_status":
+                    return ["ready": hk.isReady, "homes": hk.homeCount, "accessories": hk.totalAccessoryCount]
+                case "homekit_accessories":
+                    switch string(args, "action") ?? "list" {
+                    case "list": return try await hk.listAccessories(homeID: string(args, "home_id"), room: string(args, "room"))
+                    case "get":
+                        guard let id = string(args, "accessory_id") else { throw HomeKitManager.ControlError.invalidArgument("accessory_id is required") }
+                        guard let value = try await hk.getAccessory(id: id, homeID: string(args, "home_id"), refresh: !bool(args, "no_refresh")) else { throw HomeKitManager.ControlError.accessoryNotFound(id) }
+                        return value
+                    case "search":
+                        guard let query = string(args, "query") else { throw HomeKitManager.ControlError.invalidArgument("query is required") }
+                        return await hk.searchAccessories(query: query, category: string(args, "category"), homeID: string(args, "home_id"))
+                    case "control":
+                        guard let id = string(args, "accessory_id"), let characteristic = string(args, "characteristic"), let value = string(args, "value") else { throw HomeKitManager.ControlError.invalidArgument("accessory_id, characteristic, and value are required") }
+                        return try await hk.controlAccessory(id: id, characteristic: characteristic, value: value, homeID: string(args, "home_id"), serviceType: string(args, "service_type"), serviceName: string(args, "service_name"), serviceID: string(args, "service_id"), serviceIndex: int(args, "service_index"), dryRun: bool(args, "dry_run"), verify: args["verify"] as? Bool ?? true)
+                    default: throw HomeKitManager.ControlError.invalidArgument("unknown accessories action")
+                    }
+                case "homekit_rooms": return await hk.listRooms(homeID: string(args, "home_id"))
+                case "homekit_scenes":
+                    switch string(args, "action") ?? "list" {
+                    case "list": return await hk.listScenes(homeID: string(args, "home_id"))
+                    case "get": guard let id = string(args, "scene_id") else { throw HomeKitManager.ControlError.invalidArgument("scene_id is required") }; return try await hk.getScene(id: id, homeID: string(args, "home_id"))
+                    case "trigger": guard let id = string(args, "scene_id") else { throw HomeKitManager.ControlError.invalidArgument("scene_id is required") }; return try await hk.triggerScene(id: id, homeID: string(args, "home_id"))
+                    default: throw HomeKitManager.ControlError.invalidArgument("unknown scenes action")
+                    }
+                case "homekit_device_map": return await hk.deviceMap(homeID: string(args, "home_id"))
+                case "homekit_manage": return try await manage(args, hk: hk)
+                case "homekit_config":
+                    switch string(args, "action") ?? "get" {
+                    case "get": return HomeClawConfig.shared.toDict()
+                    case "set":
+                        if let home = string(args, "default_home_id") { HomeClawConfig.shared.defaultHomeID = home.isEmpty || home.lowercased() == "none" ? nil : home }
+                        if let mode = string(args, "accessory_filter_mode") { HomeClawConfig.shared.filterMode = mode }
+                        if let ids = args["allowed_accessory_ids"] as? [String] { HomeClawConfig.shared.setAllowedAccessories(ids) }
+                        return HomeClawConfig.shared.toDict()
+                    default: throw HomeKitManager.ControlError.invalidArgument("unknown config action")
+                    }
+                case "homekit_events":
+                    let since = (string(args, "since")).flatMap { ISO8601DateFormatter().date(from: $0) }
+                    let type = string(args, "type").flatMap(HomeEventLogger.EventType.init(rawValue:))
+                    return ["events": HomeEventLogger.shared.readEvents(since: since, limit: int(args, "limit") ?? 50, type: type)]
+                case "homekit_webhook": return try await webhook(args)
+                case "homekit_automations": return try await automations(args, hk: hk)
+                default: throw HomeKitManager.ControlError.invalidArgument("unsupported tool")
+                }
+            }()
+            return json(result)
+        } catch {
+            return Self.error(error.localizedDescription)
+        }
+    }
+
+    private static func validateArguments(_ args: [String: Any], tool: String) -> Bool {
+        let integerKeys = ["press_type", "service_index", "limit", "duration_seconds"]
+        for key in integerKeys where args[key] != nil {
+            guard let number = args[key] as? NSNumber, String(cString: number.objCType) != "c", String(cString: number.objCType) != "C", number.doubleValue.rounded() == number.doubleValue else { return false }
+        }
+        if let press = args["press_type"] as? NSNumber, !(0...2).contains(press.intValue) { return false }
+        if let index = args["service_index"] as? NSNumber, index.intValue < 1 { return false }
+        if let limit = args["limit"] as? NSNumber, !(1...1000).contains(limit.intValue) { return false }
+        if let duration = args["duration_seconds"] as? NSNumber, !(1...86400).contains(duration.intValue) { return false }
+        for key in ["dry_run", "verify", "no_refresh", "enabled"] where args[key] != nil { guard args[key] is Bool else { return false } }
+        for key in ["home_id", "accessory_id", "room", "query", "category", "characteristic", "value", "service_type", "service_name", "service_id", "scene_id", "id", "name", "new_name", "time", "since", "type", "action"] where args[key] != nil { guard args[key] is String else { return false } }
+        for key in ["actions", "conditions", "assignments"] where args[key] != nil { guard args[key] is [[String: Any]] || args[key] is [[String: String]] else { return false } }
+        for key in ["weekdays", "time_after", "time_before"] where args[key] != nil { guard let values = args[key] as? [Any] else { return false }; if key == "weekdays" { guard values.allSatisfy({ ($0 as? NSNumber).map { String(cString: $0.objCType) != "c" && $0.doubleValue.rounded() == $0.doubleValue && (1...7).contains($0.intValue) } == true }) else { return false } } else { guard values.allSatisfy({ $0 is String }) else { return false } } }
+        _ = tool
+        return true
+    }
+    private static func string(_ args: [String: Any], _ key: String) -> String? { args[key] as? String }
+    private static func int(_ args: [String: Any], _ key: String) -> Int? {
+        if let value = args[key] as? Int { return value }
+        guard let number = args[key] as? NSNumber, String(cString: number.objCType) != "c", String(cString: number.objCType) != "C", number.doubleValue.isFinite, number.doubleValue.rounded() == number.doubleValue, number.doubleValue >= Double(Int.min), number.doubleValue <= Double(Int.max) else { return nil }
+        return Int(exactly: number.int64Value)
+    }
+    private static func bool(_ args: [String: Any], _ key: String) -> Bool { args[key] as? Bool ?? false }
+    private static func json(_ value: Any) -> Data { (try? JSONSerialization.data(withJSONObject: value)) ?? Data("{}".utf8) }
+    private static func error(_ message: String) -> Data { json(["error": message]) }
+
+    @MainActor private static func manage(_ args: [String: Any], hk: HomeKitManager) async throws -> Any {
+        guard let action = string(args, "action") else { throw HomeKitManager.ControlError.invalidArgument("action is required") }
+        let home = string(args, "home_id"), id = string(args, "id"), dry = bool(args, "dry_run")
+        switch action {
+        case "rename": guard let id, let name = string(args, "new_name") else { throw HomeKitManager.ControlError.invalidArgument("id and new_name are required") }; return try await hk.renameAccessory(id: id, newName: name, homeID: home, dryRun: dry)
+        case "remove_accessory": guard let id else { throw HomeKitManager.ControlError.invalidArgument("id is required") }; return try await hk.removeAccessory(id: id, homeID: home, dryRun: dry)
+        case "assign_rooms": guard let assignments = args["assignments"] as? [[String: String]] else { throw HomeKitManager.ControlError.invalidArgument("assignments is required") }; return try await hk.assignRooms(homeName: home, assignments: assignments, dryRun: dry)
+        case "create_room": guard let name = string(args, "name") else { throw HomeKitManager.ControlError.invalidArgument("name is required") }; return try await hk.createRoom(name: name, homeID: home, dryRun: dry)
+        case "rename_room": guard let id, let name = string(args, "new_name") else { throw HomeKitManager.ControlError.invalidArgument("id and new_name are required") }; return try await hk.renameRoom(roomID: id, newName: name, homeID: home, dryRun: dry)
+        case "remove_room": guard let id else { throw HomeKitManager.ControlError.invalidArgument("id is required") }; return try await hk.removeRoom(roomID: id, homeID: home, dryRun: dry)
+        case "create_zone": guard let name = string(args, "name") else { throw HomeKitManager.ControlError.invalidArgument("name is required") }; return try await hk.createZone(name: name, homeID: home, dryRun: dry)
+        case "remove_zone": guard let id else { throw HomeKitManager.ControlError.invalidArgument("id is required") }; return try await hk.removeZone(zoneID: id, homeID: home, dryRun: dry)
+        case "add_room_to_zone": guard let room = string(args, "room"), let zone = string(args, "zone") else { throw HomeKitManager.ControlError.invalidArgument("room and zone are required") }; return try await hk.addRoomToZone(roomID: room, zoneID: zone, homeID: home, dryRun: dry)
+        case "remove_room_from_zone": guard let room = string(args, "room"), let zone = string(args, "zone") else { throw HomeKitManager.ControlError.invalidArgument("room and zone are required") }; return try await hk.removeRoomFromZone(roomID: room, zoneID: zone, homeID: home, dryRun: dry)
+        default: throw HomeKitManager.ControlError.invalidArgument("unknown manage action")
+        }
+    }
+
+    @MainActor private static func automations(_ args: [String: Any], hk: HomeKitManager) async throws -> Any {
+        let action = string(args, "action") ?? "list"
+        let home = string(args, "home_id"), dry = bool(args, "dry_run")
+        switch action {
+        case "list": return await hk.listAutomations(homeID: home)
+        case "get": guard let id = string(args, "id") else { throw HomeKitManager.ControlError.invalidArgument("id is required") }; return try await hk.getAutomation(id: id, homeID: home)
+        case "delete": guard let id = string(args, "id") else { throw HomeKitManager.ControlError.invalidArgument("id is required") }; return try await hk.deleteAutomation(id: id, homeID: home, dryRun: dry)
+        case "enable", "disable": guard let id = string(args, "id") else { throw HomeKitManager.ControlError.invalidArgument("id is required") }; return try await hk.enableAutomation(id: id, enabled: action == "enable", homeID: home)
+        case "add_condition":
+            guard let id = string(args, "id"), let condition = args["condition"] as? [String: Any], let accessory = condition["accessory"] as? String, let value = condition["value"] as? String, let property = (condition["property"] as? String) ?? (condition["characteristic"] as? String) else { throw HomeKitManager.ControlError.invalidArgument("id and condition accessory/property/value are required") }
+            return try await hk.addAutomationCondition(id: id, accessoryID: accessory, conditionRoom: condition["room"] as? String, property: property, value: value, homeID: home, dryRun: dry)
+        case "create", "create_time":
+            guard let name = string(args, "name") else { throw HomeKitManager.ControlError.invalidArgument("name is required") }
+            let actions = args["actions"] as? [[String: String]], conditions = args["conditions"] as? [[String: String]] ?? []
+            let weekdays = (args["weekdays"] as? [Int]) ?? [], timeConditions = try parseTimeConditions(args)
+            if action == "create_time" {
+                guard let time = string(args, "time") else { throw HomeKitManager.ControlError.invalidArgument("time is required") }
+                return try await hk.createTimeAutomation(name: name, time: time, weekdays: weekdays, conditions: conditions, timeConditions: timeConditions, durationSeconds: int(args, "duration_seconds"), sceneID: string(args, "scene_id"), actions: actions, homeID: home, dryRun: dry)
+            }
+            guard let accessory = string(args, "accessory_id") else { throw HomeKitManager.ControlError.invalidArgument("accessory_id is required") }
+            return try await hk.createAutomation(name: name, accessoryID: accessory, pressType: int(args, "press_type") ?? 0, characteristic: string(args, "characteristic"), triggerValue: string(args, "trigger_value"), sceneID: string(args, "scene_id"), actions: actions, serviceIndex: int(args, "service_index"), weekdays: weekdays, conditions: conditions, timeConditions: timeConditions, durationSeconds: int(args, "duration_seconds"), homeID: home, dryRun: dry)
+        default: throw HomeKitManager.ControlError.invalidArgument("unknown automations action")
+        }
+    }
+
+    private static func parseTimeConditions(_ args: [String: Any]) throws -> [TimeCondition] {
+        var result: [TimeCondition] = []
+        for (key, relation) in [("time_after", TimeCondition.Relation.after), ("time_before", TimeCondition.Relation.before)] {
+            for raw in (args[key] as? [String]) ?? [] {
+                guard let condition = TimeCondition.parse(raw, relation: relation) else { throw HomeKitManager.ControlError.invalidArgument("invalid time condition: \(raw)") }
+                result.append(condition)
+            }
+        }
+        return result
+    }
+
+    @MainActor private static func webhook(_ args: [String: Any]) async throws -> Any {
+        switch string(args, "action") ?? "status" {
+        case "status": return HomeClawConfig.shared.toDict()["webhook"] ?? ["enabled": false]
+        case "reset": WebhookCircuitBreaker.shared.manualReset(); return ["reset": true]
+        case "setup":
+            guard let url = string(args, "url"), let token = string(args, "token") else { throw HomeKitManager.ControlError.invalidArgument("url and token are required") }
+            HomeClawConfig.shared.webhookConfig = HomeClawConfig.WebhookConfig(enabled: args["enabled"] as? Bool ?? true, url: url, token: token, events: nil, webhookEndpoint: "/hooks/homeclaw")
+            return HomeClawConfig.shared.toDict()["webhook"] ?? [:]
+        case "test": return HomeEventLogger.shared.testWebhook()
+        default: throw HomeKitManager.ControlError.invalidArgument("unknown webhook action")
+        }
+    }
+}

--- a/Sources/homeclaw/MCP/_disabled/README.md
+++ b/Sources/homeclaw/MCP/_disabled/README.md
@@ -1,52 +1,36 @@
-# Disabled: HTTP MCP Server
+# Archived HTTP MCP prototype — not compiled
 
-This directory contains the HTTP MCP server implementation that has been disabled.
-These files are preserved for reference but are **not compiled** into the app.
+This directory preserves the superseded MCP SDK-based prototype for historical
+reference. XcodeGen excludes `**/_disabled/**` from the app target. These files
+are **not** the active HTTP server; do not move them into the parent directory or
+restore their SDK/token dependencies.
 
-## What was here
+## Active implementation
 
-The app previously ran an HTTP MCP server (NIO-based, port 9090) with bearer token
-authentication. All MCP clients now use either:
+The compiled implementation is in `Sources/homeclaw/MCP/` (the parent directory).
+It uses SwiftNIO directly, not `mcp-swift-sdk`. Enable **Streamable HTTP MCP** in
+**Settings → Integrations**; the setting is persistent and **off by default**.
+When enabled, the Catalyst app serves `http://127.0.0.1:9090/mcp` and `/healthz`.
+Turning it off stops the listener. Existing Node stdio and Unix-socket clients
+remain supported independently of this setting.
 
-- **stdio MCP server** (Node.js, `mcp-server/`) — used by Claude Code and Claude Desktop
-- **homekit-cli** (SPM binary) — used by OpenClaw
+The active security model is loopback-only binding, fail-closed Host/Origin
+validation, and a deny-by-default read-only HTTP tool allowlist. It intentionally
+has **no bearer token**. The prototype's bearer-token/Keychain design is
+superseded, not a missing feature to restore. HomeKit access remains subject to
+the app's entitlement and system permission.
 
-The HTTP server, bearer token auth, and Keychain token management added complexity
-without being in the active path for any current client.
+## Historical files
 
-## Files
+| File | Historical purpose |
+|------|--------------------|
+| `MCPServer.swift` | SDK-based HTTP server actor |
+| `MCPHTTPHandler.swift` | HTTP-to-MCP SDK bridge |
+| `BearerTokenValidator.swift` | Superseded bearer-token validation |
+| `ToolHandlers.swift` | Prototype tool definitions and dispatch |
 
-| File | Purpose |
-|------|---------|
-| `MCPServer.swift` | NIO-based HTTP server actor with session management |
-| `MCPHTTPHandler.swift` | NIO ChannelHandler bridging HTTP to MCP SDK |
-| `BearerTokenValidator.swift` | Bearer token extraction and validation |
-| `ToolHandlers.swift` | MCP tool definitions and dispatch to HomeKitClient |
+Related archived code lives in `Sources/homeclaw/Shared/_disabled/`
+(`KeychainManager.swift`) and `Sources/homeclaw-cli/Commands/_disabled/`
+(`TokenCommand.swift`). Those files also remain excluded from compilation.
 
-Related files in `Shared/_disabled/`:
-
-| File | Purpose |
-|------|---------|
-| `KeychainManager.swift` | macOS Keychain CRUD for bearer tokens |
-
-Related files in `homekit-cli/Commands/_disabled/`:
-
-| File | Purpose |
-|------|---------|
-| `TokenCommand.swift` | CLI command for viewing/rotating bearer tokens |
-
-## Re-enabling
-
-To re-enable the HTTP server:
-
-1. Move files back from `_disabled/` to their parent directories
-2. Restore the MCP SDK dependency in `Package.swift`:
-   ```swift
-   .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0")
-   ```
-3. Add the MCP product dependency to the `homekit-mcp` target
-4. Restore `MCPServer` startup in `AppDelegate.swift`
-5. Restore `KeychainManager` and token initialization
-6. Restore `AppConfig` HTTP constants (port, endpoint, keychain keys)
-7. Restore the Server settings tab and menu bar token/port display
-8. Add `Token.self` back to `HomeKitCLI` subcommands
+For current client setup, see the root README's **Native MCP for Hermes** section.

--- a/Sources/homeclaw/Shared/AppConfig.swift
+++ b/Sources/homeclaw/Shared/AppConfig.swift
@@ -38,6 +38,19 @@ enum AppConfig {
         return "/tmp/homeclaw.sock"
     }()
 
+    // Native MCP HTTP listener configuration. Only the port is overrideable for tests/development.
+    static let mcpBindHost = HTTPMCPConfiguration.defaultBindHost
+    static let mcpEndpoint: String = {
+        "http://\(mcpBindHost):\(mcpPort)/mcp"
+    }()
+    static let mcpPort: Int = {
+        guard let value = ProcessInfo.processInfo.environment["HOMECLAW_MCP_PORT"],
+              let port = Int(value), (1...65535).contains(port) else {
+            return HTTPMCPConfiguration.defaultPort
+        }
+        return port
+    }()
+
     // UserDefaults keys
     static let launchAtLoginKey = "launchAtLogin"
 }

--- a/Sources/homeclaw/Views/IntegrationsSettingsView.swift
+++ b/Sources/homeclaw/Views/IntegrationsSettingsView.swift
@@ -1,6 +1,32 @@
 import SwiftUI
 import UIKit
 
+/// Available in both development and App Store integration settings.
+struct NativeHTTPSettingsSection: View {
+    @EnvironmentObject private var httpIntegration: HTTPIntegrationLifecycle
+
+    var body: some View {
+        Section {
+            Toggle("Enable Streamable HTTP MCP", isOn: Binding(
+                get: { httpIntegration.isEnabled },
+                set: { httpIntegration.setEnabled($0) }))
+            Text(AppConfig.mcpEndpoint)
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+            Text("Off by default. When enabled, local clients can read HomeKit data over loopback without a token. CLI and stdio integrations are unaffected.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if let error = httpIntegration.errorMessage {
+                Text("HTTP server failed to start: \(error)")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        } header: {
+            Text("Streamable HTTP MCP").font(.headline).foregroundStyle(.primary)
+        }
+    }
+}
+
 struct IntegrationsSettingsView: View {
     @State private var claudeDesktopStatus: DesktopStatus = .checking
     @State private var claudeCodeStatus: ClaudeCodeStatus = .checking
@@ -107,11 +133,11 @@ struct IntegrationsSettingsView: View {
 
     var body: some View {
         Form {
+            NativeHTTPSettingsSection()
             cliSection
             claudeDesktopSection
             claudeCodeSection
             openClawSection
-
             if let message = statusMessage {
                 Section {
                     Label(

--- a/Sources/homeclaw/Views/SettingsView.swift
+++ b/Sources/homeclaw/Views/SettingsView.swift
@@ -1445,6 +1445,7 @@ private struct AppStoreIntegrationsView: View {
 
     var body: some View {
         Form {
+            NativeHTTPSettingsSection()
             // CLI
             Section("Command Line") {
                 LabeledContent("Binary") {

--- a/Tests/HomeClawTests/AppLaunchPolicyTests.swift
+++ b/Tests/HomeClawTests/AppLaunchPolicyTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+#if !LIFECYCLE_STANDALONE
+import XCTest
+@testable import HomeClaw
+#endif
+
+private func verifyUnitTestLaunchPolicy() throws {
+    struct Failure: Error {}
+    guard AppLaunchPolicy.isUnitTestHost(environment: ["XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"]),
+          AppLaunchPolicy.isUnitTestHost(environment: ["XCTestBundlePath": "/tmp/HomeClawTests.xctest"]),
+          !AppLaunchPolicy.isUnitTestHost(environment: [:]) else { throw Failure() }
+}
+
+#if LIFECYCLE_STANDALONE
+@main struct AppLaunchPolicyTestRunner {
+    static func main() throws {
+        try verifyUnitTestLaunchPolicy()
+        print("PASS unitTestHostDetection")
+    }
+}
+#else
+final class AppLaunchPolicyTests: XCTestCase {
+    func testUnitTestHostDetection() throws { try verifyUnitTestLaunchPolicy() }
+}
+#endif

--- a/Tests/HomeClawTests/Fixtures/mcp-tools.json
+++ b/Tests/HomeClawTests/Fixtures/mcp-tools.json
@@ -1,0 +1,550 @@
+[
+  {
+    "name": "homekit_status",
+    "description": "Check HomeClaw status — shows connectivity, home count, and accessory count.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "homekit_accessories",
+    "description": "Manage HomeKit accessories: list all, get details, search by name/room/category, or control (set characteristic values). Returns only accessories visible under the current filter configuration. Defaults to configured home if home_id not specified.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "list",
+            "get",
+            "search",
+            "control"
+          ],
+          "description": "Action to perform. Default: list"
+        },
+        "home_id": {
+          "type": "string",
+          "description": "Filter by home UUID. Defaults to configured home if not specified."
+        },
+        "room": {
+          "type": "string",
+          "description": "Filter by room name (list action only)"
+        },
+        "accessory_id": {
+          "type": "string",
+          "description": "Accessory UUID or name (get/control actions)"
+        },
+        "query": {
+          "type": "string",
+          "description": "Search query — matches name, room, category (search action)"
+        },
+        "category": {
+          "type": "string",
+          "description": "Filter by category e.g. lightbulb, lock, thermostat (search action)"
+        },
+        "characteristic": {
+          "type": "string",
+          "description": "Characteristic to set e.g. power, brightness, target_temperature (control action)"
+        },
+        "value": {
+          "type": "string",
+          "description": "Value to set e.g. true, 75, locked (control action)"
+        },
+        "service_type": {
+          "type": "string",
+          "description": "Service TYPE UUID to narrow the target when the characteristic exists on multiple services (control action). Note: every channel of a multi-gang switch shares one service type, so this alone cannot pick a channel — use service_name or service_index for that."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Name or unique UUID of the specific service to write to (control action). This is how you pick one channel of a multi-gang switch. Both values are listed in the ambiguity error and in the get action output."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Unique UUID of the specific service to write to (control action). Listed as `service_id` in the ambiguity error and as `id` per service in the get action output. Use this when two services share a name."
+        },
+        "service_index": {
+          "type": "number",
+          "description": "Channel number (ServiceLabelIndex) of the specific service to write to, e.g. 1 for the first gang (control action). Listed as `index` in the get action output when the accessory reports one."
+        },
+        "verify": {
+          "type": "boolean",
+          "description": "Default true (control action). After writing, the value is read back and a write the device did not apply is returned as an error rather than a success. Set false only for accessories whose readback is unreliable; the response then carries verification_skipped: \"disabled\"."
+        },
+        "no_refresh": {
+          "type": "boolean",
+          "description": "Skip live characteristic reads and return last-known + static values only (get action). Much faster and avoids per-call slowdowns when reading many accessories in sequence; safe for static metadata like serial number, model, and firmware."
+        }
+      }
+    }
+  },
+  {
+    "name": "homekit_rooms",
+    "description": "List HomeKit rooms and their accessories. Defaults to configured home if home_id not specified.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "home_id": {
+          "type": "string",
+          "description": "Filter by home UUID. Defaults to configured home if not specified."
+        }
+      }
+    }
+  },
+  {
+    "name": "homekit_scenes",
+    "description": "List, get details of, or trigger HomeKit scenes (action sets). Defaults to configured home if home_id not specified.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "list",
+            "get",
+            "trigger"
+          ],
+          "description": "Action to perform. Default: list. \"get\" returns all actions in the scene."
+        },
+        "home_id": {
+          "type": "string",
+          "description": "Filter by home UUID (list/get action). Defaults to configured home if not specified."
+        },
+        "scene_id": {
+          "type": "string",
+          "description": "Scene UUID or name (get/trigger action)"
+        }
+      }
+    }
+  },
+  {
+    "name": "homekit_device_map",
+    "description": "Get an LLM-optimized device map organized by home/zone/room with semantic types, auto-generated aliases, controllable characteristics, and state summaries. Use this to understand the full device landscape before controlling devices.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "home_id": {
+          "type": "string",
+          "description": "Filter by home UUID. Defaults to configured home if not specified."
+        }
+      }
+    }
+  },
+  {
+    "name": "homekit_manage",
+    "description": "Manage HomeKit structure: rename accessories, assign rooms (with UUID support for duplicate names), create/rename/remove rooms, remove accessories, create/remove zones, and manage zone membership. All actions support dry_run for safe previews.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "rename",
+            "remove_accessory",
+            "assign_rooms",
+            "create_room",
+            "rename_room",
+            "remove_room",
+            "create_zone",
+            "remove_zone",
+            "add_room_to_zone",
+            "remove_room_from_zone"
+          ],
+          "description": "Management action to perform"
+        },
+        "home_id": {
+          "type": "string",
+          "description": "Home UUID or name. Defaults to configured home."
+        },
+        "id": {
+          "type": "string",
+          "description": "Accessory, room, or zone name/UUID (action-dependent)"
+        },
+        "new_name": {
+          "type": "string",
+          "description": "New name for rename actions"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name for create actions (create_room, create_zone)"
+        },
+        "room": {
+          "type": "string",
+          "description": "Room name/UUID (zone membership actions)"
+        },
+        "zone": {
+          "type": "string",
+          "description": "Zone name/UUID (zone membership actions)"
+        },
+        "assignments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uuid": {
+                "type": "string",
+                "description": "Accessory UUID (preferred for duplicate names)"
+              },
+              "accessory": {
+                "type": "string",
+                "description": "Accessory name (fallback, case-insensitive)"
+              },
+              "room": {
+                "type": "string",
+                "description": "Target room name (created if missing)"
+              }
+            },
+            "required": [
+              "room"
+            ]
+          },
+          "description": "Array of room assignments (assign_rooms action). Each must have \"room\" plus either \"uuid\" or \"accessory\"."
+        },
+        "dry_run": {
+          "type": "boolean",
+          "description": "Preview changes without applying (default: false)"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "homekit_config",
+    "description": "View or update HomeClaw configuration. Set a default home, or configure device filtering to control which accessories are exposed.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "get",
+            "set"
+          ],
+          "description": "Action to perform. Default: get"
+        },
+        "default_home_id": {
+          "type": "string",
+          "description": "Home UUID or name to set as active home (set action). All commands operate on the active home."
+        },
+        "accessory_filter_mode": {
+          "type": "string",
+          "enum": [
+            "all",
+            "allowlist"
+          ],
+          "description": "Filter mode: \"all\" exposes every accessory, \"allowlist\" only exposes selected accessories (set action)."
+        },
+        "allowed_accessory_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array of accessory UUIDs to expose when filter mode is \"allowlist\" (set action)."
+        }
+      }
+    }
+  },
+  {
+    "name": "homekit_automations",
+    "description": "Manage HomeKit automations. List existing automations, inspect their events and linked scenes, create automations triggered by any characteristic change (button presses, motion sensors, contact sensors, occupancy, etc.) or by a time of day (clock or sunrise/sunset), delete automations, or enable/disable them. For characteristic-change triggers use action=create with press_type (buttons) or characteristic+trigger_value (sensors). For time-of-day triggers use action=create_time with the `time` field (HH:MM, sunrise, sunset, or <sun-event>±N). Both create actions accept the same predicate vocabulary: weekdays, conditions, time_after, time_before, duration_seconds. Use duration_seconds to auto-revert actions after N seconds (e.g. motion-triggered lights or sunset porch lights that turn off after a delay). Use action=add_condition to append a characteristic condition (ANDed) to an existing automation in place — the trigger UUID is preserved, so button bindings and Siri references survive. List/get also surface HMTimerTrigger automations (Apple Home native time automations) and HMCalendarEvent / HMSignificantTimeEvent / HMDurationEvent details on event triggers; result rows include trigger_type (\"button\" | \"characteristic\" | \"calendar\" | \"significant_time\" | \"timer\" | \"unknown\") and, where applicable, fire_time, fire_date, and duration_seconds. Delete/enable/disable accept any trigger subtype. Note: the predicate-composition features (conditions, time_after/time_before, add_condition) are built on standard HMEventTrigger predicate composition — supported by Apple's HomeKit framework APIs but not yet surfaced in the Home app's Automations tab. They mirror the rule-editor capabilities exposed by third-party HomeKit apps like Controller for HomeKit. Rules created or modified this way execute correctly via HomeKit; use list/get to inspect them since they may not be editable from the Home app.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "list",
+            "get",
+            "create",
+            "create_time",
+            "delete",
+            "enable",
+            "disable",
+            "add_condition"
+          ],
+          "description": "Action to perform. Default: list"
+        },
+        "home_id": {
+          "type": "string",
+          "description": "Home UUID or name. Defaults to configured home."
+        },
+        "id": {
+          "type": "string",
+          "description": "Automation UUID or name (get/delete/enable/disable actions)"
+        },
+        "name": {
+          "type": "string",
+          "description": "Automation name (create / create_time actions)"
+        },
+        "accessory_id": {
+          "type": "string",
+          "description": "Trigger accessory UUID or name (create action)"
+        },
+        "time": {
+          "type": "string",
+          "description": "Time of day the automation fires (create_time action, required). Format: \"HH:MM\" for a wall-clock time (e.g. \"06:30\", \"17:45\"; both fields must be zero-padded two digits — \"6:30\" is rejected), \"sunrise\"/\"sunset\" for sun-relative events, or \"<sun-event>±N\" where N is minutes (e.g. \"sunset-30\", \"sunrise+15\"). Offsets larger than 1440 minutes (24h) are rejected. Implemented as HMCalendarEvent for HH:MM and HMSignificantTimeEvent for sunrise/sunset. All other predicate flags (weekdays, conditions, time_after, time_before, duration_seconds) compose with `time` the same way they do on the create action — `time` is the trigger event, those are the gating predicates."
+        },
+        "scene_id": {
+          "type": "string",
+          "description": "Scene UUID or name to trigger (create / create_time actions). Alternative to actions."
+        },
+        "actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accessory": {
+                "type": "string",
+                "description": "Target accessory UUID (strongly preferred) or name"
+              },
+              "property": {
+                "type": "string",
+                "description": "Characteristic to set (e.g., power, brightness, color_temperature)"
+              },
+              "characteristic": {
+                "type": "string",
+                "description": "Alias for \"property\" — provide one or the other"
+              },
+              "value": {
+                "type": "string",
+                "description": "Target value as string (e.g., \"true\", \"50\", \"344\")"
+              },
+              "room": {
+                "type": "string",
+                "description": "Room name for disambiguation (optional)"
+              }
+            },
+            "required": [
+              "accessory",
+              "value"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "property"
+                ]
+              },
+              {
+                "required": [
+                  "characteristic"
+                ]
+              }
+            ]
+          },
+          "description": "Inline actions for the automation (create / create_time actions). Alternative to scene_id. Creates a scene named after the automation. Each action sets one characteristic on one accessory."
+        },
+        "press_type": {
+          "type": "number",
+          "enum": [
+            0,
+            1,
+            2
+          ],
+          "description": "Button press type: 0=single (default), 1=double, 2=long press. For button triggers only; mutually exclusive with characteristic. (create action)"
+        },
+        "characteristic": {
+          "type": "string",
+          "description": "Characteristic name to trigger on (e.g., motion_detected, contact_state, occupancy_detected, current_temperature). Alternative to press_type for non-button triggers. (create action)"
+        },
+        "trigger_value": {
+          "type": "string",
+          "description": "Value that triggers the automation (e.g., \"true\", \"false\", \"1\", \"0\"). Required when characteristic is set. Uses exact value matching. (create action)"
+        },
+        "service_index": {
+          "type": "number",
+          "description": "Button index for multi-button accessories (1 or 2). For button triggers only. (create action)"
+        },
+        "weekdays": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "enum": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7
+            ]
+          },
+          "description": "Restrict the automation to fire only on these weekdays (1=Sun, 2=Mon, ..., 7=Sat). When omitted, characteristic-trigger automations (create) fire every day; time-of-day automations (create_time) auto-fill all 7 days since iOS 15+ marks time-conditional automations without weekday gating as \"unreliable\". Setting time_after/time_before on create with no weekdays also auto-fills all 7 days and sets `weekdays_auto_filled: true` in the response. (create / create_time actions)"
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accessory": {
+                "type": "string",
+                "description": "Condition accessory UUID (preferred) or name"
+              },
+              "property": {
+                "type": "string",
+                "description": "Characteristic name (e.g., contact_state, occupancy_detected, power)"
+              },
+              "characteristic": {
+                "type": "string",
+                "description": "Alias for \"property\" — provide one or the other"
+              },
+              "value": {
+                "type": "string",
+                "description": "Required value as string (e.g., \"true\", \"0\", \"50\"). Uses exact match (==)."
+              },
+              "room": {
+                "type": "string",
+                "description": "Room name for accessory disambiguation when multiple accessories share a name (optional)"
+              }
+            },
+            "required": [
+              "accessory",
+              "value"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "property"
+                ]
+              },
+              {
+                "required": [
+                  "characteristic"
+                ]
+              }
+            ]
+          },
+          "description": "Extra characteristic predicates ANDed into the trigger predicate. The trigger fires only when the trigger event happens AND every condition holds. Example: porch motion (or sunset, on create_time) that only triggers when the front door is closed AND nobody is home. Each condition is a (characteristic == value) match against any accessory in the home. (create / create_time actions)"
+        },
+        "time_after": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Time predicates ANDed into the trigger so it only fires after the given time. Same vocabulary as the `time` field: \"HH:MM\" for a wall-clock time (zero-padded, e.g. \"07:00\") or \"<sunrise|sunset>[±N]\" where N is minutes (e.g., \"sunset-30\", \"sunrise+15\", \"sunset\"). Offsets larger than 1440 minutes are rejected. Combine with time_before for a window (e.g., time_after=[\"07:00\"] + time_before=[\"20:30\"] for \"only during the day\", or time_after=[\"sunset-30\"] + time_before=[\"sunrise+15\"] for \"between dusk and dawn\"). On create_time these are gating predicates on top of the `time` trigger event, not the trigger itself. When set without explicit weekdays, HomeClaw auto-fills all 7 days; see the weekdays field. (create / create_time actions)"
+        },
+        "time_before": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Time predicates ANDed into the trigger so it only fires before the given time. Same format and offset rules as time_after. (create / create_time actions)"
+        },
+        "duration_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 86400,
+          "description": "Auto-revert the trigger's actions after this many seconds (1-86400, i.e. up to 24 hours). Implemented as an HMDurationEvent attached to the trigger's endEvents — HomeKit handles the revert natively, no follow-up automation required. Common use cases: motion-triggered lights that should turn off again after a delay (e.g. `duration_seconds: 300` for a 5-minute hold), or sunset porch lights that should turn off after an hour. (create / create_time actions)"
+        },
+        "condition": {
+          "type": "object",
+          "properties": {
+            "accessory": {
+              "type": "string",
+              "description": "Condition accessory UUID (preferred) or name"
+            },
+            "property": {
+              "type": "string",
+              "description": "Characteristic name (e.g., contact_state, occupancy_detected, power)"
+            },
+            "characteristic": {
+              "type": "string",
+              "description": "Alias for \"property\" — provide one or the other"
+            },
+            "value": {
+              "type": "string",
+              "description": "Required value as string (e.g., \"true\", \"0\", \"50\"). Uses exact match (==)."
+            },
+            "room": {
+              "type": "string",
+              "description": "Room name for accessory disambiguation when multiple accessories share a name (optional)"
+            }
+          },
+          "required": [
+            "accessory",
+            "value"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "property"
+              ]
+            },
+            {
+              "required": [
+                "characteristic"
+              ]
+            }
+          ],
+          "description": "Single characteristic condition (object — note the singular field name, distinct from the plural `conditions` array used by create / create_time) to append (ANDed) to an existing automation's trigger predicate. To add multiple conditions, call add_condition repeatedly — each call preserves the trigger UUID, so physical button bindings, Siri references, and other UUID-keyed integrations survive every modification. The read-side decoder (list/get) surfaces the new condition automatically. To replace an existing condition set, delete the automation and recreate it. (add_condition action)"
+        },
+        "dry_run": {
+          "type": "boolean",
+          "description": "Preview changes without applying (create/create_time/delete/add_condition actions)"
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "name": "homekit_webhook",
+    "description": "Manage webhook configuration for pushing HomeKit events to OpenClaw or other services. Actions: setup (configure URL, token, and enable in one step), test (send a test event and show the HTTP response), reset (reset the circuit breaker), status (show webhook health and delivery stats).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "setup",
+            "test",
+            "reset",
+            "status"
+          ],
+          "description": "Action to perform. Default: status"
+        },
+        "url": {
+          "type": "string",
+          "description": "Base gateway URL, e.g. http://127.0.0.1:18789 (setup action). HomeClaw appends /hooks/wake automatically — do NOT include the path."
+        },
+        "token": {
+          "type": "string",
+          "description": "Bearer token for webhook authentication (setup action)"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable the webhook (setup action). Default: true"
+        }
+      }
+    }
+  },
+  {
+    "name": "homekit_events",
+    "description": "Get recent HomeKit events — characteristic changes, scene triggers, and accessory control actions. Use to understand what happened recently in the home.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of events to return (default: 50)"
+        },
+        "since": {
+          "type": "string",
+          "description": "ISO 8601 timestamp — only return events after this time"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "characteristic_change",
+            "homes_updated",
+            "scene_triggered",
+            "accessory_controlled"
+          ],
+          "description": "Filter by event type"
+        }
+      }
+    }
+  }
+]

--- a/Tests/HomeClawTests/HTTPIntegrationLifecycleTests.swift
+++ b/Tests/HomeClawTests/HTTPIntegrationLifecycleTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+#if !LIFECYCLE_STANDALONE
+import XCTest
+@testable import HomeClaw
+#endif
+
+@MainActor
+private enum LifecycleChecks {
+    struct Failure: Error { let message: String }
+    static func expect(_ condition: Bool, _ message: String) throws {
+        if !condition { throw Failure(message: message) }
+    }
+
+    @MainActor final class Gate {
+        var continuation: CheckedContinuation<Void, Never>?
+        func wait() async { await withCheckedContinuation { continuation = $0 } }
+        func open() { continuation?.resume(); continuation = nil }
+    }
+
+    static func disableDuringStartup() async throws {
+        let suite = "HTTPIntegrationLifecycleTests.\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let gate = Gate()
+        var listening = false
+        let lifecycle = HTTPIntegrationLifecycle(defaults: defaults, start: {
+            await gate.wait()
+            listening = true
+        }, stop: { listening = false })
+        lifecycle.setEnabled(true)
+        while gate.continuation == nil { await Task.yield() }
+        lifecycle.setEnabled(false)
+        // Let a naively concurrent stop finish before the suspended start.
+        for _ in 0..<20 { await Task.yield() }
+        gate.open()
+        for _ in 0..<20 { await Task.yield() }
+        await lifecycle.waitUntilSettled()
+        try expect(!listening, "Disable during suspended startup must close the late listener")
+    }
+
+    static func shutdownPreventsRestartAndWaitsForHTTP() async throws {
+        let suite = "HTTPIntegrationLifecycleTests.\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let gate = Gate()
+        var events: [String] = []
+        let lifecycle = HTTPIntegrationLifecycle(defaults: defaults, start: {
+            events.append("start")
+        }, stop: {
+            events.append("http-stopping")
+            await gate.wait()
+            events.append("http-stopped")
+        })
+        lifecycle.setEnabled(true)
+        await lifecycle.waitUntilSettled()
+        let shutdown = lifecycle.beginShutdown { events.append("socket-stopped") }
+        try expect(events == ["start", "socket-stopped"], "Legacy stop must execute synchronously")
+        lifecycle.setEnabled(true)
+        lifecycle.startIfEnabled()
+        let completion = Task { await shutdown.value; events.append("terminate") }
+        while gate.continuation == nil { await Task.yield() }
+        try expect(!events.contains("terminate"), "Termination must wait for HTTP cleanup without blocking MainActor")
+        gate.open()
+        await completion.value
+        await lifecycle.waitUntilSettled()
+        try expect(events == ["start", "socket-stopped", "http-stopping", "http-stopped", "terminate"], "Shutdown must prevent restarts and complete before termination")
+        try expect(defaults.bool(forKey: HTTPIntegrationLifecycle.enabledKey), "Quit must preserve preference for next launch")
+    }
+
+    static func rapidTogglesDoNotStartAfterDisable() async throws {
+        let suite = "HTTPIntegrationLifecycleTests.\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        var starts = 0
+        let lifecycle = HTTPIntegrationLifecycle(defaults: defaults, start: { starts += 1 }, stop: {})
+        lifecycle.setEnabled(true)
+        lifecycle.setEnabled(false)
+        lifecycle.setEnabled(true)
+        lifecycle.setEnabled(false)
+        await lifecycle.waitUntilSettled()
+        try expect(starts == 0, "Queued enables must not start after final disable")
+    }
+
+    static func defaultOffAndPersistence() async throws {
+        let suite = "HTTPIntegrationLifecycleTests.\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        var starts = 0
+        let lifecycle = HTTPIntegrationLifecycle(defaults: defaults, start: { starts += 1 }, stop: {})
+        lifecycle.startIfEnabled()
+        await lifecycle.waitUntilSettled()
+        try expect(!lifecycle.isEnabled && starts == 0, "Absent setting must not start HTTP")
+        lifecycle.setEnabled(true)
+        await lifecycle.waitUntilSettled()
+        try expect(starts == 1, "Enabling starts HTTP")
+        let restored = HTTPIntegrationLifecycle(defaults: defaults, start: { starts += 1 }, stop: {})
+        try expect(restored.isEnabled, "Enabled preference must persist")
+        lifecycle.setEnabled(false)
+        await lifecycle.waitUntilSettled()
+        try expect(!defaults.bool(forKey: HTTPIntegrationLifecycle.enabledKey), "Disabled preference must persist")
+    }
+}
+
+#if LIFECYCLE_STANDALONE
+@main
+struct HTTPIntegrationLifecycleTestRunner {
+    static func main() async throws {
+        try await LifecycleChecks.defaultOffAndPersistence()
+        print("PASS defaultOffAndPersistence")
+        try await LifecycleChecks.disableDuringStartup()
+        print("PASS disableDuringStartup")
+        try await LifecycleChecks.shutdownPreventsRestartAndWaitsForHTTP()
+        print("PASS shutdownPreventsRestartAndWaitsForHTTP")
+        try await LifecycleChecks.rapidTogglesDoNotStartAfterDisable()
+        print("PASS rapidTogglesDoNotStartAfterDisable")
+    }
+}
+#else
+final class HTTPIntegrationLifecycleTests: XCTestCase {
+    @MainActor func testRapidTogglesDoNotStartAfterDisable() async throws {
+        try await LifecycleChecks.rapidTogglesDoNotStartAfterDisable()
+    }
+    @MainActor func testDisableDuringStartup() async throws {
+        try await LifecycleChecks.disableDuringStartup()
+    }
+    @MainActor func testShutdownPreventsRestartAndWaitsForHTTP() async throws {
+        try await LifecycleChecks.shutdownPreventsRestartAndWaitsForHTTP()
+    }
+    @MainActor func testDefaultOffAndPersistence() async throws {
+        try await LifecycleChecks.defaultOffAndPersistence()
+    }
+}
+#endif

--- a/Tests/HomeClawTests/HTTPMCPConfigurationTests.swift
+++ b/Tests/HomeClawTests/HTTPMCPConfigurationTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import HomeClaw
+
+final class HTTPMCPConfigurationTests: XCTestCase {
+    func testDefaultPortIs9090() {
+        XCTAssertEqual(HTTPMCPConfiguration.defaultPort, 9090)
+    }
+
+    func testExplicitPortIsPreserved() {
+        XCTAssertEqual(HTTPMCPConfiguration(port: 19090, bindHost: "127.0.0.1").port, 19090)
+    }
+
+    func testLoopbackAddressesAreAccepted() throws {
+        XCTAssertNoThrow(try HTTPMCPConfiguration(port: 9090, bindHost: "127.0.0.1").validateLoopbackBind())
+        XCTAssertNoThrow(try HTTPMCPConfiguration(port: 9090, bindHost: "::1").validateLoopbackBind())
+    }
+
+    func testNonLoopbackAddressesAreRejected() {
+        for host in ["0.0.0.0", "::", "192.168.1.10"] {
+            XCTAssertThrowsError(try HTTPMCPConfiguration(port: 9090, bindHost: host).validateLoopbackBind(), host)
+        }
+    }
+}

--- a/Tests/HomeClawTests/HTTPMCPHealthResponseTests.swift
+++ b/Tests/HomeClawTests/HTTPMCPHealthResponseTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import HomeClaw
+
+final class HTTPMCPHealthResponseTests: XCTestCase {
+    func testReadyResponseIsDeterministicAndSecretFree() throws {
+        let first = HTTPMCPHealthResponse(listenerReady: true, homeKitReady: true)
+        let second = HTTPMCPHealthResponse(listenerReady: true, homeKitReady: true)
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.statusCode, 200)
+        XCTAssertEqual(first.bodyString, "{\"homekit_ready\":true,\"listener_ready\":true,\"status\":\"ready\"}")
+        XCTAssertFalse(first.bodyString.contains("token"))
+        XCTAssertFalse(first.bodyString.contains("secret"))
+    }
+
+    func testListenerReadyButHomeKitUnavailableIsNotReady() {
+        let response = HTTPMCPHealthResponse(listenerReady: true, homeKitReady: false)
+
+        XCTAssertEqual(response.statusCode, 503)
+        XCTAssertEqual(response.bodyString, "{\"homekit_ready\":false,\"listener_ready\":true,\"status\":\"not_ready\"}")
+    }
+
+    func testHealthResponseContainsOnlyReadinessFields() {
+        let response = HTTPMCPHealthResponse(listenerReady: false, homeKitReady: false)
+
+        XCTAssertEqual(response.statusCode, 503)
+        XCTAssertEqual(response.bodyString, "{\"homekit_ready\":false,\"listener_ready\":false,\"status\":\"not_ready\"}")
+        XCTAssertFalse(response.bodyString.contains("socket"))
+        XCTAssertFalse(response.bodyString.contains("accessor"))
+    }
+}

--- a/Tests/HomeClawTests/HTTPMCPRequestPolicyTests.swift
+++ b/Tests/HomeClawTests/HTTPMCPRequestPolicyTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import HomeClaw
+
+final class HTTPMCPRequestPolicyTests: XCTestCase {
+    func testAcceptsLoopbackHostsAndAbsentOrigin() throws {
+        XCTAssertNoThrow(try HTTPMCPRequestPolicy.validate(host: "127.0.0.1:9090", origin: nil, bindHost: "127.0.0.1"))
+        XCTAssertNoThrow(try HTTPMCPRequestPolicy.validate(host: "[::1]:9090", origin: nil, bindHost: "::1"))
+        XCTAssertNoThrow(try HTTPMCPRequestPolicy.validate(host: "localhost", origin: nil, bindHost: "127.0.0.1"))
+    }
+
+    func testAcceptsLoopbackOrigin() throws {
+        XCTAssertNoThrow(try HTTPMCPRequestPolicy.validate(
+            host: "127.0.0.1:9090", origin: "http://localhost:9090", bindHost: "127.0.0.1"))
+        XCTAssertNoThrow(try HTTPMCPRequestPolicy.validate(
+            host: "[::1]:9090", origin: "http://[::1]:9090", bindHost: "::1"))
+    }
+
+    func testRejectsPublicHostsAndOrigins() {
+        let cases: [(String, String?, String)] = [
+            ("evil.example:9090", nil, "127.0.0.1"),
+            ("127.0.0.1:9090", "https://evil.example", "127.0.0.1"),
+            ("127.0.0.1:9090", "not an origin", "127.0.0.1"),
+            ("localhost:9090", nil, "::1"),
+        ]
+        for (host, origin, bindHost) in cases {
+            XCTAssertThrowsError(try HTTPMCPRequestPolicy.validate(
+                host: host, origin: origin, bindHost: bindHost))
+        }
+    }
+
+    func testPolicyErrorsDoNotEchoBodiesOrCredentials() {
+        let body = "password=super-secret bearer=top-secret"
+        XCTAssertThrowsError(try HTTPMCPRequestPolicy.validate(
+            host: "evil.example?body=\(body)", origin: "https://evil.example/\(body)", bindHost: "127.0.0.1")) { error in
+            let description = String(describing: error)
+            XCTAssertFalse(description.contains(body))
+            XCTAssertFalse(description.contains("super-secret"))
+            XCTAssertFalse(description.contains("top-secret"))
+        }
+    }
+}

--- a/Tests/HomeClawTests/MCPHTTPChannelOwnershipTests.swift
+++ b/Tests/HomeClawTests/MCPHTTPChannelOwnershipTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@preconcurrency import NIOCore
+@preconcurrency import NIOHTTP1
+import NIOEmbedded
+@testable import HomeClaw
+
+private actor SuspendedOwnershipRegistry: MCPToolRegistry {
+    nonisolated var toolsJSON: Data { Data(#"[{"name":"homekit_status"}]"#.utf8) }
+    private(set) var entered = false
+    private var continuation: CheckedContinuation<Data, Never>?
+    func call(name: String, arguments: Data) async -> Data {
+        entered = true
+        return await withCheckedContinuation { continuation = $0 }
+    }
+    func release() { continuation?.resume(returning: Data("{}".utf8)); continuation = nil }
+}
+
+/// Exercises MCPHTTPHandler.channelInactive, not just its bookkeeping helper.
+/// The registry is controlled and never reaches HomeKit; no listener is bound.
+final class MCPHTTPChannelOwnershipTests: XCTestCase {
+    private func session(_ server: MCPServer) async throws -> String {
+        let id = await server.sessionStore.create()
+        return try XCTUnwrap(id)
+    }
+
+    private func headers(_ session: String, stream: Bool = true) -> HTTPHeaders {
+        HTTPHeaders([("Host", "127.0.0.1"), ("Accept", stream ? "text/event-stream" : "application/json"),
+                     ("Content-Type", "application/json"), ("Mcp-Session-Id", session),
+                     ("MCP-Protocol-Version", MCPServer.supportedProtocolVersion)])
+    }
+
+    private func channel(_ server: MCPServer) async throws -> NIOAsyncTestingChannel {
+        let channel = await NIOAsyncTestingChannel(handler: MCPHTTPHandler(server: server))
+        try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 9090)).get()
+        return channel
+    }
+
+    private func sendGET(_ channel: NIOAsyncTestingChannel, session: String) async throws {
+        try await channel.writeInbound(HTTPServerRequestPart.head(HTTPRequestHead(version: .http1_1, method: .GET, uri: "/mcp", headers: headers(session))))
+        try await channel.writeInbound(HTTPServerRequestPart.end(nil))
+    }
+
+    private func waitForConnected(_ channel: NIOAsyncTestingChannel) async throws {
+        let head = try await channel.waitForOutboundWrite(as: HTTPServerResponsePart.self)
+        guard case .head(let response) = head else { return XCTFail("Expected SSE response head") }
+        XCTAssertEqual(response.status, .ok)
+        let body = try await channel.waitForOutboundWrite(as: HTTPServerResponsePart.self)
+        guard case .body(.byteBuffer(let buffer)) = body else { return XCTFail("Expected connected frame") }
+        XCTAssertEqual(String(buffer: buffer), ": connected\n\n")
+    }
+
+    private func eventually(_ predicate: @escaping @Sendable () async -> Bool,
+                            file: StaticString = #filePath, line: UInt = #line) async throws {
+        for _ in 0..<200 {
+            if await predicate() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTFail("Timed out waiting for lifecycle state", file: file, line: line)
+    }
+
+    private func assertStillOwned(_ ownership: SSEStreamOwnership, server: MCPServer,
+                                  file: StaticString = #filePath, line: UInt = #line) async throws {
+        // Check throughout a bounded observation window: cleanup is dispatched in a Task.
+        for _ in 0..<40 {
+            let current = await server.testSSEOwnerships
+            XCTAssertTrue(current.contains(ownership), "Disconnect retired another connection's SSE", file: file, line: line)
+            if !current.contains(ownership) { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+
+    func testPOSTDisconnectPreservesAnotherConnectionsSSE() async throws {
+        let registry = SuspendedOwnershipRegistry()
+        let server = MCPServer(toolRegistry: registry)
+        let id = try await session(server)
+        let streamChannel = try await channel(server)
+        let postChannel = try await channel(server)
+        try await sendGET(streamChannel, session: id)
+        try await waitForConnected(streamChannel)
+        let snapshot = await server.testSSEOwnerships
+        let ownership = try XCTUnwrap(snapshot.first)
+
+        try await postChannel.writeInbound(HTTPServerRequestPart.head(HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp", headers: headers(id, stream: false))))
+        let body = ByteBuffer(string: #"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"homekit_status","arguments":{}}}"#)
+        try await postChannel.writeInbound(HTTPServerRequestPart.body(body))
+        try await postChannel.writeInbound(HTTPServerRequestPart.end(nil))
+        try await eventually { await registry.entered }
+        try await postChannel.close().get() // Real channelInactive while the POST is in flight.
+        try await assertStillOwned(ownership, server: server)
+        await registry.release()
+        try await streamChannel.close().get()
+        try await eventually { await server.testSSEOwnerships.isEmpty }
+        _ = try await postChannel.finish(acceptAlreadyClosed: true)
+        _ = try await streamChannel.finish(acceptAlreadyClosed: true)
+        await server.stop()
+    }
+
+    func testOldSSEDisconnectPreservesReplacement() async throws {
+        let server = MCPServer(toolRegistry: HomeClawMCPToolRegistry.test(status: "unused"))
+        let id = try await session(server)
+        let oldChannel = try await channel(server)
+        try await sendGET(oldChannel, session: id)
+        try await waitForConnected(oldChannel)
+        let oldSnapshot = await server.testSSEOwnerships
+        let oldOwnership = try XCTUnwrap(oldSnapshot.first)
+
+        // Hold the old event loop so its completion cannot retire bookkeeping
+        // before channelInactive. Replacement is created on the independent actor.
+        let entered = expectation(description: "old loop held")
+        let release = DispatchSemaphore(value: 0)
+        oldChannel.eventLoop.execute {
+            entered.fulfill()
+            _ = release.wait(timeout: .now() + 5)
+            oldChannel.close(promise: nil)
+        }
+        await fulfillment(of: [entered], timeout: 2)
+        let replacement = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: Dictionary(uniqueKeysWithValues: headers(id).map { ($0.name, $0.value) })))
+        let ownership = try XCTUnwrap(replacement.sseOwnership)
+        XCTAssertNotEqual(oldOwnership, ownership)
+        release.signal()
+        try await oldChannel.closeFuture.get()
+        try await assertStillOwned(ownership, server: server)
+        await server.cleanupSSE(for: ownership)
+        _ = try await oldChannel.finish(acceptAlreadyClosed: true)
+        await server.stop()
+    }
+
+    func testOwnerDisconnectRemovesItsSSEButKeepsSession() async throws {
+        let server = MCPServer(toolRegistry: HomeClawMCPToolRegistry.test(status: "unused"))
+        let id = try await session(server)
+        let owner = try await channel(server)
+        try await sendGET(owner, session: id)
+        try await waitForConnected(owner)
+        let before = await server.testSSEOwnerships
+        XCTAssertEqual(before.count, 1)
+        try await owner.close().get()
+        try await eventually { await server.testSSEOwnerships.isEmpty }
+        let sessionCount = await server.sessionStore.count
+        XCTAssertEqual(sessionCount, 1)
+        _ = try await owner.finish(acceptAlreadyClosed: true)
+        await server.stop()
+    }
+
+    func testDisconnectBeforeSSERegistrationDoesNotLeakOwnership() async throws {
+        let server = MCPServer(toolRegistry: HomeClawMCPToolRegistry.test(status: "unused"))
+        let id = try await session(server)
+        let owner = try await channel(server)
+        let head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/mcp", headers: headers(id))
+        let entered = expectation(description: "request started with event loop held")
+        let release = DispatchSemaphore(value: 0)
+        owner.eventLoop.execute {
+            owner.pipeline.fireChannelRead(HTTPServerRequestPart.head(head))
+            owner.pipeline.fireChannelRead(HTTPServerRequestPart.end(nil))
+            entered.fulfill()
+            _ = release.wait(timeout: .now() + 5)
+            owner.close(promise: nil)
+        }
+        await fulfillment(of: [entered], timeout: 2)
+        try await eventually { await !server.testSSEOwnerships.isEmpty }
+        release.signal() // channelInactive runs before queued markSSEActive.
+        try await owner.closeFuture.get()
+        try await eventually { await server.testSSEOwnerships.isEmpty }
+        _ = try await owner.finish(acceptAlreadyClosed: true)
+        await server.stop()
+    }
+}

--- a/Tests/HomeClawTests/MCPTransportParityTests.swift
+++ b/Tests/HomeClawTests/MCPTransportParityTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import HomeClaw
+
+@MainActor
+final class MCPTransportParityTests: XCTestCase {
+    func testCanonicalDescriptorsMatchNodeGeneratedFixture() throws {
+        // The Node drift check compares this entire fixture AND the embedded Swift
+        // JSON against the real lib/schemas.js export (not a hardcoded tool list).
+        let fixture = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "mcp-tools", withExtension: "json"))
+        let expected = try JSONSerialization.jsonObject(with: Data(contentsOf: fixture)) as? NSArray
+        let actual = try JSONSerialization.jsonObject(with: ToolHandlers.allToolsJSON) as? NSArray
+        XCTAssertEqual(try XCTUnwrap(actual), try XCTUnwrap(expected))
+        XCTAssertEqual(HomeClawMCPToolRegistry.shared.toolsJSON, ToolHandlers.allToolsJSON)
+        let tools = try XCTUnwrap(actual as? [[String: Any]])
+        XCTAssertFalse(tools.isEmpty)
+        let names = tools.compactMap { $0["name"] as? String }
+        XCTAssertEqual(ToolHandlers.allToolNames, names)
+        XCTAssertEqual(Set(names).count, tools.count)
+    }
+
+    func testHTTPToolsListOmitsMutatingAccessoryActionButCanonicalSchemaRetainsIt() async throws {
+        let canonical = try XCTUnwrap(JSONSerialization.jsonObject(with: ToolHandlers.allToolsJSON) as? [[String: Any]])
+        let canonicalAccessory = try XCTUnwrap(canonical.first { $0["name"] as? String == "homekit_accessories" })
+        XCTAssertTrue(try actions(in: canonicalAccessory).contains("control"))
+
+        let registry = RecordingParityRegistry()
+        let server = MCPServer(toolRegistry: registry)
+        let headers = try await initialize(server)
+        let tools = try await advertisedTools(server, headers: headers)
+        let httpAccessory = try XCTUnwrap(tools.first { $0["name"] as? String == "homekit_accessories" })
+        XCTAssertEqual(try actions(in: httpAccessory), ["list", "get", "search"])
+        let calls = await registry.calls
+        XCTAssertTrue(calls.isEmpty, "tools/list must not execute any handler")
+    }
+
+    func testEveryHTTPAdvertisedToolRoutesToInjectedRegistryWithoutHomeKit() async throws {
+        // This proves transport/registry wiring, NOT execution of native HomeKit
+        // handlers. Even a policy regression can only reach this inert recorder.
+        let registry = RecordingParityRegistry()
+        let server = MCPServer(toolRegistry: registry)
+        let headers = try await initialize(server)
+        let tools = try await advertisedTools(server, headers: headers)
+        XCTAssertFalse(tools.isEmpty)
+        for tool in tools {
+            let name = try XCTUnwrap(tool["name"] as? String)
+            let arguments = name == "homekit_accessories" ? ["action": "list"] : [:]
+            let request = try JSONSerialization.data(withJSONObject: [
+                "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                "params": ["name": name, "arguments": arguments]
+            ])
+            let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+            XCTAssertEqual(response.statusCode, 200)
+            let body = try object(response)
+            XCTAssertNil(body["error"])
+            let result = try XCTUnwrap(body["result"] as? [String: Any])
+            let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+            let text = try XCTUnwrap(content.first?["text"] as? String)
+            let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+            XCTAssertEqual(payload["recordedTool"] as? String, name)
+            let calls = await registry.calls
+            let call = try XCTUnwrap(calls.last)
+            XCTAssertEqual(call.name, name)
+            let received = try JSONSerialization.jsonObject(with: call.arguments) as? [String: String]
+            XCTAssertEqual(received, arguments)
+        }
+        let calls = await registry.calls
+        XCTAssertEqual(calls.map(\.name), tools.compactMap { $0["name"] as? String })
+    }
+
+    func testHTTPRejectsUnadvertisedToolsAndMutatingActionsBeforeRegistry() async throws {
+        let registry = RecordingParityRegistry()
+        let server = MCPServer(toolRegistry: registry)
+        let headers = try await initialize(server)
+        let advertised = try await advertisedTools(server, headers: headers).compactMap { $0["name"] as? String }
+        let hidden = ToolHandlers.allToolNames.filter { !advertised.contains($0) }
+        XCTAssertFalse(hidden.isEmpty)
+        let probes = hidden.map { ($0, [String: String]()) } + [
+            ("homekit_accessories", ["action": "control"]),
+            ("homekit_accessories", ["action": "future_action"]),
+            ("future_tool", [:])
+        ]
+        for (name, arguments) in probes {
+            let request = try JSONSerialization.data(withJSONObject: [
+                "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                "params": ["name": name, "arguments": arguments]
+            ])
+            let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+            XCTAssertNotNil(try object(response)["error"], "Must reject \(name) \(arguments)")
+        }
+        let calls = await registry.calls
+        XCTAssertTrue(calls.isEmpty, "Denied calls must never reach the dispatcher")
+    }
+
+    private func initialize(_ server: MCPServer) async throws -> [String: String] {
+        let body = Data(#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"parity-test","version":"1.0"}}}"#.utf8)
+        let headers = ["Content-Type": "application/json", "Accept": "application/json"]
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: body))
+        let session = try XCTUnwrap(response.header("Mcp-Session-Id"))
+        return headers.merging(["Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]) { _, value in value }
+    }
+
+    private func advertisedTools(_ server: MCPServer, headers: [String: String]) async throws -> [[String: Any]] {
+        let body = Data(#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#.utf8)
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: body))
+        let result = try XCTUnwrap(try object(response)["result"] as? [String: Any])
+        return try XCTUnwrap(result["tools"] as? [[String: Any]])
+    }
+
+    private func object(_ response: HTTPResponse) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: try XCTUnwrap(response.bodyData)) as? [String: Any])
+    }
+
+    private func actions(in tool: [String: Any]) throws -> [String] {
+        let schema = try XCTUnwrap(tool["inputSchema"] as? [String: Any])
+        let properties = try XCTUnwrap(schema["properties"] as? [String: Any])
+        let action = try XCTUnwrap(properties["action"] as? [String: Any])
+        return try XCTUnwrap(action["enum"] as? [String])
+    }
+}
+
+private actor RecordingParityRegistry: MCPToolRegistry {
+    struct Call: Sendable {
+        let name: String
+        let arguments: Data
+    }
+    nonisolated let toolsJSON = ToolHandlers.allToolsJSON
+    private(set) var calls: [Call] = []
+
+    func call(name: String, arguments: Data) async -> Data {
+        calls.append(Call(name: name, arguments: arguments))
+        return (try? JSONSerialization.data(withJSONObject: ["recordedTool": name])) ?? Data()
+    }
+}

--- a/Tests/HomeClawTests/StreamableHTTPReviewRegressionTests.swift
+++ b/Tests/HomeClawTests/StreamableHTTPReviewRegressionTests.swift
@@ -1,0 +1,404 @@
+import XCTest
+@preconcurrency import NIOHTTP1
+@testable import HomeClaw
+
+private struct ErrorMCPToolRegistry: MCPToolRegistry {
+    var toolsJSON: Data { Data("[{\"name\":\"homekit_status\"}]".utf8) }
+    func call(name: String, arguments: Data) async -> Data {
+        Data("{\"error\":\"tool failed\"}".utf8)
+    }
+}
+
+private struct HangingMCPToolRegistry: MCPToolRegistry {
+    var toolsJSON: Data { Data("[{\"name\":\"homekit_status\"}]".utf8) }
+    func call(name: String, arguments: Data) async -> Data {
+        try? await Task.sleep(for: .seconds(60)); return Data("{\"status\":\"late\"}".utf8)
+    }
+}
+
+private struct IgnoringCancellationMCPToolRegistry: MCPToolRegistry {
+    var toolsJSON: Data { Data("[{\"name\":\"homekit_status\"}]".utf8) }
+    func call(name: String, arguments: Data) async -> Data {
+        await Task.detached {
+            try? await Task.sleep(for: .seconds(1))
+            return Data("{\"status\":\"late\"}".utf8)
+        }.value
+    }
+}
+
+private actor EventLog {
+    private(set) var events: [String] = []
+
+    func append(_ event: String) {
+        events.append(event)
+    }
+}
+
+private actor CallCounter {
+    private(set) var count = 0
+
+    func increment() {
+        count += 1
+    }
+}
+
+final class StreamableHTTPReviewRegressionTests: XCTestCase {
+    private let jsonHeaders = ["Content-Type": "application/json", "Accept": "application/json"]
+    private let initialize = Data("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}".utf8)
+
+    func testResponseOrderGateReleasesConcurrentRequestsInReservationOrder() async {
+        let gate = MCPHTTPResponseOrder()
+        let first = gate.reserve()
+        let second = gate.reserve()
+        let events = EventLog()
+
+        let secondTask = Task {
+            await gate.waitTurn(second)
+            await events.append("second")
+            gate.finish(second)
+        }
+        try? await Task.sleep(for: .milliseconds(10))
+        let eventsBeforeFirst = await events.events
+        XCTAssertEqual(eventsBeforeFirst, [])
+
+        let firstTask = Task {
+            await gate.waitTurn(first)
+            await events.append("first")
+            gate.finish(first)
+        }
+        _ = await firstTask.value
+        _ = await secondTask.value
+        let finalEvents = await events.events
+        XCTAssertEqual(finalEvents, ["first", "second"])
+    }
+
+    func testHandlerLifecycleRetiresCompletedTaskAndSession() {
+        let lifecycle = MCPHTTPHandlerLifecycle()
+        let taskID = UUID()
+        lifecycle.begin(taskID: taskID, sessionID: "completed")
+
+        lifecycle.finish(taskID: taskID)
+
+        XCTAssertTrue(lifecycle.activeTaskIDs.isEmpty)
+        XCTAssertTrue(lifecycle.activeSessionIDs.isEmpty)
+    }
+
+    func testHandlerLifecycleKeepsSSESessionWhenPOSTRequestFinishes() {
+        let lifecycle = MCPHTTPHandlerLifecycle()
+        let sseTaskID = UUID()
+        let postTaskID = UUID()
+        lifecycle.begin(taskID: sseTaskID, sessionID: "stream")
+        lifecycle.markSSEActive(SSEStreamOwnership(sessionID: "stream", token: UUID()))
+        lifecycle.begin(taskID: postTaskID, sessionID: "stream")
+
+        lifecycle.finish(taskID: postTaskID)
+
+        XCTAssertEqual(lifecycle.activeSessionIDs, ["stream"])
+        XCTAssertEqual(lifecycle.activeTaskIDs, [sseTaskID])
+        XCTAssertTrue(lifecycle.activeSSESessionIDs.contains("stream"))
+    }
+
+    func testHandlerLifecycleChannelCloseReturnsAllSSESessions() {
+        let lifecycle = MCPHTTPHandlerLifecycle()
+        let taskID = UUID()
+        lifecycle.begin(taskID: taskID, sessionID: "stream")
+        lifecycle.markSSEActive(SSEStreamOwnership(sessionID: "stream", token: UUID()))
+
+        let cleaned = lifecycle.cancelAll()
+
+        XCTAssertEqual(cleaned, ["stream"])
+        XCTAssertTrue(lifecycle.activeTaskIDs.isEmpty)
+        XCTAssertTrue(lifecycle.activeSessionIDs.isEmpty)
+        XCTAssertTrue(lifecycle.activeSSESessionIDs.isEmpty)
+    }
+
+    func testCancelledRequestCleansSSEAfterActorRequestReturns() async {
+        let log = EventLog()
+        await log.append("request-started")
+        await log.append("continuation-registered")
+        await log.append("request-returned")
+
+        await MCPHTTPHandler.cleanupCancelledRequestIfNeeded(sseOwnership: SSEStreamOwnership(sessionID: "stream", token: UUID()), isCancelled: true) { ownership in
+            await log.append("cleanup \(ownership.sessionID)")
+        }
+
+        let actualEvents = await log.events
+        XCTAssertEqual(actualEvents, ["request-started", "continuation-registered", "request-returned", "cleanup stream"])
+    }
+
+    func testCompletedPOSTDoesNotCleanSSE() async {
+        let counter = CallCounter()
+
+        await MCPHTTPHandler.cleanupCancelledRequestIfNeeded(sseOwnership: nil, isCancelled: false) { _ in
+            await counter.increment()
+        }
+
+        let finalCount = await counter.count
+        XCTAssertEqual(finalCount, 0)
+    }
+
+    func testMCPPathUsesRequestPathNotAbsoluteEndpointURL() async {
+        let response = await MCPServer().handleHTTPRequest(HTTPRequest(method: "POST", uri: "/mcp", headers: jsonHeaders, body: initialize))
+        XCTAssertEqual(response.statusCode, 200)
+    }
+
+    func testProtocolErrorsAreJSONRPCAnd405AdvertisesAllow() async throws {
+        let unsupported = await MCPServer().handleHTTPRequest(HTTPRequest(method: "PUT", headers: jsonHeaders))
+        XCTAssertEqual(unsupported.statusCode, 405)
+        XCTAssertEqual(unsupported.header("Allow"), "GET, POST, DELETE")
+        XCTAssertEqual(unsupported.header("Content-Type"), "application/json; charset=utf-8")
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: try XCTUnwrap(unsupported.bodyData)) as? [String: Any])
+        XCTAssertEqual(object["error"] as? [String: Any] != nil, true)
+    }
+
+    func testNotificationIsBasedOnMissingIDNotMethodPrefix() async throws {
+        let server = MCPServer()
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let headers = jsonHeaders.merging(["Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]) { _, new in new }
+        let request = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"notifications/custom\",\"params\":{}}".utf8)
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertTrue(response.bodyString?.contains("\"id\":2") == true)
+        let notification = Data("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/custom\"}".utf8)
+        let notificationResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: notification))
+        XCTAssertEqual(notificationResponse.statusCode, 202)
+        XCTAssertNil(notificationResponse.bodyData)
+    }
+
+    func testNonInitializeRequiresSupportedProtocolVersion() async throws {
+        let server = MCPServer()
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let body = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}".utf8)
+        let base = jsonHeaders.merging(["Mcp-Session-Id": session]) { _, new in new }
+        let baseResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: base, body: body))
+        XCTAssertEqual(baseResponse.statusCode, 400)
+        let supported = base.merging(["MCP-Protocol-Version": "2025-06-18"]) { _, new in new }
+        let supportedResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: supported, body: body))
+        XCTAssertEqual(supportedResponse.statusCode, 200)
+    }
+
+    func testWildcardAcceptIsAccepted() async {
+        let response = await MCPServer().handleHTTPRequest(HTTPRequest(method: "POST", headers: ["Host": "127.0.0.1", "Content-Type": "application/json", "Accept": "*/*"], body: initialize))
+        XCTAssertEqual(response.statusCode, 200)
+    }
+
+    func testDuplicateHeadersCombineCaseInsensitively() {
+        var headers = HTTPHeaders()
+        headers.add(name: "Accept", value: "application/json")
+        headers.add(name: "accept", value: "text/event-stream")
+        headers.add(name: "Content-Type", value: "application/json")
+        headers.add(name: "content-type", value: "application/json; charset=utf-8")
+
+        let normalized = MCPHTTPHandler.normalizedHeaders(from: headers)
+
+        XCTAssertEqual(normalized["Accept"], "application/json, text/event-stream")
+        XCTAssertEqual(normalized["Content-Type"], "application/json, application/json; charset=utf-8")
+    }
+
+    func testNormalDispatchCancelsAndReleasesTimeoutSleeper() async {
+        let result = await DispatchTimeoutRace.run(timeout: .seconds(1), timeoutValue: "timeout") {
+            for _ in 0..<100 where MCPServer.testActiveTimeoutSleeperCount == 0 {
+                await Task.yield()
+            }
+            return "done"
+        }
+
+        XCTAssertEqual(result, "done")
+        for _ in 0..<100 where MCPServer.testActiveTimeoutSleeperCount != 0 {
+            await Task.yield()
+        }
+        XCTAssertEqual(MCPServer.testActiveTimeoutSleeperCount, 0)
+    }
+
+    func testToolDispatchTimeoutReturnsError() async throws {
+        let server = MCPServer(toolRegistry: HangingMCPToolRegistry(), dispatchTimeout: .milliseconds(10))
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let request = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"homekit_status\"}}".utf8)
+        let headers = jsonHeaders.merging(["Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]) { _, new in new }
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+        XCTAssertTrue(response.bodyString?.contains("timed out") == true)
+    }
+
+    func testToolDispatchTimeoutIsBoundedWhenRegistryIgnoresCancellation() async throws {
+        let server = MCPServer(toolRegistry: IgnoringCancellationMCPToolRegistry(), dispatchTimeout: .milliseconds(10))
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let request = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"homekit_status\"}}".utf8)
+        let headers = jsonHeaders.merging(["Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]) { _, new in new }
+        let clock = ContinuousClock()
+        let start = clock.now
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+        let elapsed = start.duration(to: clock.now)
+        XCTAssertTrue(response.bodyString?.contains("Tool dispatch timed out") == true)
+        XCTAssertLessThan(elapsed, .milliseconds(500))
+    }
+
+    func testNativeToolRejectsFractionalAndOutOfRangeIntegers() async throws {
+        let fractional = try JSONSerialization.data(withJSONObject: ["limit": 1.5])
+        let outOfRange = try JSONSerialization.data(withJSONObject: ["duration_seconds": 86401])
+        let fractionalResult = String(decoding: await ToolHandlers.call(name: "homekit_events", arguments: fractional), as: UTF8.self)
+        XCTAssertTrue(fractionalResult.contains("Invalid arguments"))
+        let outOfRangeResult = String(decoding: await ToolHandlers.call(name: "homekit_events", arguments: outOfRange), as: UTF8.self)
+        XCTAssertTrue(outOfRangeResult.contains("Invalid arguments"))
+    }
+    func testToolsListUsesRegisteredHomeClawTools() async throws {
+        let server = MCPServer()
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let request = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}".utf8)
+        let headers = jsonHeaders.merging(["Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]) { _, new in new }
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+        XCTAssertTrue(response.bodyString?.contains("homekit_status") == true)
+    }
+
+    func testReadOnlyHomeKitToolDispatchesThroughRegistry() async throws {
+        let registry = HomeClawMCPToolRegistry.test(status: "registered")
+        let server = MCPServer(toolRegistry: registry)
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let request = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"homekit_status\",\"arguments\":{}}}".utf8)
+        let headers = jsonHeaders.merging(["Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]) { _, new in new }
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertTrue(response.bodyString?.contains("registered") == true)
+    }
+
+    func testGetReturnsLiveRequestScopedSSEStreamUntilCancelled() async throws {
+        let server = MCPServer()
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let headers = ["Accept": "text/event-stream", "Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: headers))
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertNotNil(response.stream)
+        var iterator = response.stream!.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(String(data: try XCTUnwrap(first), encoding: .utf8), ": connected\n\n")
+        let pending = Task { await iterator.next() }
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertFalse(pending.isCancelled)
+        pending.cancel()
+    }
+
+    func testReplacementSSEStreamFinishesPreviousContinuation() async throws {
+        let server = MCPServer()
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let headers = ["Accept": "text/event-stream", "Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]
+
+        let first = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: headers))
+        var firstIterator = try XCTUnwrap(first.stream).makeAsyncIterator()
+        _ = await firstIterator.next()
+        let second = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: headers))
+        XCTAssertNotNil(second.stream)
+
+        let replaced = await firstIterator.next()
+        XCTAssertNil(replaced)
+    }
+
+    func testOldSSECompletionCannotRetireReplacementStream() async throws {
+        let server = MCPServer()
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let headers = ["Accept": "text/event-stream", "Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]
+        let first = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: headers))
+        let second = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: headers))
+        let firstOwnership = try XCTUnwrap(first.sseOwnership)
+        let secondOwnership = try XCTUnwrap(second.sseOwnership)
+        XCTAssertNotEqual(firstOwnership, secondOwnership)
+
+        let lifecycle = MCPHTTPHandlerLifecycle()
+        let firstTask = UUID()
+        let secondTask = UUID()
+        lifecycle.begin(taskID: firstTask, sessionID: session)
+        lifecycle.markSSEActive(firstOwnership)
+        lifecycle.begin(taskID: secondTask, sessionID: session)
+        lifecycle.markSSEActive(secondOwnership)
+
+        lifecycle.finishSSE(firstOwnership)
+        lifecycle.finish(taskID: firstTask)
+
+        XCTAssertEqual(lifecycle.activeSessionIDs, [session])
+        XCTAssertTrue(lifecycle.activeSSESessionIDs.contains(session))
+        XCTAssertTrue(lifecycle.activeSSEOwnerships.contains(secondOwnership))
+
+        lifecycle.finishSSE(secondOwnership)
+        lifecycle.finish(taskID: secondTask)
+        XCTAssertTrue(lifecycle.activeSessionIDs.isEmpty)
+    }
+
+    func testExplicitSSECleanupFinishesContinuation() async throws {
+        let server = MCPServer()
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: ["Accept": "text/event-stream", "Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]))
+        var iterator = try XCTUnwrap(response.stream).makeAsyncIterator()
+        _ = await iterator.next()
+
+        await server.cleanupSSE(for: session)
+
+        let cleaned = await iterator.next()
+        XCTAssertNil(cleaned)
+    }
+
+    func testToolHandlerErrorsBecomeMCPToolErrors() async throws {
+        let registry = ErrorMCPToolRegistry()
+        let server = MCPServer(toolRegistry: registry)
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let request = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"homekit_status\",\"arguments\":{}}}".utf8)
+        let headers = jsonHeaders.merging(["Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]) { _, new in new }
+
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: try XCTUnwrap(response.bodyData)) as? [String: Any])
+        let result = try XCTUnwrap(object["result"] as? [String: Any])
+        XCTAssertEqual(result["isError"] as? Bool, true)
+        XCTAssertNil(object["error"])
+    }
+
+    func testToolCallRejectsReadOnlyNameNotAdvertisedByRegistry() async throws {
+        let server = MCPServer(toolRegistry: ErrorMCPToolRegistry())
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let request = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"homekit_accessories\",\"arguments\":{\"action\":\"list\"}}}".utf8)
+        let headers = jsonHeaders.merging(["Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]) { _, new in new }
+
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: headers, body: request))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: try XCTUnwrap(response.bodyData)) as? [String: Any])
+        XCTAssertEqual((object["error"] as? [String: Any])?["code"] as? Int, -32602)
+    }
+
+    func testPeriodicExpiryCleanupFinishesIdleSSEStream() async throws {
+        let store = StreamableHTTPSessionStore(ttl: 1)
+        let server = MCPServer(configuration: HTTPMCPConfiguration(sessionTTL: 1), sessionStore: store)
+        await server.startExpiryCleanup()
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: ["Accept": "text/event-stream", "Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]))
+        var iterator = try XCTUnwrap(response.stream).makeAsyncIterator()
+        _ = await iterator.next()
+
+        try await Task.sleep(for: .milliseconds(1_100))
+
+        let cleaned = await iterator.next()
+        XCTAssertNil(cleaned)
+        await server.stop()
+    }
+
+    func testSessionExpiryFinishesSSEContinuation() async throws {
+        let server = MCPServer(sessionStore: StreamableHTTPSessionStore(ttl: 60))
+        let initResponse = await server.handleHTTPRequest(HTTPRequest(method: "POST", headers: jsonHeaders, body: initialize))
+        let session = try XCTUnwrap(initResponse.header("Mcp-Session-Id"))
+        let response = await server.handleHTTPRequest(HTTPRequest(method: "GET", headers: ["Accept": "text/event-stream", "Mcp-Session-Id": session, "MCP-Protocol-Version": MCPServer.supportedProtocolVersion]))
+        var iterator = try XCTUnwrap(response.stream).makeAsyncIterator()
+        _ = await iterator.next()
+
+        await server.cleanupExpiredSessions(now: Date().addingTimeInterval(61))
+
+        let cleaned = await iterator.next()
+        XCTAssertNil(cleaned)
+    }
+}

--- a/Tests/HomeClawTests/StreamableHTTPReviewRegressionTests.swift
+++ b/Tests/HomeClawTests/StreamableHTTPReviewRegressionTests.swift
@@ -98,15 +98,17 @@ final class StreamableHTTPReviewRegressionTests: XCTestCase {
         XCTAssertTrue(lifecycle.activeSSESessionIDs.contains("stream"))
     }
 
-    func testHandlerLifecycleChannelCloseReturnsAllSSESessions() {
+    func testHandlerLifecycleChannelCloseReturnsOnlyOwnedSSEStreams() {
         let lifecycle = MCPHTTPHandlerLifecycle()
         let taskID = UUID()
+        let ownership = SSEStreamOwnership(sessionID: "stream", token: UUID())
         lifecycle.begin(taskID: taskID, sessionID: "stream")
-        lifecycle.markSSEActive(SSEStreamOwnership(sessionID: "stream", token: UUID()))
+        lifecycle.markSSEActive(ownership)
+        lifecycle.begin(taskID: UUID(), sessionID: "borrowed-post-session")
 
         let cleaned = lifecycle.cancelAll()
 
-        XCTAssertEqual(cleaned, ["stream"])
+        XCTAssertEqual(cleaned, [ownership])
         XCTAssertTrue(lifecycle.activeTaskIDs.isEmpty)
         XCTAssertTrue(lifecycle.activeSessionIDs.isEmpty)
         XCTAssertTrue(lifecycle.activeSSESessionIDs.isEmpty)

--- a/Tests/HomeClawTests/StreamableHTTPSessionStoreTests.swift
+++ b/Tests/HomeClawTests/StreamableHTTPSessionStoreTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import HomeClaw
+
+final class StreamableHTTPSessionStoreTests: XCTestCase {
+    func testCreateGetTouchAndRemoveLifecycle() async throws {
+        let store = StreamableHTTPSessionStore(ttl: 60)
+        let raw = await store.create()
+        let id = try XCTUnwrap(raw)
+        XCTAssertFalse(id.isEmpty)
+        let found = await store.get(id); XCTAssertNotNil(found)
+        let touched = await store.touch(id); XCTAssertTrue(touched)
+        let removed = await store.remove(id); XCTAssertTrue(removed)
+        let gone = await store.get(id); XCTAssertNil(gone)
+        let removedAgain = await store.remove(id); XCTAssertFalse(removedAgain)
+    }
+
+    func testSessionsAreOpaqueAndIsolated() async throws {
+        let store = StreamableHTTPSessionStore()
+        let r1 = await store.create(); let first = try XCTUnwrap(r1)
+        let r2 = await store.create(); let second = try XCTUnwrap(r2)
+        XCTAssertNotEqual(first, second)
+        let found = await store.get(first); XCTAssertNotNil(found)
+        let unknown = await store.get("not-a-session"); XCTAssertNil(unknown)
+    }
+
+    func testCleanupRemovesExpiredSessions() async {
+        let store = StreamableHTTPSessionStore(ttl: 0)
+        _ = await store.create()
+        let removed = await store.removeExpired(now: Date().addingTimeInterval(1))
+        XCTAssertEqual(removed, 1)
+        let count = await store.count; XCTAssertEqual(count, 0)
+    }
+
+    func testCreateEnforcesCap() async {
+        let store = StreamableHTTPSessionStore(ttl: 60, maxSessions: 1)
+        let first = await store.create(); XCTAssertNotNil(first)
+        let second = await store.create(); XCTAssertNil(second)
+        let cnt = await store.count; XCTAssertEqual(cnt, 1)
+    }
+}

--- a/Tests/HomeClawTests/StreamableHTTPTransportTests.swift
+++ b/Tests/HomeClawTests/StreamableHTTPTransportTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import HomeClaw
+
+final class StreamableHTTPTransportTests: XCTestCase {
+    private let json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}"
+    private let protocolVersion = MCPServer.supportedProtocolVersion
+    private var headers: [String: String] { ["Content-Type": "application/json", "Accept": "application/json"] }
+    private func send(_ server: MCPServer, _ request: HTTPRequest) async -> HTTPResponse { await server.handleHTTPRequest(request) }
+    private func sessionHeaders(for id: String, accept: String = "application/json") -> [String: String] {
+        ["Content-Type": "application/json", "Accept": accept, "Mcp-Session-Id": id, "MCP-Protocol-Version": protocolVersion]
+    }
+
+    func testInitializeCreatesSessionAndReturnsSessionHeader() async {
+        let response = await send(MCPServer(homeKitReady: false), HTTPRequest(method: "POST", headers: headers, body: Data(json.utf8)))
+        XCTAssertEqual(response.statusCode, 200); XCTAssertNotNil(response.header("Mcp-Session-Id")); XCTAssertTrue(response.bodyString?.contains("protocolVersion") == true)
+    }
+
+    func testEmptyAndMalformedContentTypesAreRejectedWithoutAllocatingSessions() async {
+        let server = MCPServer(homeKitReady: false)
+        let invalidTypes: [String?] = [nil, "", " ", ";", ";application/json", "; charset=utf-8", "text/plain"]
+        for contentType in invalidTypes {
+            var requestHeaders = headers
+            requestHeaders["Content-Type"] = contentType
+            let response = await send(server, HTTPRequest(method: "POST", headers: requestHeaders, body: Data(json.utf8)))
+            XCTAssertEqual(response.statusCode, 415, "Content-Type: \(String(describing: contentType))")
+            XCTAssertNil(response.header("Mcp-Session-Id"))
+        }
+        let count = await server.sessionStore.count
+        XCTAssertEqual(count, 0)
+    }
+
+    func testJSONContentTypeAllowsCaseAndParameters() async {
+        for contentType in ["Application/JSON", " application/json ; charset=utf-8"] {
+            let response = await send(MCPServer(homeKitReady: false), HTTPRequest(method: "POST", headers: ["Content-Type": contentType, "Accept": "application/json"], body: Data(json.utf8)))
+            XCTAssertEqual(response.statusCode, 200)
+        }
+    }
+
+    func testInvalidInitializeDoesNotAllocateSession() async throws {
+        let server = MCPServer()
+        let badJSON = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}"
+        let bad = await send(server, HTTPRequest(method: "POST", headers: headers, body: Data(badJSON.utf8)))
+        XCTAssertEqual(bad.statusCode, 400); XCTAssertNil(bad.header("Mcp-Session-Id"))
+        let c0 = await server.sessionStore.count; XCTAssertEqual(c0, 0)
+        // initialize notification with invalid params: still 202, no allocation (notifications never create)
+        let notifBad = "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"params\":{}}"
+        let notif = await send(server, HTTPRequest(method: "POST", headers: headers, body: Data(notifBad.utf8)))
+        XCTAssertEqual(notif.statusCode, 202)
+        let c1 = await server.sessionStore.count; XCTAssertEqual(c1, 0)
+    }
+
+    func testSessionCapReturns429() async throws {
+        let store = StreamableHTTPSessionStore(ttl: 3600, maxSessions: 1)
+        let server = MCPServer(sessionStore: store)
+        let first = await send(server, HTTPRequest(method: "POST", headers: headers, body: Data(json.utf8)))
+        XCTAssertEqual(first.statusCode, 200)
+        let second = await send(server, HTTPRequest(method: "POST", headers: headers, body: Data(json.utf8)))
+        XCTAssertEqual(second.statusCode, 429)
+        let cnt = await store.count; XCTAssertEqual(cnt, 1)
+    }
+
+    func testRequestsRequireTheirOwnValidSession() async {
+            let server = MCPServer(); let initialize = await send(server, HTTPRequest(method: "POST", headers: headers, body: Data(json.utf8)))
+            let id = initialize.header("Mcp-Session-Id")!
+            let list = Data("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}".utf8)
+            let missing = await send(server, HTTPRequest(method: "POST", headers: headers, body: list)); XCTAssertEqual(missing.statusCode, 400)
+            let validHeaders = sessionHeaders(for: id)
+            let valid = await send(server, HTTPRequest(method: "POST", headers: validHeaders, body: list)); XCTAssertEqual(valid.statusCode, 200)
+            let unknownHeaders = sessionHeaders(for: "unknown")
+            let unknown = await send(server, HTTPRequest(method: "POST", headers: unknownHeaders, body: list)); XCTAssertEqual(unknown.statusCode, 404)
+        }
+
+    func testNotificationIsAcceptedAndGetAndDeleteAreSessionScoped() async throws {
+            let server = MCPServer(); let initialize = await send(server, HTTPRequest(method: "POST", headers: headers, body: Data(json.utf8)))
+            let id = try XCTUnwrap(initialize.header("Mcp-Session-Id"))
+            let sessionHeadersJSON = self.sessionHeaders(for: id, accept: "application/json")
+            let sessionHeadersSSE = self.sessionHeaders(for: id, accept: "text/event-stream")
+            let notification = Data("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}".utf8)
+            let accepted = await send(server, HTTPRequest(method: "POST", headers: sessionHeadersJSON, body: notification)); XCTAssertEqual(accepted.statusCode, 202); XCTAssertNil(accepted.bodyData)
+            let sse = await send(server, HTTPRequest(method: "GET", headers: sessionHeadersSSE)); XCTAssertEqual(sse.statusCode, 200); XCTAssertEqual(sse.header("Content-Type"), "text/event-stream"); XCTAssertNotNil(sse.stream)
+            // initial SSE chunk is delivered via stream, not bodyData
+            if let stream = sse.stream {
+                var it = stream.makeAsyncIterator(); let first = await it.next()
+                XCTAssertEqual(first, Data(": connected\n\n".utf8))
+            }
+            let deleted = await send(server, HTTPRequest(method: "DELETE", headers: sessionHeadersSSE)); XCTAssertEqual(deleted.statusCode, 200)
+            let gone = await send(server, HTTPRequest(method: "GET", headers: sessionHeadersSSE)); XCTAssertEqual(gone.statusCode, 404)
+        }
+
+    func testMixedCaseAcceptMediaTypeIsAccepted() async {
+        let response = await send(MCPServer(homeKitReady: false), HTTPRequest(method: "POST", headers: ["Content-Type": "application/json", "Accept": "Application/JSON"], body: Data(json.utf8)))
+        XCTAssertEqual(response.statusCode, 200)
+    }
+
+    func testZeroQualityAcceptMediaTypeIsRejected() async {
+        let response = await send(MCPServer(homeKitReady: false), HTTPRequest(method: "POST", headers: ["Content-Type": "application/json", "Accept": "Application/JSON; Q=0; charset=utf-8"], body: Data(json.utf8)))
+        XCTAssertEqual(response.statusCode, 406)
+    }
+
+    func testPostRejectsEventStreamOnlyAccept() async {
+        let response = await send(MCPServer(homeKitReady: false), HTTPRequest(method: "POST", headers: ["Content-Type": "application/json", "Accept": "text/event-stream"], body: Data(json.utf8)))
+        XCTAssertEqual(response.statusCode, 406)
+    }
+
+    func testPostAcceptsMixedMediaTypesWhenJSONIsAcceptable() async {
+        let response = await send(MCPServer(homeKitReady: false), HTTPRequest(method: "POST", headers: ["Content-Type": "application/json", "Accept": "text/event-stream; q=1, application/json; q=0.5"], body: Data(json.utf8)))
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual(response.header("Content-Type"), "application/json; charset=utf-8")
+    }
+
+    func testRejectsProtocolAndMediaErrorsBeforeExecution() async {
+        let server = MCPServer()
+        let badType = ["Content-Type": "text/plain", "Accept": "application/json"]; let typeResponse = await send(server, HTTPRequest(method: "POST", headers: badType, body: Data(json.utf8))); XCTAssertEqual(typeResponse.statusCode, 415)
+        let badAccept = ["Content-Type": "application/json", "Accept": "text/plain"]; let acceptResponse = await send(server, HTTPRequest(method: "POST", headers: badAccept, body: Data(json.utf8))); XCTAssertEqual(acceptResponse.statusCode, 406)
+        let malformed = await send(server, HTTPRequest(method: "POST", headers: headers, body: Data("{bad".utf8))); XCTAssertEqual(malformed.statusCode, 400)
+        let method = await send(server, HTTPRequest(method: "PUT", headers: headers)); XCTAssertEqual(method.statusCode, 405)
+        let path = await send(server, HTTPRequest(method: "POST", uri: "/wrong", headers: headers, body: Data(json.utf8))); XCTAssertEqual(path.statusCode, 404)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -241,6 +241,8 @@ targets:
       - path: Tests/HomeClawTests
     dependencies:
       - target: HomeClaw
+      - package: swift-nio
+        product: NIOEmbedded
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.shahine.homeclaw.tests

--- a/project.yml
+++ b/project.yml
@@ -3,6 +3,7 @@ options:
   bundleIdPrefix: com.shahine
   deploymentTarget:
     iOS: "18.0"
+    macOS: "26.0"
   xcodeVersion: "26.0"
   generateEmptyDirectories: true
   groupSortPosition: top
@@ -22,6 +23,9 @@ packages:
   SwiftTUI:
     url: https://github.com/rensbreur/SwiftTUI.git
     branch: main
+  swift-nio:
+    url: https://github.com/apple/swift-nio.git
+    exactVersion: "2.99.0"
 
 targets:
   # ─── Unified Catalyst App ─────────────────────────────────
@@ -46,6 +50,7 @@ targets:
         PRODUCT_NAME: HomeClaw
         TARGETED_DEVICE_FAMILY: "6"
         SUPPORTS_MACCATALYST: YES
+        MACOSX_DEPLOYMENT_TARGET: "26.0"
         DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER: NO
         INFOPLIST_FILE: Resources/Info.plist
         CODE_SIGN_ENTITLEMENTS: Resources/HomeClaw.entitlements
@@ -73,6 +78,12 @@ targets:
       - target: homeclaw-cli
         embed: false
       - sdk: HomeKit.framework
+      - package: swift-nio
+        product: NIOCore
+      - package: swift-nio
+        product: NIOHTTP1
+      - package: swift-nio
+        product: NIOPosix
     preBuildScripts:
       - name: "Increment Build Number (Archive Only)"
         script: |
@@ -215,6 +226,29 @@ targets:
         TEST_TARGET_NAME: HomeClaw
         TARGETED_DEVICE_FAMILY: "6"
         SUPPORTS_MACCATALYST: YES
+        MACOSX_DEPLOYMENT_TARGET: "26.0"
+        DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER: NO
+        GENERATE_INFOPLIST_FILE: YES
+        ENABLE_USER_SCRIPT_SANDBOXING: NO
+
+  # ─── Unit Tests ────────────────────────────────────────────
+  HomeClawTests:
+    type: bundle.unit-test
+    platform: iOS
+    attributes:
+      UIKitCatalyst: optimized
+    sources:
+      - path: Tests/HomeClawTests
+    dependencies:
+      - target: HomeClaw
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.shahine.homeclaw.tests
+        PRODUCT_NAME: HomeClawTests
+        TEST_TARGET_NAME: HomeClaw
+        TARGETED_DEVICE_FAMILY: "6"
+        SUPPORTS_MACCATALYST: YES
+        MACOSX_DEPLOYMENT_TARGET: "26.0"
         DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER: NO
         GENERATE_INFOPLIST_FILE: YES
         ENABLE_USER_SCRIPT_SANDBOXING: NO
@@ -260,6 +294,10 @@ schemes:
         HomeClaw: all
         macOSBridge: all
         homeclaw-cli: all
+    test:
+      config: Debug
+      targets:
+        - HomeClawTests
     run:
       config: Debug
       executable: HomeClaw
@@ -267,6 +305,16 @@ schemes:
       config: Release
     profile:
       config: Release
+
+  HomeClawTests:
+    build:
+      targets:
+        HomeClaw: all
+        HomeClawTests: [test]
+    test:
+      config: Debug
+      targets:
+        - HomeClawTests
 
   HomeClawUITests:
     build:

--- a/scripts/check-mcp-schema-parity.mjs
+++ b/scripts/check-mcp-schema-parity.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// lib/schemas.js is authoritative. Run this check in CI; regenerate reviewed
+// Swift JSON + XCTest fixture with: node scripts/check-mcp-schema-parity.mjs --write
+import assert from 'node:assert/strict';
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+export const swiftPath = resolve(root, 'Sources/homeclaw/MCP/ToolHandlers.swift');
+export const fixturePath = resolve(root, 'Tests/HomeClawTests/Fixtures/mcp-tools.json');
+const schemaPath = resolve(root, 'lib/schemas.js');
+const literalPattern = /static let allToolsJSON: Data = Data\(#"""\n([\s\S]*?)\n    """#\.utf8\)/;
+
+export async function checkParity(nodeSchemaPath = schemaPath) {
+  const { tools } = await import(pathToFileURL(nodeSchemaPath).href);
+  const source = await readFile(swiftPath, 'utf8');
+  const literal = source.match(literalPattern);
+  assert.ok(literal, 'ToolHandlers must embed readable raw JSON, not an opaque blob');
+  assert.deepStrictEqual(JSON.parse(literal[1]), tools, 'Swift descriptors drifted from lib/schemas.js');
+  assert.deepStrictEqual(JSON.parse(await readFile(fixturePath, 'utf8')), tools,
+    'XCTest fixture drifted from lib/schemas.js');
+  assert.equal(new Set(tools.map(tool => tool.name)).size, tools.length, 'Duplicate tool names');
+  return tools.length;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    if (process.argv.includes('--write')) {
+      const { tools } = await import(pathToFileURL(schemaPath).href);
+      const json = JSON.stringify(tools, null, 2);
+      assert.ok(!json.includes('"""#') && !json.includes('\\#'), 'Unsafe Swift raw-string delimiter');
+      const source = await readFile(swiftPath, 'utf8');
+      assert.ok(literalPattern.test(source), 'Readable Swift literal not found');
+      await writeFile(swiftPath, source.replace(literalPattern, () =>
+        `static let allToolsJSON: Data = Data(#"""\n${json.split('\n').map(line => `    ${line}`).join('\n')}\n    """#.utf8)`));
+      await writeFile(fixturePath, `${json}\n`);
+    }
+    console.log(`MCP schema parity OK: ${await checkParity()} complete Node/Swift/fixture descriptors`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-mcp-schema-parity.test.mjs
+++ b/scripts/check-mcp-schema-parity.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { checkParity } from './check-mcp-schema-parity.mjs';
+
+const schemaURL = new URL('../lib/schemas.js', import.meta.url);
+
+test('complete canonical descriptors match the actual Node export', async () => {
+  assert.ok(await checkParity() > 0);
+});
+
+// Mutate real schema source in temporary ESM modules: never change the checkout
+// or start a Node server/CLI/HomeKit connection. Names alone remain unchanged.
+for (const [label, mutation] of [
+  ['description', "tools[0].description += ' changed';"],
+  ['nested property type', "tools[1].inputSchema.properties.service_index.type = 'string';"],
+  ['action enum', "tools[1].inputSchema.properties.action.enum.push('future_action');"],
+  ['required fields', "tools[1].inputSchema.required = ['accessory_id'];"],
+  ['new descriptor field', "tools[0].annotations = { readOnlyHint: true };"],
+  ['removed tool', 'tools.pop();'],
+]) {
+  test(`rejects Node schema drift: ${label}`, async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'homeclaw-schema-'));
+    try {
+      const path = join(directory, 'schemas.mjs');
+      await writeFile(path, `${await readFile(schemaURL, 'utf8')}\n${mutation}\n`);
+      await assert.rejects(checkParity(path), /Swift descriptors drifted/);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+test('parity tests never invoke the live HomeKit dispatcher', async () => {
+  const source = await readFile(new URL('../Tests/HomeClawTests/MCPTransportParityTests.swift', import.meta.url), 'utf8');
+  assert.doesNotMatch(source, /ToolHandlers\.call\s*\(/,
+    'Parity tests must use a recording registry, not live HomeKit operations');
+  assert.doesNotMatch(source, /MCPServer\(\)/,
+    'Parity transports must receive an explicit non-actuating registry');
+});

--- a/scripts/test-catalyst.sh
+++ b/scripts/test-catalyst.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Run the entire app-hosted unit suite, never the SPM CLI suite or a test slice.
+# Generate HomeClaw.xcodeproj and install npm dependencies before invoking this.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+EVIDENCE_DIR="${CATALYST_EVIDENCE_DIR:-$PWD/.build/catalyst-test-evidence}"
+mkdir -p "$EVIDENCE_DIR"
+EVIDENCE_DIR="$(cd "$EVIDENCE_DIR" && pwd)"
+RESULT="$EVIDENCE_DIR/HomeClawTests.xcresult"
+# Refuse stale evidence rather than accidentally reporting an earlier run.
+if [[ -e "$RESULT" ]]; then
+  printf 'Result bundle already exists: %s; use a fresh CATALYST_EVIDENCE_DIR\n' "$RESULT" >&2
+  exit 2
+fi
+
+# Serial execution keeps process-global diagnostics and loopback ports isolated.
+# XCTest's timeouts make a hung test fail rather than silently excluding it.
+set +e
+xcodebuild test \
+  -project HomeClaw.xcodeproj \
+  -scheme HomeClawTests \
+  -configuration Debug \
+  -destination 'platform=macOS,variant=Mac Catalyst' \
+  -derivedDataPath "$EVIDENCE_DIR/DerivedData" \
+  -resultBundlePath "$RESULT" \
+  -parallel-testing-enabled NO \
+  -test-timeouts-enabled YES \
+  -default-test-execution-time-allowance 30 \
+  -maximum-test-execution-time-allowance 60 \
+  CODE_SIGNING_ALLOWED=NO \
+  2>&1 | tee "$EVIDENCE_DIR/xcodebuild.log"
+statuses=("${PIPESTATUS[@]}")
+set -e
+printf '%s\n' "${statuses[0]}" > "$EVIDENCE_DIR/xcodebuild-exit-status.txt"
+
+# Try to extract evidence even after failed tests; never mask xcodebuild's exit.
+set +e
+xcrun xcresulttool get test-results summary --path "$RESULT" > "$EVIDENCE_DIR/summary.json"
+summary_status=$?
+xcrun xcresulttool get test-results tests --path "$RESULT" > "$EVIDENCE_DIR/tests.json"
+tests_status=$?
+set -e
+if [[ "${statuses[0]}" -ne 0 ]]; then exit "${statuses[0]}"; fi
+if [[ "${statuses[1]}" -ne 0 ]]; then exit "${statuses[1]}"; fi
+if [[ "$summary_status" -ne 0 ]]; then exit "$summary_status"; fi
+if [[ "$tests_status" -ne 0 ]]; then exit "$tests_status"; fi
+python3 scripts/verify-catalyst-results.py "$EVIDENCE_DIR/summary.json" "$EVIDENCE_DIR/tests.json"

--- a/scripts/test-ci-evidence.py
+++ b/scripts/test-ci-evidence.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""CI harness regression tests using explicit fixtures, not Catalyst coverage."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPTS = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("evidence", SCRIPTS / "verify-catalyst-results.py")
+assert spec is not None and spec.loader is not None
+evidence = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(evidence)
+
+
+def passing_fixture():
+    return ({"result": "Passed", "totalTestCount": 1, "passedTests": 1,
+             "failedTests": 0, "skippedTests": 0, "expectedFailures": 0},
+            {"testNodes": [{"nodeType": "Unit test bundle", "name": "HomeClawTests",
+                            "children": [{"nodeType": "Test Case", "name": "testFixture",
+                                          "result": "Passed"}]}]})
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_passed_fixture(self):
+        self.assertIn("1 passed", evidence.verify(*passing_fixture()))
+
+    def test_rejects_incomplete_or_skipped_summary(self):
+        for key, value in (("totalTestCount", 0), ("passedTests", 0), ("failedTests", 1),
+                           ("skippedTests", 1), ("expectedFailures", 1),
+                           ("result", "Failed"), ("passedTests", True)):
+            with self.subTest(key=key):
+                summary, tests = passing_fixture()
+                summary[key] = value
+                with self.assertRaises(ValueError):
+                    evidence.verify(summary, tests)
+
+    def test_rejects_wrong_bundle_or_missing_cases(self):
+        summary, tests = passing_fixture()
+        tests["testNodes"][0]["name"] = "homeclaw-cliTests"
+        with self.assertRaises(ValueError):
+            evidence.verify(summary, tests)
+        summary, tests = passing_fixture()
+        tests["testNodes"][0]["children"] = []
+        with self.assertRaises(ValueError):
+            evidence.verify(summary, tests)
+
+    def test_runner_status_propagation_with_stub_commands(self):
+        # PATH points at fixtures; this never launches Xcode or compiles the app.
+        for build_status, extract_status, expected in ((0, 0, 0), (65, 0, 65), (65, 9, 65), (0, 9, 9)):
+            with self.subTest(build=build_status, extract=extract_status), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                (root / "scripts").mkdir()
+                (root / "bin").mkdir()
+                for name in ("test-catalyst.sh", "verify-catalyst-results.py"):
+                    shutil.copy(SCRIPTS / name, root / "scripts" / name)
+                summary, tests = passing_fixture()
+                (root / "summary.json").write_text(json.dumps(summary))
+                (root / "tests.json").write_text(json.dumps(tests))
+                build = root / "bin/xcodebuild"
+                build.write_text('#!/bin/bash\nprintf "%s\\n" "$@" > args.txt\nprintf "stub xcodebuild\\n"\nexit "$STUB_BUILD_STATUS"\n')
+                extract = root / "bin/xcrun"
+                extract.write_text('#!/bin/bash\nif [[ "$STUB_EXTRACT_STATUS" != 0 ]]; then exit "$STUB_EXTRACT_STATUS"; fi\n/bin/cat "$4.json"\n')
+                build.chmod(0o755)
+                extract.chmod(0o755)
+                env = dict(os.environ, PATH=f'{root / "bin"}:{os.environ["PATH"]}',
+                           STUB_BUILD_STATUS=str(build_status), STUB_EXTRACT_STATUS=str(extract_status),
+                           CATALYST_EVIDENCE_DIR=str(root / "evidence"))
+                env.pop("GITHUB_STEP_SUMMARY", None)
+                result = subprocess.run(["bash", str(root / "scripts/test-catalyst.sh")],
+                                        env=env, capture_output=True, text=True)
+                self.assertEqual(result.returncode, expected, result.stdout + result.stderr)
+                args = (root / "args.txt").read_text()
+                self.assertTrue(args.startswith("test\n"))
+                self.assertNotIn("-only-testing", args)
+                self.assertNotIn("-skip-testing", args)
+                self.assertEqual((root / "evidence/xcodebuild-exit-status.txt").read_text().strip(), str(build_status))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-integration-settings.py
+++ b/scripts/test-integration-settings.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Source-wiring regression for the two compile-time Integrations variants.
+
+Behavior of the bound controller is exercised by HTTPIntegrationLifecycleTests.
+This guard catches a setting accidentally omitted from the APP_STORE branch.
+"""
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class IntegrationSettingsWiringTests(unittest.TestCase):
+    def test_development_and_app_store_include_shared_http_control(self):
+        development = (ROOT / 'Sources/homeclaw/Views/IntegrationsSettingsView.swift').read_text()
+        settings = (ROOT / 'Sources/homeclaw/Views/SettingsView.swift').read_text()
+        app_store = settings.split('private struct AppStoreIntegrationsView: View {', 1)[1]
+        self.assertTrue('NativeHTTPSettingsSection()' in development, 'Development Integrations must include the shared HTTP toggle')
+        self.assertTrue('NativeHTTPSettingsSection()' in app_store, 'App Store Integrations must include the shared HTTP toggle')
+        self.assertIn('struct NativeHTTPSettingsSection: View', development)
+        self.assertIn('httpIntegration.setEnabled($0)', development)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/verify-catalyst-results.py
+++ b/scripts/verify-catalyst-results.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Fail closed on empty, skipped, or incomplete app-hosted XCTest evidence."""
+import json
+import os
+from pathlib import Path
+import sys
+
+
+def verify(summary, tests):
+    counts = ("totalTestCount", "passedTests", "failedTests", "skippedTests", "expectedFailures")
+    if any(type(summary.get(key)) is not int or summary[key] < 0 for key in counts):
+        raise ValueError("Missing or invalid XCTest summary counts")
+    total = summary["totalTestCount"]
+    if (summary.get("result") != "Passed" or total <= 0
+            or summary["passedTests"] != total
+            or any(summary[key] != 0 for key in counts[2:])):
+        raise ValueError(f"All HomeClawTests must pass without skips: {summary}")
+
+    def walk(nodes):
+        for node in nodes:
+            yield node
+            yield from walk(node.get("children", []))
+
+    bundles = [node for node in walk(tests.get("testNodes", []))
+               if node.get("nodeType") == "Unit test bundle"]
+    if len(bundles) != 1 or bundles[0].get("name") not in ("HomeClawTests", "HomeClawTests.xctest"):
+        raise ValueError("Expected exactly the HomeClawTests unit test bundle")
+    cases = [node for node in walk(bundles[0].get("children", []))
+             if node.get("nodeType") == "Test Case"]
+    if len(cases) != total or any(case.get("result") != "Passed" for case in cases):
+        raise ValueError("Individual test results disagree with the passing summary")
+    return f"HomeClawTests (Mac Catalyst): {total} passed; 0 failed; 0 skipped."
+
+
+def main():
+    try:
+        with open(sys.argv[1]) as handle:
+            summary = json.load(handle)
+        with open(sys.argv[2]) as handle:
+            tests = json.load(handle)
+        message = verify(summary, tests)
+    except (ValueError, OSError, IndexError, TypeError, KeyError) as error:
+        print(f"Invalid Catalyst test evidence: {error}", file=sys.stderr)
+        return 1
+    print(message)
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as handle:
+            handle.write(f"### Catalyst unit tests\n\n{message}\n\n"
+                         "Full log, individual results, and xcresult bundle are attached as artifacts.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add default-off, native Streamable HTTP MCP to the Catalyst app at `http://127.0.0.1:9090/mcp`. Existing Node stdio and Unix-socket clients remain supported.

## Maintainer requests addressed

- Persistent on/off toggle in both development and App Store Integrations settings; serialized startup, disable, and shutdown.
- Removed unused MCP SDK; active transport uses SwiftNIO without dependency patches.
- Synchronous legacy-socket teardown before termination; explicit Quit awaits HTTP cleanup. AppKit system/Apple-event quit also performs synchronous socket cleanup. Final termination can only offer best-effort asynchronous HTTP cleanup.
- Full `HomeClawTests` execution in CI, macOS 26-compatible deployment targets, checked xcresult counts and uploaded evidence.
- Readable JSON descriptors compared against actual Node exports; inert registry tests avoid live HomeKit mutations.
- Archived prototype README corrected; obsolete token instructions removed.
- App identity, team, entitlements and provisioning unchanged. CLI tests are labeled compatibility coverage, not native transport verification.

Loopback Host/Origin checks and deny-by-default read-only enforcement remain intact. Sessions, request bodies and in-flight work are bounded. Full-suite testing and adversarial review also found and fixed FIFO waiter wakeup and empty Content-Type crash defects. The transport-aware dispatcher redesign remains deferred as requested.

## History and scope

Five commits: native implementation, tests/CI, documentation, system-quit cleanup, and SSE ownership cleanup. Based on upstream `0d4e1cd793df3601dc5050547e89256dc04ce531`, preserving socket hardening and version 1.0.11. Removed local-agent ignore entries and unrelated CLI lockfile churn; retained safety tests and readable schema fixtures.

## Local verification

Head: `3b12a340659d9a860458d0fb2e20e2a1e9aef82b`.

- Full Catalyst suite: **66 passed, zero failures/skips**, no filters.
- Unsigned `DEBUG APP_STORE` build passed (not a Release archive/signing check).
- Schema regressions: 8 passed; all 10 canonical descriptors matched.
- CI evidence harness: 4 passed; settings wiring: 1 passed.
- Node stdio build, CLI compatibility suite, and diff check passed.

Builds reused an unmodified dependency checkout. These checks do not establish signed deployment or live HomeKit access. GitHub CI and maintainer approval remain separate landing gates.

## Lifecycle follow-up

- Disconnect cleanup uses exact SSE ownership tokens; an in-flight POST or replaced connection cannot close another connection’s stream.
- Response-task exit handles cancellation before event-loop registration, preventing orphaned continuations.
- Four production-handler channel regressions cover borrowed sessions, replacement streams, owner disconnect, and late registration. Baseline reproduction failed before the fix; a token-only intermediate fix exposed the registration race. The final four regressions also passed ten repetitions.
- Local signing/app-group adaptations remain excluded. Prior signed HomeKit/restart checks used locally adapted source; the SSE fix is validated through embedded production-handler execution, not a newly deployed signed app.
