### PR TITLE
Restrict the control socket to the owning user

### DIFF
--- a/Sources/homeclaw/HomeKit/SocketServer.swift
+++ b/Sources/homeclaw/HomeKit/SocketServer.swift
@@ -294,8 +294,10 @@ final class SocketServer: @unchecked Sendable {
             return
         }
 
-        // Make socket world-accessible so the CLI and MCP server can connect
-        chmod(path, 0o666)
+        // Owner-only. The CLI and MCP server run as the same user, so 0600 is
+        // sufficient for them and keeps other local accounts off the socket.
+        // Peer identity is additionally verified on accept(); see acceptConnection().
+        chmod(path, 0o600)
 
         // Increase socket buffers for large responses (192 accessories = ~300KB JSON)
         var bufSize: Int32 = 1_048_576 // 1 MB
@@ -387,6 +389,18 @@ final class SocketServer: @unchecked Sendable {
     private func acceptConnection() {
         let clientFD = accept(serverFD, nil, nil)
         guard clientFD >= 0 else { return }
+
+        // Defence in depth: file permissions alone don't establish who is on the
+        // other end (the path can be reachable via a permissive parent directory,
+        // and the /tmp fallback is world-traversable). Verify the peer's effective
+        // uid matches ours before handing it the command surface.
+        var peerUID: uid_t = 0
+        var peerGID: gid_t = 0
+        guard getpeereid(clientFD, &peerUID, &peerGID) == 0, peerUID == getuid() else {
+            AppLogger.socket.error("Rejected socket connection from uid \(Int(peerUID))")
+            close(clientFD)
+            return
+        }
 
         // On macOS, accept() inherits the non-blocking flag from the listening socket.
         // Reset the client FD to blocking so recv() waits for data instead of returning EAGAIN.


### PR DESCRIPTION
The Unix control socket is created world-accessible and accepts any local connection without establishing peer identity.

`SocketServer.swift` set `chmod(path, 0o600)`'s predecessor `0o666` deliberately ("Make socket world-accessible so the CLI and MCP server can connect"), and `acceptConnection()` called `accept(serverFD, nil, nil)` — discarding the peer `sockaddr`, with no `getpeereid`, no uid check, and no credential of any kind on the path. The socket is live at that mode today:

```
srw-rw-rw-@ 1 <user> staff homeclaw.sock
```

Both clients that need it — `homeclaw-cli` and the Node MCP server — run as the same user, so the permissive mode buys nothing.

## Changes

- **`0o600` instead of `0o666`.** Owner-only is sufficient for every supported client.
- **`getpeereid()` check on accept.** Close the connection unless the peer's effective uid matches ours. Permissions alone don't establish who is connecting, and the `/tmp` fallback path is world-traversable.

Defence in depth: either change alone would help, and the uid check is the one that holds regardless of how the socket path is reached.

## Verification

- Catalyst build **succeeds**, and the build log confirms `SocketServer.swift` was actually recompiled — worth stating explicitly, because `swift build` reports success while compiling none of this file (`Package.swift` declares only `homeclaw-cli`, not `Sources/homeclaw`).
- **Not** functionally exercised against a running rebuilt app: verifying that `homeclaw-cli` still connects end-to-end requires replacing the installed app, which I haven't done. The uid check should be transparent for same-user clients, but that path deserves a manual smoke test before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gWjEbhHLJvUvvo1yGGY3D