### PR TITLE
Resolve the App Store profile instead of hardcoding its name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,8 @@ require "shellwords"
 require "fileutils"
 require "tmpdir"
 require "time"
+require "digest"
+require "base64"
 
 default_platform(:ios)
 
@@ -242,6 +244,28 @@ end
 # the canonical prefix and that hasn't expired. Purely local -- no network.
 APPSTORE_PROFILE_PREFIX = "com.shahine.homeclaw AppStore"
 
+# SHA-1 fingerprints of every code-signing identity in the local keychain.
+def local_certificate_fingerprints
+  @local_certificate_fingerprints ||= begin
+    out, _, _ = Open3.capture3("security", "find-identity", "-v", "-p", "codesigning")
+    out.scan(/\b([0-9A-F]{40})\b/).flatten.uniq
+  end
+end
+
+# True when at least one certificate embedded in the profile is installed
+# locally. DeveloperCertificates holds base64 DER blobs; their SHA-1 is the
+# same fingerprint `security find-identity` prints.
+def profile_certs_available?(plist)
+  section = plist[%r{<key>DeveloperCertificates</key>\s*<array>(.*?)</array>}m, 1]
+  return false if section.nil?
+
+  section.scan(%r{<data>(.*?)</data>}m).flatten.any? do |b64|
+    der = Base64.decode64(b64)
+    fingerprint = Digest::SHA1.hexdigest(der).upcase
+    local_certificate_fingerprints.include?(fingerprint)
+  end
+end
+
 def appstore_profile_name
   return ENV["HOMECLAW_APPSTORE_PROFILE"] unless ENV["HOMECLAW_APPSTORE_PROFILE"].to_s.empty?
 
@@ -260,11 +284,19 @@ def appstore_profile_name
     exp = Time.parse(expiry) rescue nil
     next if exp.nil? || exp < Time.now
 
+    # Expiry alone isn't enough. A profile minted on another Mac embeds that
+    # machine's distribution certificate; picking it because it happens to
+    # expire later reproduces the exact certificate mismatch this resolver
+    # exists to avoid. Require that one of the profile's embedded certs is
+    # actually installed here.
+    next unless profile_certs_available?(plist)
+
     best = [name, exp] if best.nil? || exp > best[1]
   end
 
   UI.user_error!(
     "No unexpired provisioning profile starting with #{APPSTORE_PROFILE_PREFIX.inspect} is installed.\n" \
+    "(A profile whose signing certificate isn't in this keychain is skipped.)\n" \
     "Create one: fastlane run sigh app_identifier:com.shahine.homeclaw platform:catalyst force:true\n" \
     "Or point at one explicitly: HOMECLAW_APPSTORE_PROFILE='<name>' fastlane <lane>"
   ) if best.nil?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,7 @@ require "open3"
 require "shellwords"
 require "fileutils"
 require "tmpdir"
+require "time"
 
 default_platform(:ios)
 
@@ -229,6 +230,49 @@ def xcodebuild_auth_args
     " -authenticationKeyIssuerID #{Shellwords.escape(issuer_id)}"
 end
 
+# Resolve the App Store provisioning profile to export with.
+#
+# The name can't be hardcoded. `sigh` refuses to reuse a profile whose signing
+# certificate isn't installed locally, and when the canonical name is already
+# taken it creates a timestamped one ("<name> 1788724911") instead of replacing
+# it. A machine that didn't mint the original profile therefore ends up with a
+# working profile under a name the Fastfile doesn't know.
+#
+# Pick the newest installed profile for this bundle id whose name starts with
+# the canonical prefix and that hasn't expired. Purely local -- no network.
+APPSTORE_PROFILE_PREFIX = "com.shahine.homeclaw AppStore"
+
+def appstore_profile_name
+  return ENV["HOMECLAW_APPSTORE_PROFILE"] unless ENV["HOMECLAW_APPSTORE_PROFILE"].to_s.empty?
+
+  dir = File.expand_path("~/Library/Developer/Xcode/UserData/Provisioning Profiles")
+  best = nil
+
+  Dir[File.join(dir, "*.provisionprofile")].each do |path|
+    plist, _, status = Open3.capture3("security", "cms", "-D", "-i", path)
+    next unless status.success?
+
+    name = plist[%r{<key>Name</key>\s*<string>([^<]*)</string>}, 1]
+    next unless name&.start_with?(APPSTORE_PROFILE_PREFIX)
+
+    expiry = plist[%r{<key>ExpirationDate</key>\s*<date>([^<]*)</date>}, 1]
+    next if expiry.nil?
+    exp = Time.parse(expiry) rescue nil
+    next if exp.nil? || exp < Time.now
+
+    best = [name, exp] if best.nil? || exp > best[1]
+  end
+
+  UI.user_error!(
+    "No unexpired provisioning profile starting with #{APPSTORE_PROFILE_PREFIX.inspect} is installed.\n" \
+    "Create one: fastlane run sigh app_identifier:com.shahine.homeclaw platform:catalyst force:true\n" \
+    "Or point at one explicitly: HOMECLAW_APPSTORE_PROFILE='<name>' fastlane <lane>"
+  ) if best.nil?
+
+  UI.message("Provisioning profile: #{best[0]}")
+  best[0]
+end
+
 def archive_and_export(team:, version:, build_number:, export: false)
   rm_rf = ->(p) { FileUtils.rm_rf(p) }
   rm_rf.call(ARCHIVE_PATH)
@@ -253,7 +297,7 @@ def archive_and_export(team:, version:, build_number:, export: false)
       signingStyle: "manual",
       signingCertificate: "Apple Distribution",
       installerSigningCertificate: "3rd Party Mac Developer Installer",
-      provisioningProfiles: { "com.shahine.homeclaw" => "com.shahine.homeclaw AppStore" },
+      provisioningProfiles: { BUNDLE_ID => appstore_profile_name },
     }
   )
 


### PR DESCRIPTION
`export_options` pinned the provisioning profile to the literal string `"com.shahine.homeclaw AppStore"`. That name only ever works on the machine that minted the profile.

The failure mode is subtle:

- `sigh` won't reuse a profile whose signing certificate isn't installed locally — the existing `com.shahine.homeclaw AppStore` references distribution cert `GAV36XT2LU`, which lives on one Mac.
- When the canonical name is already taken, `sigh` doesn't replace it — it creates a **timestamped** profile (`com.shahine.homeclaw AppStore 1788724911`).

So a second machine ends up holding a perfectly valid profile under a name the Fastfile has never heard of, and `exportArchive` fails with `Provisioning profile "..." doesn't include signing certificate "3rd Party Mac Developer Installer: ..."` — a message that points at the certificate when the actual problem is the profile name.

## Change

`appstore_profile_name` picks the newest installed profile for this bundle id whose name starts with the canonical prefix and hasn't expired. Purely local, reading the installed `.provisionprofile` files — no network, no ASC call.

- `HOMECLAW_APPSTORE_PROFILE` overrides it for a one-off.
- A missing profile now fails with the exact `sigh` command to run, instead of a misleading signing error.
- Profile key uses `BUNDLE_ID` rather than repeating the literal.

## Verification

Archive, export, and `.pkg` signing all succeed against a profile this lookup resolved, on a machine where the hardcoded name failed. `ruby -c` clean.

## Not fixed here

`.xcode-version` pins `27.0`, which resolves to Xcode **beta** (`27A5237l`). App Store uploads from a beta toolchain are rejected with `90301 — Apple is not currently accepting applications built with this version of Xcode`. Releases currently need `XCODE_APP=/Applications/Xcode.app` to work at all. Worth deciding separately whether the pin should track the release Xcode with the beta opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gWjEbhHLJvUvvo1yGGY3D